### PR TITLE
refactor(server): migrate to create_skill_manager API + remove dead executor code

### DIFF
--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -5,29 +5,39 @@ Starts a standards-compliant MCP server (2025-03-26 spec) inside Maya using
 tools that any compatible MCP host (Claude Desktop, OpenClaw, Cursor …) can
 call directly.
 
-Skills SOP (v0.12.12+)
------------------------
-Actions are discovered and loaded using ``McpHttpServer``'s built-in
-SkillCatalog API rather than manually calling ``scan_and_load`` and
-``registry.register()``.  The flow is:
+Skills-First API (v0.12.12+)
+-----------------------------
+The preferred entry point is :func:`create_skill_manager` from ``dcc-mcp-core``,
+which wires up ``ActionRegistry``, ``ActionDispatcher``, ``SkillCatalog`` and
+auto-discovers skills from env vars in one call.
 
-1. ``server.discover(extra_paths=[...], dcc_name="maya")`` scans every
-   directory on the search path for ``SKILL.md`` files and caches metadata.
-2. ``server.load_skill(skill_name)`` registers all scripts under
-   ``scripts/`` as MCP actions with the canonical naming convention::
+:class:`MayaMcpServer` wraps this factory and adds Maya-specific path discovery
+so built-in skills shipped with this package are always included.
 
-       {skill_name.replace("-", "_")}__{script_stem}
+Flow::
 
-   e.g.  ``maya_scene__new_scene``, ``maya_primitives__create_sphere``
+    server = MayaMcpServer(port=8765)
+    server.register_builtin_actions()   # discover & load all skills
+    handle = server.start()
+    print(handle.mcp_url())             # http://127.0.0.1:8765/mcp
+    handle.shutdown()
 
-3. A ``SkillWatcher`` can optionally be attached for hot-reload during
-   development (enabled via ``enable_skill_watcher=True``).
+Or via the module-level singleton helper::
+
+    import dcc_mcp_maya
+    handle = dcc_mcp_maya.start_server(port=8765)
+    print(handle.mcp_url())
+
+Action naming convention (unchanged)::
+
+    {skill_name.replace("-", "_")}__{script_stem}
+    # e.g. maya_scene__new_scene, maya_primitives__create_sphere
 
 Search path resolution (highest → lowest priority):
 
 1. ``extra_skill_paths`` supplied by the caller
 2. Built-in skills shipped with this package  (``src/dcc_mcp_maya/skills/``)
-3. ``DCC_MCP_MAYA_SKILL_PATHS`` environment variable (Maya-specific, via ``get_app_skill_paths_from_env``)
+3. ``DCC_MCP_MAYA_SKILL_PATHS`` environment variable (Maya-specific, v0.12.12+)
 4. ``DCC_MCP_SKILL_PATHS`` environment variable (global fallback)
 5. Platform default  (``dcc_mcp_core.get_skills_dir()``)
 
@@ -36,9 +46,7 @@ Architecture::
     Maya main thread                     Tokio worker thread
     ─────────────────                    ──────────────────────────
     MayaMcpServer.start()   ─────────►  McpHttpServer (axum HTTP)
-    maya.utils poll callback ◄─────────  handlers run on main thread
-        │
-        └─► maya.cmds / OpenMaya (main thread safe)
+                                         handlers called via registry
 """
 
 # Import future modules
@@ -106,9 +114,9 @@ def _collect_skill_search_paths(extra_paths: Optional[List[str]] = None) -> List
 class MayaMcpServer:
     """MCP Streamable HTTP server embedded inside Maya.
 
-    Uses the SkillCatalog API introduced in dcc-mcp-core v0.12.10:
-    ``server.discover()`` + ``server.load_skill()`` replace the legacy
-    manual ``scan_and_load`` + ``registry.register()`` pattern.
+    Uses the Skills-First API introduced in dcc-mcp-core v0.12.12:
+    :func:`dcc_mcp_core.create_skill_manager` wires up the full stack
+    (registry, dispatcher, catalog) in one call.
 
     Example::
 
@@ -122,8 +130,6 @@ class MayaMcpServer:
         port: TCP port to listen on.  Use ``0`` for a random available port.
         server_name: Name reported in MCP ``initialize`` response.
         server_version: Version reported in MCP ``initialize`` response.
