### PR TITLE
fix(ci): use ubuntu-22.04 for Python 3.7 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Main matrix: modern OS + Python 3.8-3.12
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        exclude:
-          # Python 3.7 is EOL and not available on macos-latest (arm64)
-          - os: macos-latest
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        include:
+          # Python 3.7 requires Ubuntu 22.04 (ubuntu-latest is 24.04 and dropped 3.7)
+          - os: ubuntu-22.04
+            python-version: "3.7"
+          # Python 3.7 on Windows is still available
+          - os: windows-latest
             python-version: "3.7"
 
     steps:


### PR DESCRIPTION
Python 3.7 is not available on ubuntu-latest (Ubuntu 24.04). Use ubuntu-22.04 for the 3.7 job.