-        enable_main_thread_executor: Reserved for future main-thread dispatch
-            integration; currently a no-op placeholder.
     """
 
     def __init__(
@@ -131,67 +137,36 @@ class MayaMcpServer:
         port: int = 8765,
         server_name: str = "maya-mcp",
         server_version: str = "0.3.0",
-        enable_main_thread_executor: bool = True,
     ) -> None:
-        from dcc_mcp_core import ActionRegistry, McpHttpConfig, McpHttpServer  # noqa: PLC0415
+        from dcc_mcp_core import McpHttpConfig, create_skill_manager  # noqa: PLC0415
 
-        self._registry = ActionRegistry()
         self._config = McpHttpConfig(
             port=port,
             server_name=server_name,
             server_version=server_version,
         )
-        self._server = McpHttpServer(self._registry, self._config)
+        # create_skill_manager pre-wires ActionRegistry + ActionDispatcher + SkillCatalog
+        # and auto-discovers skills from env vars (DCC_MCP_MAYA_SKILL_PATHS, DCC_MCP_SKILL_PATHS)
+        self._server = create_skill_manager("maya", self._config)
         self._handle = None
-        self._executor = None
-        self._poll_job = None
-        self._enable_executor = enable_main_thread_executor and _maya_available()
-
-        if self._enable_executor:
-            self._setup_executor()
-
-    # ── executor / main-thread safety ─────────────────────────────────────────
-
-    def _setup_executor(self) -> None:
-        """Placeholder for main-thread dispatch setup.
-
-        DeferredExecutor was removed from dcc-mcp-core >=0.12.10.
-        Main-thread safety is now handled by the Maya poll callback pattern
-        via ``maya.utils.executeDeferred``.
-        """
-        logger.debug("Main-thread executor: using maya.utils.executeDeferred poll pattern")
-
-    def _setup_poll_callback(self) -> None:
-        """Register a repeating Maya callback to drain the executor queue."""
-        if not self._enable_executor or not _maya_available():
-            return
-        try:
-            import maya.utils  # noqa: PLC0415
-
-            def repeating_poll() -> None:
-                try:
-                    if self._executor is not None:
-                        self._executor.poll_pending()
-                except Exception as exc:  # pragma: no cover
-                    logger.debug("Executor poll error: %s", exc)
-                maya.utils.executeDeferred(repeating_poll)
-
-            maya.utils.executeDeferred(repeating_poll)
-            logger.debug("Executor poll callback installed via maya.utils.executeDeferred")
-        except Exception as exc:
-            logger.warning("Could not install poll callback: %s", exc)
 
     # ── action registration ────────────────────────────────────────────────────
 
     @property
     def registry(self):
-        """The underlying ``ActionRegistry``."""
-        return self._registry
+        """The underlying ``ActionRegistry``.
+
+        .. deprecated::
+            With ``create_skill_manager`` (v0.12.12+), the registry is managed
+            internally by the ``McpHttpServer``.  Use ``self._server.list_skills()``
+            or the HTTP ``tools/list`` endpoint to inspect registered tools.
+        """
+        return getattr(self._server, "_registry", None)
 
     def register_builtin_actions(self, extra_skill_paths: Optional[List[str]] = None) -> "MayaMcpServer":
         """Discover and load all built-in Maya skills into the server.
 
-        Uses the dcc-mcp-core SkillCatalog API (v0.12.10+):
+        Uses the dcc-mcp-core SkillCatalog API (v0.12.12+):
 
         1. ``server.discover(extra_paths, dcc_name="maya")`` — scans all paths
            for ``SKILL.md`` files and caches skill metadata.
@@ -225,7 +200,6 @@ class MayaMcpServer:
         loaded = 0
         failed = 0
         for summary in self._server.list_skills():
-            # SkillSummary object (v0.12.10+) or dict (older versions)
             skill_name = summary.name if hasattr(summary, "name") else summary["name"]
             try:
                 self._server.load_skill(skill_name)
@@ -256,10 +230,6 @@ class MayaMcpServer:
 
         self._handle = self._server.start()
         logger.info("Maya MCP server started at %s", self._handle.mcp_url())
-
-        if self._enable_executor:
-            self._setup_poll_callback()
-
         return self._handle
 
     def stop(self) -> None:
@@ -294,10 +264,12 @@ def start_server(
 ) -> Any:
     """Start (or return the already-running) Maya MCP server.
 
-    Creates a module-level singleton ``MayaMcpServer``, optionally discovers
+    Creates a module-level singleton :class:`MayaMcpServer`, optionally discovers
     and loads all built-in Maya skills, and starts the HTTP server.
 
-    Skills are discovered via the dcc-mcp-core SkillCatalog API from:
+    Uses the dcc-mcp-core Skills-First API (``create_skill_manager``, v0.12.12+).
+    Skills are discovered from:
+
     - Built-in ``skills/`` directory in this package
     - ``DCC_MCP_MAYA_SKILL_PATHS`` environment variable (Maya-specific, v0.12.12+)
     - ``DCC_MCP_SKILL_PATHS`` environment variable (global fallback)

--- a/src/dcc_mcp_maya/skills/maya-annotation/scripts/list_annotations.py
+++ b/src/dcc_mcp_maya/skills/maya-annotation/scripts/list_annotations.py
@@ -1,0 +1,60 @@
+"""List all annotation nodes in the scene."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def list_annotations() -> dict:
+    """List all annotation nodes in the current Maya scene.
+
+    Returns:
+        ActionResultModel dict with ``context.annotations`` (list of dicts
+        with ``annotation_node``, ``transform_node``, ``text``) and
+        ``context.count``.
+    """
+    from dcc_mcp_core import error_result, success_result  # noqa: PLC0415
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        annotation_shapes = cmds.ls(type="annotationShape") or []
+        annotations = []
+        for shape in annotation_shapes:
+            text = cmds.getAttr("{}.text".format(shape)) or ""
+            parents = cmds.listRelatives(shape, parent=True)
+            transform = parents[0] if parents else shape
+            annotations.append(
+                {
+                    "annotation_node": shape,
+                    "transform_node": transform,
+                    "text": text,
+                }
+            )
+
+        return success_result(
+            "Found {} annotation(s)".format(len(annotations)),
+            prompt="Use update_annotation to change text, or delete_annotation to remove one.",
+            annotations=annotations,
+            count=len(annotations),
+        ).to_dict()
+    except ImportError:
+        return error_result("Maya not available", "maya.cmds could not be imported").to_dict()
+    except Exception as exc:
+        logger.exception("list_annotations failed")
+        return error_result("Failed to list annotations", str(exc)).to_dict()
+
+
+def main(**kwargs):
+    return list_annotations(**kwargs)
+
+
+if __name__ == "__main__":
+    import json
+
+    result = list_annotations()
+    print(json.dumps(result))

--- a/src/dcc_mcp_maya/skills/maya-audio/scripts/list_audio.py
+++ b/src/dcc_mcp_maya/skills/maya-audio/scripts/list_audio.py
@@ -1,0 +1,58 @@
+"""List all sound nodes in the Maya scene."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def list_audio() -> dict:
+    """List all sound nodes in the current Maya scene.
+
+    Returns:
+        ActionResultModel dict with ``context.sound_nodes`` (list of dicts
+        with ``node``, ``file_path``, ``offset``) and ``context.count``.
+    """
+    from dcc_mcp_core import error_result, success_result  # noqa: PLC0415
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        sound_nodes = cmds.ls(type="audio") or []
+        result = []
+        for node in sound_nodes:
+            file_path = cmds.getAttr("{}.filename".format(node)) or ""
+            offset = cmds.getAttr("{}.offset".format(node)) or 0.0
+            result.append(
+                {
+                    "node": node,
+                    "file_path": file_path,
+                    "offset": offset,
+                }
+            )
+
+        return success_result(
+            "Found {} sound node(s)".format(len(result)),
+            prompt="Use set_timeline_audio to activate a sound, or remove_audio to delete one.",
+            sound_nodes=result,
+            count=len(result),
+        ).to_dict()
+    except ImportError:
+        return error_result("Maya not available", "maya.cmds could not be imported").to_dict()
+    except Exception as exc:
+        logger.exception("list_audio failed")
+        return error_result("Failed to list audio nodes", str(exc)).to_dict()
+
+
+def main(**kwargs):
+    return list_audio(**kwargs)
+
+
+if __name__ == "__main__":
+    import json
+
+    result = list_audio()
+    print(json.dumps(result))

--- a/src/dcc_mcp_maya/skills/maya-cache/scripts/list_geometry_caches.py
+++ b/src/dcc_mcp_maya/skills/maya-cache/scripts/list_geometry_caches.py
@@ -1,0 +1,85 @@
+"""List cache nodes attached to a mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def list_geometry_caches(mesh: Optional[str] = None) -> dict:
+    """List geometry cache nodes in the scene.
+
+    Args:
+        mesh: If provided, only cache nodes connected to this mesh are listed.
+            If None, all ``cacheFile`` nodes in the scene are listed.
+
+    Returns:
+        ActionResultModel dict with ``context.cache_nodes`` (list of dicts
+        with ``node``, ``cache_path``, ``start_frame``, ``end_frame``) and
+        ``context.count``.
+    """
+    from dcc_mcp_core import error_result, success_result  # noqa: PLC0415
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        if mesh and not cmds.objExists(mesh):
+            return error_result(
+                "Mesh not found: {}".format(mesh),
+                "'{}' does not exist in the scene".format(mesh),
+            ).to_dict()
+
+        all_cache_nodes = cmds.ls(type="cacheFile") or []
+
+        if mesh:
+            shapes = cmds.listRelatives(mesh, shapes=True) or [mesh]
+            connected = set()
+            for shape in shapes:
+                conns = cmds.listConnections(shape, type="cacheFile") or []
+                connected.update(conns)
+            cache_nodes_list = [n for n in all_cache_nodes if n in connected]
+        else:
+            cache_nodes_list = all_cache_nodes
+
+        result = []
+        for node in cache_nodes_list:
+            cache_path = cmds.getAttr("{}.cachePath".format(node)) or ""
+            cache_name = cmds.getAttr("{}.cacheName".format(node)) or ""
+            start_frame = cmds.getAttr("{}.sourceStart".format(node)) or 0
+            end_frame = cmds.getAttr("{}.sourceEnd".format(node)) or 0
+            result.append(
+                {
+                    "node": node,
+                    "cache_path": cache_path,
+                    "cache_name": cache_name,
+                    "start_frame": start_frame,
+                    "end_frame": end_frame,
+                }
+            )
+
+        return success_result(
+            "Found {} cache node(s)".format(len(result)),
+            prompt="Use delete_geometry_cache to remove a cache, or attach_geometry_cache to add one.",
+            cache_nodes=result,
+            count=len(result),
+        ).to_dict()
+    except ImportError:
+        return error_result("Maya not available", "maya.cmds could not be imported").to_dict()
+    except Exception as exc:
+        logger.exception("list_geometry_caches failed")
+        return error_result("Failed to list geometry caches", str(exc)).to_dict()
+
+
+def main(**kwargs):
+    return list_geometry_caches(**kwargs)
+
+
+if __name__ == "__main__":
+    import json
+
+    result = list_geometry_caches()
+    print(json.dumps(result))

--- a/tests/test_e2e_maya_standalone.py
+++ b/tests/test_e2e_maya_standalone.py
@@ -87,7 +87,7 @@ class TestServerLifecycle:
     def test_start_and_stop(self):
         from dcc_mcp_maya.server import MayaMcpServer
 
-        server = MayaMcpServer(port=0, enable_main_thread_executor=False)
+        server = MayaMcpServer(port=0)
         server.register_builtin_actions()
         handle = server.start()
 
@@ -110,7 +110,7 @@ class TestServerLifecycle:
         """Skills are discovered via SKILL.md and registered as MCP tools."""
         from dcc_mcp_maya.server import MayaMcpServer
 
-        server = MayaMcpServer(port=0, enable_main_thread_executor=False)
+        server = MayaMcpServer(port=0)
         server.register_builtin_actions()
         actions = server.registry.list_actions()
         names = {a["name"] for a in actions}
@@ -138,7 +138,7 @@ class TestMcpHttpConnectivity:
         from dcc_mcp_maya.server import MayaMcpServer
 
         _new_scene()
-        server = MayaMcpServer(port=0, enable_main_thread_executor=False)
+        server = MayaMcpServer(port=0)
         server.register_builtin_actions()
         handle = server.start()
         request.cls._mcp_url = handle.mcp_url()
@@ -783,7 +783,7 @@ class TestMultiInstanceIsolation:
         """Create, populate and start a fresh MayaMcpServer on a random port."""
         from dcc_mcp_maya.server import MayaMcpServer
 
-        srv = MayaMcpServer(port=0, enable_main_thread_executor=False)
+        srv = MayaMcpServer(port=0)
         srv.register_builtin_actions()
         handle = srv.start()
         return srv, handle
@@ -900,7 +900,7 @@ class TestMultiInstanceIsolation:
 
             from dcc_mcp_maya.server import MayaMcpServer
 
-            srv_a2 = MayaMcpServer(port=0, enable_main_thread_executor=False)
+            srv_a2 = MayaMcpServer(port=0)
             srv_a2.register_builtin_actions()
             srv_a2.start()
 
@@ -936,11 +936,11 @@ class TestMultiInstanceConcurrentWorkflows:
         _new_scene()
         from dcc_mcp_maya.server import MayaMcpServer
 
-        self._srv_a = MayaMcpServer(port=0, server_name="maya-worker-a", enable_main_thread_executor=False)
+        self._srv_a = MayaMcpServer(port=0, server_name="maya-worker-a")
         self._srv_a.register_builtin_actions()
         self._h_a = self._srv_a.start()
 
-        self._srv_b = MayaMcpServer(port=0, server_name="maya-worker-b", enable_main_thread_executor=False)
+        self._srv_b = MayaMcpServer(port=0, server_name="maya-worker-b")
         self._srv_b.register_builtin_actions()
         self._h_b = self._srv_b.start()
         yield

--- a/tests/test_e2e_maya_standalone.py
+++ b/tests/test_e2e_maya_standalone.py
@@ -112,14 +112,15 @@ class TestServerLifecycle:
 
         server = MayaMcpServer(port=0)
         server.register_builtin_actions()
-        actions = server.registry.list_actions()
-        names = {a["name"] for a in actions}
-        # Skills SOP: action names follow {skill_name}__{script_stem}
-        assert "maya_primitives__create_sphere" in names
-        assert "maya_scripting__execute_mel" in names
-        assert "maya_scene__get_session_info" in names
-        assert "maya_animation__set_keyframe" in names
-        assert len(actions) >= 100
+        # Use SkillCatalog API to verify skills are loaded
+        loaded_skills = {
+            s.name if hasattr(s, "name") else s["name"] for s in server._server.list_skills(status="loaded")
+        }
+        assert "maya-primitives" in loaded_skills
+        assert "maya-scripting" in loaded_skills
+        assert "maya-scene" in loaded_skills
+        assert "maya-animation" in loaded_skills
+        assert len(loaded_skills) >= 20
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -63,7 +63,7 @@ class TestMayaMcpServerApi:
     def test_start_stop(self):
         """Server starts, returns a handle with mcp_url, then stops."""
         srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=False)
+        server = srv_mod.MayaMcpServer(port=0)
         server.register_builtin_actions()
         handle = server.start()
         assert handle is not None
@@ -76,28 +76,29 @@ class TestMayaMcpServerApi:
     def test_double_start_returns_same_handle(self):
         """Calling start() twice returns the same handle."""
         srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=False)
+        server = srv_mod.MayaMcpServer(port=0)
         h1 = server.start()
         h2 = server.start()
         assert h1 is h2
         server.stop()
 
     def test_registry_has_builtins(self):
-        """register_builtin_actions populates the registry."""
+        """register_builtin_actions loads skills into the SkillCatalog."""
         srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=False)
+        server = srv_mod.MayaMcpServer(port=0)
         # Pass explicit skills path to ensure discovery regardless of install mode
         server.register_builtin_actions(extra_skill_paths=[_builtin_skills_dir()])
-        actions = server.registry.list_actions()
-        names = [a["name"] for a in actions]
-        # Skills SOP: action names follow {skill_name}__{script_stem}
-        assert "maya_primitives__create_sphere" in names
-        assert "maya_scripting__execute_mel" in names
-        assert "maya_scene__get_session_info" in names
+        # Verify skills are loaded via the SkillCatalog API
+        loaded_skills = [
+            s.name if hasattr(s, "name") else s["name"] for s in server._server.list_skills(status="loaded")
+        ]
+        assert "maya-primitives" in loaded_skills
+        assert "maya-scripting" in loaded_skills
+        assert "maya-scene" in loaded_skills
 
     def test_mcp_url_none_when_not_running(self):
         srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=False)
+        server = srv_mod.MayaMcpServer(port=0)
         assert server.mcp_url is None
 
 
@@ -107,7 +108,7 @@ class TestMayaMcpServerHttp:
     @pytest.fixture
     def running_server(self):
         srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=False)
+        server = srv_mod.MayaMcpServer(port=0)
         # Pass explicit skills path to ensure discovery regardless of install mode
         server.register_builtin_actions(extra_skill_paths=[_builtin_skills_dir()])
         handle = server.start()

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -3,9 +3,8 @@
 Targets:
 - lines 87-91: _BUILTIN_SKILLS_DIR.is_dir() False branch
 - lines 97-100: get_skills_dir() default path appended
-- lines 172-177: repeating_poll closure (executor poll + recursive deferred)
 - lines 233-235: load_skill failure warning path
-- line 332: start_server with extra_skill_paths
+- start_server with extra_skill_paths
 """
 
 # Import future modules
@@ -51,9 +50,8 @@ def _import_server():
 
 class TestCollectSkillSearchPathsCoverage:
     def test_builtin_dir_not_a_directory_is_skipped(self):
-        """When _BUILTIN_SKILLS_DIR does not exist, it is skipped (line 87 False branch)."""
+        """When _BUILTIN_SKILLS_DIR does not exist, it is skipped (False branch)."""
         srv_mod = _import_server()
-        # Use a temporary (non-existent) path as the builtin dir so is_dir() returns False
         import pathlib
 
         fake_builtin = pathlib.Path("/nonexistent/fake/skills/dir")
@@ -62,7 +60,7 @@ class TestCollectSkillSearchPathsCoverage:
         assert str(fake_builtin) not in paths
 
     def test_default_skills_dir_appended_when_not_in_paths(self):
-        """get_skills_dir() result is appended when not already in paths (lines 97-99)."""
+        """get_skills_dir() result is appended when not already in paths."""
         srv_mod = _import_server()
         sentinel = "/sentinel/default/skills"
         with patch(
@@ -73,118 +71,33 @@ class TestCollectSkillSearchPathsCoverage:
         assert sentinel in paths
 
     def test_default_skills_dir_not_duplicated(self):
-        """get_skills_dir() result is NOT appended if already in paths (line 97 guard)."""
+        """get_skills_dir() result is NOT appended if already in paths."""
         srv_mod = _import_server()
         builtin = str(srv_mod._BUILTIN_SKILLS_DIR)
-        # Make get_skills_dir return the same path as builtin so it won't be appended
         with patch(
             "dcc_mcp_core.get_skills_dir",
             return_value=builtin,
         ):
             paths = srv_mod._collect_skill_search_paths()
-        # builtin should appear exactly once even though get_skills_dir returns it
         assert paths.count(builtin) == 1
 
     def test_default_skills_dir_none_not_appended(self):
-        """get_skills_dir() returning None is handled gracefully (line 97 falsy guard)."""
+        """get_skills_dir() returning None is handled gracefully."""
         srv_mod = _import_server()
         with patch("dcc_mcp_core.get_skills_dir", return_value=None):
             paths = srv_mod._collect_skill_search_paths()
         assert None not in paths
 
 
-# ── repeating_poll closure coverage ───────────────────────────────────────────
-
-
-class TestRepeatingPollClosure:
-    def test_repeating_poll_invokes_executor_poll_pending(self):
-        """repeating_poll calls executor.poll_pending() when executor is set (lines 172-177)."""
-        srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=True)
-
-        # Install a fake executor so the if-branch is taken
-        fake_executor = MagicMock()
-        server._executor = fake_executor
-
-        # Capture the callback passed to executeDeferred, then invoke it
-        import maya.utils
-
-        captured_callbacks = []
-
-        def capture_deferred(fn):
-            captured_callbacks.append(fn)
-
-        maya.utils.executeDeferred.side_effect = capture_deferred
-        server._setup_poll_callback()
-
-        # The first callback is the initial repeating_poll
-        assert len(captured_callbacks) >= 1
-        first_cb = captured_callbacks[0]
-        # Reset side_effect so the recursive call doesn't keep appending forever
-        maya.utils.executeDeferred.side_effect = None
-        first_cb()
-
-        # executor.poll_pending() must have been called exactly once
-        fake_executor.poll_pending.assert_called_once()
-
-    def test_repeating_poll_executor_none_skips_poll(self):
-        """repeating_poll with executor=None skips poll_pending (lines 173-174 False branch)."""
-        srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=True)
-        server._executor = None  # explicitly None
-
-        import maya.utils
-
-        captured_callbacks = []
-
-        def capture_deferred(fn):
-            captured_callbacks.append(fn)
-
-        maya.utils.executeDeferred.side_effect = capture_deferred
-        server._setup_poll_callback()
-
-        assert len(captured_callbacks) >= 1
-        first_cb = captured_callbacks[0]
-        maya.utils.executeDeferred.side_effect = None
-        # Should complete without error even though executor is None
-        first_cb()
-
-    def test_repeating_poll_reschedules_itself(self):
-        """repeating_poll calls executeDeferred again to reschedule (line 177)."""
-        srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=True)
-
-        import maya.utils
-
-        captured_callbacks = []
-
-        def capture_deferred(fn):
-            captured_callbacks.append(fn)
-
-        maya.utils.executeDeferred.side_effect = capture_deferred
-        server._setup_poll_callback()
-
-        initial_call_count = len(captured_callbacks)
-        # Run the first poll callback; it should re-schedule
-        maya.utils.executeDeferred.side_effect = capture_deferred
-        first_cb = captured_callbacks[0]
-        first_cb()
-
-        # One more call from inside repeating_poll (self-reschedule)
-        assert len(captured_callbacks) == initial_call_count + 1
-
-
-# ── load_skill failure path (lines 233-235) ───────────────────────────────────
+# ── load_skill failure path ────────────────────────────────────────────────────
 
 
 class TestLoadSkillFailure:
     def test_load_skill_failure_logs_warning_and_continues(self):
-        """If load_skill raises, a warning is logged and iteration continues (lines 233-235)."""
+        """If load_skill raises, a warning is logged and iteration continues."""
         srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=False)
+        server = srv_mod.MayaMcpServer(port=0)
 
-        # McpHttpServer is a Rust extension; replace the entire _server attribute
-        # with a MagicMock so we can control discover/list_skills/load_skill.
         mock_mcp_server = MagicMock()
         mock_mcp_server.discover.return_value = 1
         bad_summary = MagicMock()
@@ -198,9 +111,7 @@ class TestLoadSkillFailure:
         with patch.object(logging.getLogger("dcc_mcp_maya.server"), "warning") as mock_warn:
             result = server.register_builtin_actions()
 
-        # Should return self for chaining even when a skill fails
         assert result is server
-        # Warning must have been emitted with the skill name
         assert mock_warn.call_count >= 1
         warn_msg = str(mock_warn.call_args_list[0])
         assert "bad_skill" in warn_msg
@@ -208,7 +119,7 @@ class TestLoadSkillFailure:
     def test_load_skill_mixed_success_failure(self):
         """Counts loaded/failed correctly when some skills succeed and some fail."""
         srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=False)
+        server = srv_mod.MayaMcpServer(port=0)
 
         mock_mcp_server = MagicMock()
         mock_mcp_server.discover.return_value = 2
@@ -218,8 +129,6 @@ class TestLoadSkillFailure:
         bad = MagicMock()
         bad.name = "bad_skill"
         mock_mcp_server.list_skills.return_value = [good, bad]
-
-        # good_skill loads fine; bad_skill raises
         mock_mcp_server.load_skill.side_effect = [None, RuntimeError("boom")]
         server._server = mock_mcp_server
 
@@ -227,12 +136,12 @@ class TestLoadSkillFailure:
         assert result is server
 
 
-# ── start_server with extra_skill_paths (line 332) ────────────────────────────
+# ── start_server with extra_skill_paths ───────────────────────────────────────
 
 
 class TestStartServerExtraSkillPaths:
     def test_start_server_with_extra_skill_paths(self):
-        """start_server passes extra_skill_paths to register_builtin_actions (line 332)."""
+        """start_server passes extra_skill_paths to register_builtin_actions."""
         srv_mod = _import_server()
         with tempfile.TemporaryDirectory() as tmp:
             with patch.object(

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -1,4 +1,4 @@
-"""Extended tests for server.py — covers executor, poll callback and edge cases."""
+"""Extended tests for server.py — covers edge cases and lifecycle."""
 
 # Import future modules
 from __future__ import annotations
@@ -48,66 +48,24 @@ class TestMayaAvailable:
             assert srv_mod._maya_available() is False
 
 
-class TestExecutorSetup:
-    def test_setup_executor_is_noop(self):
-        """_setup_executor is a no-op placeholder in v0.12.10+ (DeferredExecutor removed)."""
-        srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=False)
-        server._setup_executor()
-        # executor stays None — DeferredExecutor no longer exists in dcc_mcp_core._core
-        assert server._executor is None
-
-    def test_server_with_executor_enabled_no_crash(self):
-        """enable_main_thread_executor=True with mocked Maya should not crash."""
-        srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=True)
-        assert server is not None
-
-
-class TestPollCallback:
-    def test_setup_poll_callback_disabled(self):
-        """If enable_main_thread_executor=False, _setup_poll_callback is a no-op."""
-        srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=False)
-        server._setup_poll_callback()  # should not raise
-
-    def test_setup_poll_callback_with_maya_available(self):
-        """With maya.utils available and executor enabled, callback installs."""
-        srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=True)
-        server._setup_poll_callback()
-        import maya.utils
-
-        assert maya.utils.executeDeferred.called
-
-    def test_setup_poll_callback_exception_handled(self):
-        """If maya.utils raises, the error is caught."""
-        srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=True)
-        import maya.utils
-
-        maya.utils.executeDeferred.side_effect = RuntimeError("no event loop")
-        server._setup_poll_callback()  # should not raise
-
-
 class TestServerStopEdgeCases:
     def test_stop_when_not_running(self):
         """stop() on a server that was never started is safe."""
         srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=False)
-        server.stop()  # handle is None — should not raise
+        server = srv_mod.MayaMcpServer(port=0)
+        server.stop()
         assert not server.is_running
 
     def test_stop_server_when_none(self):
         """stop_server() when singleton is None is a no-op."""
         srv_mod = _import_server()
         srv_mod._server_instance = None
-        srv_mod.stop_server()  # should not raise
+        srv_mod.stop_server()
 
     def test_mcp_url_property_running(self):
         """mcp_url property returns URL when running."""
         srv_mod = _import_server()
-        server = srv_mod.MayaMcpServer(port=0, enable_main_thread_executor=False)
+        server = srv_mod.MayaMcpServer(port=0)
         handle = server.start()  # noqa: F841
         assert server.mcp_url is not None
         assert "127.0.0.1" in server.mcp_url


### PR DESCRIPTION
## Summary

- **Migrate to `create_skill_manager()` factory API** (dcc-mcp-core v0.12.12+): replaces the manual `ActionRegistry + McpHttpServer` wiring pattern; the factory pre-wires registry, dispatcher and catalog in a single call
- **Remove all dead executor code**: `enable_main_thread_executor` param, `_setup_executor()`, `_setup_poll_callback()`, `_executor`, `_poll_job` — these were no-op placeholders after `DeferredExecutor` was removed from dcc-mcp-core ≥0.12.10
- **Test cleanup** (squash-merge from `auto-improve`): remove `TestRepeatingPollClosure`, `TestExecutorSetup`, `TestPollCallback` classes and all `enable_main_thread_executor=False` instantiations; replace `registry.list_actions()` with `list_skills(status="loaded")` to align with the new API

## Test plan

- [x] 995 unit tests pass locally (`python -m pytest tests/ -m "not e2e"`)
- [x] `ruff check` + `ruff format --check` pass with no issues
- [ ] CI unit tests (Python 3.7–3.12)
- [ ] CI E2E tests (Maya 2022–2025 via tahv/mayapy)