### PR TITLE
feat(ci): add Maya .mod module distribution with offline packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,46 @@ jobs:
           verbose: true
           print-hash: true
 
+  # ── Build Maya .mod module ZIPs ──────────────────────────────────────────────
+  build-mod:
+    needs: [release-please]
+    if: needs.release-please.outputs.release_created == 'true'
+    strategy:
+      matrix:
+        include:
+          - platform: win64
+            runs-on: windows-latest
+          - platform: linux
+            runs-on: ubuntu-latest
+          - platform: macos
+            runs-on: macos-latest
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install assemble dependencies
+        run: pip install dcc-mcp-core
+
+      - name: Assemble .mod module
+        run: |
+          python packaging/assemble_mod.py \
+            --version ${{ needs.release-please.outputs.version }} \
+            --platform ${{ matrix.platform }} \
+            --output dist/mod \
+            --project-root .
+        shell: bash
+
+      - name: Upload mod artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: mod-${{ matrix.platform }}
+          path: dist/mod/*.zip
+
   # ── Attach wheels to GitHub Release ─────────────────────────────────────────
   attach-release-assets:
     needs: [release-please, publish]
@@ -108,3 +148,27 @@ jobs:
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: dist/*
+
+  # ── Attach .mod module ZIPs to GitHub Release ───────────────────────────────
+  attach-mod-release:
+    needs: [release-please, build-mod]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all mod artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: mod-artifacts/
+          pattern: mod-*
+
+      - name: List mod artifacts
+        run: find mod-artifacts/ -name "*.zip" -ls
+
+      - name: Attach mod ZIPs to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          files: mod-artifacts/**/*.zip

--- a/maya/plugin/dcc_mcp_maya.py
+++ b/maya/plugin/dcc_mcp_maya.py
@@ -30,15 +30,27 @@ from __future__ import annotations
 import logging
 import os
 
+import maya.cmds as cmds
+
 # Import third-party modules
 import maya.OpenMaya as om
-import maya.cmds as cmds
-import maya.utils
 
 logger = logging.getLogger(__name__)
 
 VENDOR = "dcc-mcp"
-VERSION = "0.3.0"
+
+
+def _get_version() -> str:
+    """Read version from the installed package, with static fallback."""
+    try:
+        from dcc_mcp_maya.__version__ import __version__  # noqa: PLC0415
+
+        return __version__
+    except Exception:
+        return "0.0.0"
+
+
+VERSION = _get_version()
 
 # ── module-level server handle ────────────────────────────────────────────────
 _handle = None
@@ -47,9 +59,10 @@ _menu_name = "DccMcpMenu"
 
 # ── plugin init ───────────────────────────────────────────────────────────────
 
+
 def initializePlugin(plugin):
     """Called by Maya when the plugin is loaded."""
-    fn = om.MFnPlugin(plugin, VENDOR, VERSION)
+    om.MFnPlugin(plugin, VENDOR, VERSION)
     try:
         _add_menu()
         _start()
@@ -71,6 +84,7 @@ def uninitializePlugin(plugin):
 
 
 # ── server helpers ────────────────────────────────────────────────────────────
+
 
 def _start() -> None:
     global _handle
@@ -107,6 +121,7 @@ def _server_url() -> str:
 
 
 # ── menu ─────────────────────────────────────────────────────────────────────
+
 
 def _add_menu() -> None:
     try:
@@ -145,6 +160,7 @@ def _open_browser() -> None:
     url = _server_url()
     if url and url != "<not running>":
         import webbrowser  # noqa: PLC0415
+
         webbrowser.open(url)
     else:
         cmds.warning("MCP server is not running.")

--- a/packaging/assemble_mod.py
+++ b/packaging/assemble_mod.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Assemble a Maya .mod module directory for dcc-mcp-maya.
+
+Usage:
+    python assemble_mod.py --version 0.3.0 --platform win64 --output dist/mod
+
+This script:
+1. Creates the .mod module directory structure
+2. Copies the Python package and plugin files
+3. Extracts dcc_mcp_core from a downloaded wheel into python/dcc_mcp_core/
+4. Generates the .mod file with correct platform/version
+5. Copies install/uninstall scripts and README
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run(cmd: list[str], **kwargs) -> str:
+    """Run a subprocess and return stdout."""
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True, **kwargs)
+    return result.stdout.strip()
+
+
+def resolve_core_version(project_root: Path) -> str:
+    """Read the dcc-mcp-core minimum version from pyproject.toml."""
+    import re
+
+    toml_path = project_root / "pyproject.toml"
+    content = toml_path.read_text(encoding="utf-8")
+    m = re.search(r"dcc-mcp-core>=(\d+\.\d+\.\d+)", content)
+    if m:
+        return m.group(1)
+    m = re.search(r"dcc-mcp-core>=([\d.]+)", content)
+    if m:
+        return m.group(1)
+    raise RuntimeError("Cannot find dcc-mcp-core version in pyproject.toml")
+
+
+def download_core_wheels(version: str, platform: str, dest: Path) -> list[Path]:
+    """Download dcc-mcp-core wheels for the target platform.
+
+    Downloads both abi3 (cp38+, covers Maya 2023+) and cp37 (Maya 2022)
+    wheels where available.
+    """
+    # Wheel specs: (python_tag, abi_tag, pip_platform_tag)
+    wheel_specs: list[tuple[str, str, str]] = []
+
+    if platform == "win64":
+        wheel_specs = [
+            ("cp38", "abi3", "win_amd64"),
+            ("cp37", "cp37m", "win_amd64"),
+        ]
+    elif platform == "linux":
+        wheel_specs = [
+            ("cp38", "abi3", "manylinux_2_17_x86_64.manylinux2014_x86_64"),
+            ("cp37", "cp37m", "manylinux_2_17_x86_64.manylinux2014_x86_64"),
+        ]
+    elif platform == "macos":
+        # No cp37 wheel on macOS — Maya 2022 not supported
+        wheel_specs = [
+            ("cp38", "abi3", "macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2"),
+        ]
+
+    for py_tag, abi_tag, plat_tag in wheel_specs:
+        cmd = [
+            sys.executable,
+            "-m",
+            "pip",
+            "download",
+            f"dcc-mcp-core=={version}",
+            "--no-deps",
+            "--only-binary=:all:",
+            f"--platform={plat_tag}",
+            f"--python-tag={py_tag}",
+            f"--abi={abi_tag}",
+            "-d",
+            str(dest),
+        ]
+        print(f"  Downloading core wheel ({py_tag}-{abi_tag}, {plat_tag})...")
+        run(cmd)
+
+    wheels = list(dest.glob("dcc_mcp_core-*.whl"))
+    print(f"  Downloaded {len(wheels)} wheel(s)")
+    return wheels
+
+
+def extract_wheel(wheel_path: Path, dest: Path, *, extensions_only: bool = False) -> None:
+    """Extract a wheel into dest.
+
+    If extensions_only is True, only copy compiled extension files (.pyd/.so)
+    to avoid overwriting Python source files from the abi3 wheel.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--no-deps", "--target", tmp, str(wheel_path)],
+            check=True,
+            capture_output=True,
+        )
+        tmp_path = Path(tmp)
+        for item in tmp_path.rglob("*"):
+            if not item.is_file():
+                continue
+            rel = item.relative_to(tmp_path)
+            dest_file = dest / rel
+            if extensions_only:
+                # Only copy compiled extensions (.pyd, .so, .dylib)
+                if item.suffix not in (".pyd", ".so", ".dylib"):
+                    continue
+            dest_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, dest_file)
+
+
+def generate_mod_file(version: str, platform: str) -> str:
+    """Generate the .mod file content."""
+    platform_str = {
+        "win64": "win64",
+        "linux": "linux",
+        "macos": "macos",
+    }[platform]
+
+    maya_versions = ["2022", "2023", "2024", "2025"]
+    # macOS has no cp37 wheel, skip Maya 2022
+    if platform == "macos":
+        maya_versions = ["2023", "2024", "2025"]
+
+    lines = []
+    for mv in maya_versions:
+        lines.append(f"+ MAYAVERSION:{mv} PLATFORM:{platform_str} dcc_mcp_maya {version} .")
+        lines.append("PYTHONPATH+:=python")
+
+    return "\n".join(lines) + "\n"
+
+
+def assemble(project_root: Path, version: str, platform: str, output: Path) -> Path:
+    """Assemble the .mod module directory."""
+    module_name = "dcc-mcp-maya"
+    module_dir = output / module_name
+
+    # Clean output
+    if module_dir.exists():
+        shutil.rmtree(module_dir)
+
+    # Create directories
+    (module_dir / "plug-ins").mkdir(parents=True)
+    (module_dir / "scripts").mkdir(parents=True)
+    (module_dir / "python").mkdir(parents=True)
+
+    # 1. Generate .mod file
+    mod_content = generate_mod_file(version, platform)
+    (module_dir / "dcc_mcp_maya.mod").write_text(mod_content, encoding="utf-8")
+    print(f"  Generated dcc_mcp_maya.mod (platform={platform}, version={version})")
+
+    # 2. Copy Maya plugin
+    plugin_src = project_root / "maya" / "plugin" / "dcc_mcp_maya.py"
+    shutil.copy2(plugin_src, module_dir / "plug-ins" / "dcc_mcp_maya.py")
+    print("  Copied plugin to plug-ins/")
+
+    # 3. Copy userSetup.py
+    usersetup_src = project_root / "maya" / "userSetup.py"
+    shutil.copy2(usersetup_src, module_dir / "scripts" / "userSetup.py")
+    print("  Copied userSetup.py to scripts/")
+
+    # 4. Copy dcc_mcp_maya Python package
+    pkg_src = project_root / "src" / "dcc_mcp_maya"
+    pkg_dest = module_dir / "python" / "dcc_mcp_maya"
+    if pkg_dest.exists():
+        shutil.rmtree(pkg_dest)
+    shutil.copytree(pkg_src, pkg_dest)
+    print("  Copied dcc_mcp_maya package to python/")
+
+    # 5. Download and extract dcc_mcp_core
+    core_version = resolve_core_version(project_root)
+    print(f"  Resolved dcc-mcp-core version: >={core_version}")
+
+    with tempfile.TemporaryDirectory() as wheel_cache:
+        wheels = download_core_wheels(core_version, platform, Path(wheel_cache))
+        # Sort: abi3 first (full extract), then cp37 (extensions only)
+        abi3_wheels = [w for w in wheels if "abi3" in w.name]
+        cp37_wheels = [w for w in wheels if "abi3" not in w.name]
+        for wheel in abi3_wheels:
+            print(f"  Extracting {wheel.name} (full)...")
+            extract_wheel(wheel, module_dir / "python")
+        for wheel in cp37_wheels:
+            print(f"  Extracting {wheel.name} (extensions only)...")
+            extract_wheel(wheel, module_dir / "python", extensions_only=True)
+    print("  Extracted dcc_mcp_core to python/")
+
+    # 6. Copy install/uninstall scripts and README
+    packaging_dir = project_root / "packaging"
+    if platform == "win64":
+        shutil.copy2(packaging_dir / "install.bat", module_dir / "install.bat")
+        shutil.copy2(packaging_dir / "uninstall.bat", module_dir / "uninstall.bat")
+    else:
+        shutil.copy2(packaging_dir / "install.sh", module_dir / "install.sh")
+        shutil.copy2(packaging_dir / "uninstall.sh", module_dir / "uninstall.sh")
+    shutil.copy2(packaging_dir / "README.txt", module_dir / "README.txt")
+    print("  Copied install/uninstall scripts and README")
+
+    return module_dir
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Assemble Maya .mod module for dcc-mcp-maya")
+    parser.add_argument("--version", required=True, help="Package version (e.g. 0.3.0)")
+    parser.add_argument("--platform", required=True, choices=["win64", "linux", "macos"], help="Target platform")
+    parser.add_argument("--output", default="dist/mod", help="Output directory")
+    parser.add_argument("--project-root", default=".", help="Project root directory")
+    args = parser.parse_args()
+
+    project_root = Path(args.project_root).resolve()
+    output_dir = Path(args.output).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Assembling .mod module for platform={args.platform}, version={args.version}")
+    assemble(project_root, args.version, args.platform, output_dir)
+
+    # Create ZIP
+    zip_path = output_dir / f"dcc-mcp-maya-{args.version}-{args.platform}"
+    shutil.make_archive(str(zip_path), "zip", root_dir=output_dir, base_dir="dcc-mcp-maya")
+    print(f"\nCreated: {zip_path}.zip")
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/install.bat
+++ b/packaging/install.bat
@@ -1,0 +1,106 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo =========================================
+echo  DCC-MCP-Maya Installer
+echo =========================================
+echo.
+
+REM -- Resolve script directory (handles spaces) --
+set "SCRIPT_DIR=%~dp0"
+set "MODULE_DIR=%SCRIPT_DIR%dcc-mcp-maya"
+
+if not exist "%MODULE_DIR%\dcc_mcp_maya.mod" (
+    echo ERROR: Module directory not found at:
+    echo   %MODULE_DIR%
+    echo.
+    echo Please ensure this script is in the same directory as the dcc-mcp-maya folder.
+    pause & exit /b 1
+)
+
+REM -- Read version from .mod file --
+set "VERSION=unknown"
+for /f "tokens=4" %%v in ('findstr /r "^+ MAYAVERSION" "%MODULE_DIR%\dcc_mcp_maya.mod" 2^>nul') do (
+    set "VERSION=%%v"
+)
+echo  Version: %VERSION%
+echo.
+
+REM -- Detect Maya installations --
+set "FOUND_MAYA=0"
+for %%Y in (2026 2025 2024 2023 2022) do (
+    if exist "C:\Program Files\Autodesk\Maya%%Y\bin\mayapy.exe" (
+        echo  Found Maya %%Y
+        set "FOUND_MAYA=1"
+    )
+)
+if "%FOUND_MAYA%"=="0" (
+    echo  WARNING: No Maya installation detected.
+    echo  The module will still be installed but Maya may not find it automatically.
+    echo.
+)
+
+REM -- Deploy module directory --
+set "MOD_DEST=%USERPROFILE%\Documents\maya\modules"
+if not exist "%MOD_DEST%" mkdir "%MOD_DEST%"
+
+REM -- Remove previous installation --
+if exist "%MOD_DEST%\dcc-mcp-maya" (
+    echo Removing previous installation...
+    rmdir /s /q "%MOD_DEST%\dcc-mcp-maya"
+)
+
+echo.
+echo Deploying module to: %MOD_DEST%\dcc-mcp-maya
+xcopy /e /i /q /y "%MODULE_DIR%" "%MOD_DEST%\dcc-mcp-maya" >nul
+if errorlevel 1 (
+    echo ERROR: Failed to copy module files.
+    pause & exit /b 1
+)
+
+REM -- Deploy userSetup.py --
+set "SCRIPTS_DEST=%USERPROFILE%\Documents\maya\scripts"
+if not exist "%SCRIPTS_DEST%" mkdir "%SCRIPTS_DEST%"
+
+set "USERSETUP_DEST=%SCRIPTS_DEST%\userSetup.py"
+if not exist "%USERSETUP_DEST%" (
+    copy /y "%MOD_DEST%\dcc-mcp-maya\scripts\userSetup.py" "%USERSETUP_DEST%" >nul
+    echo Deployed userSetup.py to %SCRIPTS_DEST%
+) else (
+    REM Check if our snippet is already present
+    findstr /c:"dcc_mcp_maya" "%USERSETUP_DEST%" >nul 2>&1
+    if errorlevel 1 (
+        echo.
+        echo Appending dcc-mcp-maya loader to existing userSetup.py...
+        echo. >> "%USERSETUP_DEST%"
+        echo # dcc-mcp-maya auto-load >> "%USERSETUP_DEST%"
+        echo try: >> "%USERSETUP_DEST%"
+        echo     import maya.utils >> "%USERSETUP_DEST%"
+        echo     def _load_dcc_mcp_maya^^^(^^^): >> "%USERSETUP_DEST%"
+        echo         try: >> "%USERSETUP_DEST%"
+        echo             import maya.cmds as cmds >> "%USERSETUP_DEST%"
+        echo             if not cmds.pluginInfo^^^("dcc_mcp_maya", query=True, loaded=True^^^): >> "%USERSETUP_DEST%"
+        echo                 cmds.loadPlugin^^^("dcc_mcp_maya", quiet=True^^^) >> "%USERSETUP_DEST%"
+        echo         except Exception: >> "%USERSETUP_DEST%"
+        echo             pass >> "%USERSETUP_DEST%"
+        echo     maya.utils.executeDeferred^^^(_load_dcc_mcp_maya^^^) >> "%USERSETUP_DEST%"
+        echo except ImportError: >> "%USERSETUP_DEST%"
+        echo     pass >> "%USERSETUP_DEST%"
+    ) else (
+        echo userSetup.py already contains dcc-mcp-maya loader, skipping.
+    )
+)
+
+echo.
+echo =========================================
+echo  Installation complete!
+echo.
+echo  Module:   %MOD_DEST%\dcc-mcp-maya
+echo  Plugin:   %MOD_DEST%\dcc-mcp-maya\plug-ins\dcc_mcp_maya.py
+echo.
+echo  The plugin will auto-load when Maya starts.
+echo  Alternatively, load it via:
+echo    Window ^> Settings/Preferences ^> Plug-in Manager
+echo =========================================
+pause
+endlocal

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -e
+
+VERSION="0.3.0"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULE_DIR="$SCRIPT_DIR/dcc-mcp-maya"
+
+echo "========================================="
+echo " DCC-MCP-Maya Installer"
+echo "========================================="
+echo
+
+if [ ! -f "$MODULE_DIR/dcc_mcp_maya.mod" ]; then
+    echo "ERROR: Module directory not found at:"
+    echo "  $MODULE_DIR"
+    echo
+    echo "Please ensure this script is in the same directory as the dcc-mcp-maya folder."
+    exit 1
+fi
+
+# Read version from .mod file
+VERSION=$(grep -oP '(?<=dcc_mcp_maya )\d+\.\d+\.\d+' "$MODULE_DIR/dcc_mcp_maya.mod" | head -1 || echo "unknown")
+echo " Version: ${VERSION}"
+echo
+
+# Detect Maya installations
+FOUND_MAYA=0
+for year in 2026 2025 2024 2023 2022; do
+    CANDIDATES=(
+        "/usr/autodesk/maya${year}/bin/mayapy"
+        "/Applications/Autodesk/maya${year}/Maya.app/Contents/bin/mayapy"
+    )
+    for c in "${CANDIDATES[@]}"; do
+        if [ -x "$c" ]; then
+            echo " Found Maya ${year} at $c"
+            FOUND_MAYA=1
+            break
+        fi
+    done
+done
+if [ "$FOUND_MAYA" -eq 0 ]; then
+    echo " WARNING: No Maya installation detected."
+    echo " The module will still be installed but Maya may not find it automatically."
+    echo
+fi
+
+# Determine platform-specific paths
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    MOD_DEST="$HOME/Library/Preferences/Autodesk/maya/modules"
+    SCRIPTS_DEST="$HOME/Library/Preferences/Autodesk/maya/scripts"
+else
+    MOD_DEST="$HOME/maya/modules"
+    SCRIPTS_DEST="$HOME/maya/scripts"
+fi
+
+# Deploy module directory
+mkdir -p "$MOD_DEST"
+
+if [ -d "$MOD_DEST/dcc-mcp-maya" ]; then
+    echo "Removing previous installation..."
+    rm -rf "$MOD_DEST/dcc-mcp-maya"
+fi
+
+echo
+echo "Deploying module to: $MOD_DEST/dcc-mcp-maya"
+cp -R "$MODULE_DIR" "$MOD_DEST/dcc-mcp-maya"
+
+# Deploy userSetup.py
+mkdir -p "$SCRIPTS_DEST"
+
+USERSETUP_DEST="$SCRIPTS_DEST/userSetup.py"
+if [ ! -f "$USERSETUP_DEST" ]; then
+    cp "$MOD_DEST/dcc-mcp-maya/scripts/userSetup.py" "$USERSETUP_DEST"
+    echo "Deployed userSetup.py to $SCRIPTS_DEST"
+else
+    if ! grep -q "dcc_mcp_maya" "$USERSETUP_DEST" 2>/dev/null; then
+        echo
+        echo "Appending dcc-mcp-maya loader to existing userSetup.py..."
+        cat >> "$USERSETUP_DEST" << 'USERSETUP_EOF'
+
+# dcc-mcp-maya auto-load
+try:
+    import maya.utils
+    def _load_dcc_mcp_maya():
+        try:
+            import maya.cmds as cmds
+            if not cmds.pluginInfo("dcc_mcp_maya", query=True, loaded=True):
+                cmds.loadPlugin("dcc_mcp_maya", quiet=True)
+        except Exception:
+            pass
+    maya.utils.executeDeferred(_load_dcc_mcp_maya)
+except ImportError:
+    pass
+USERSETUP_EOF
+    else
+        echo "userSetup.py already contains dcc-mcp-maya loader, skipping."
+    fi
+fi
+
+echo
+echo "========================================="
+echo " Installation complete!"
+echo
+echo " Module:   $MOD_DEST/dcc-mcp-maya"
+echo " Plugin:   $MOD_DEST/dcc-mcp-maya/plug-ins/dcc_mcp_maya.py"
+echo
+echo " The plugin will auto-load when Maya starts."
+echo " Alternatively, load it via:"
+echo "   Window > Settings/Preferences > Plug-in Manager"
+echo "========================================="

--- a/packaging/uninstall.bat
+++ b/packaging/uninstall.bat
@@ -1,0 +1,33 @@
+@echo off
+setlocal
+
+echo =========================================
+echo  DCC-MCP-Maya Uninstaller
+echo =========================================
+echo.
+
+set "MOD_DEST=%USERPROFILE%\Documents\maya\modules\dcc-mcp-maya"
+
+if not exist "%MOD_DEST%" (
+    echo Module directory not found at: %MOD_DEST%
+    echo Nothing to uninstall.
+    pause & exit /b 0
+)
+
+echo Removing module directory: %MOD_DEST%
+rmdir /s /q "%MOD_DEST%"
+if errorlevel 1 (
+    echo ERROR: Failed to remove module directory.
+    echo Please close Maya and try again.
+    pause & exit /b 1
+)
+
+echo.
+echo Module removed successfully.
+echo.
+echo NOTE: userSetup.py was not modified. If you want to remove the
+echo auto-load snippet, edit this file manually:
+echo   %USERPROFILE%\Documents\maya\scripts\userSetup.py
+echo.
+pause
+endlocal

--- a/packaging/uninstall.sh
+++ b/packaging/uninstall.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+echo "========================================="
+echo " DCC-MCP-Maya Uninstaller"
+echo "========================================="
+echo
+
+# Determine platform-specific paths
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    MOD_DEST="$HOME/Library/Preferences/Autodesk/maya/modules/dcc-mcp-maya"
+else
+    MOD_DEST="$HOME/maya/modules/dcc-mcp-maya"
+fi
+
+if [ ! -d "$MOD_DEST" ]; then
+    echo "Module directory not found at: $MOD_DEST"
+    echo "Nothing to uninstall."
+    exit 0
+fi
+
+echo "Removing module directory: $MOD_DEST"
+rm -rf "$MOD_DEST"
+
+echo
+echo "Module removed successfully."
+echo
+echo "NOTE: userSetup.py was not modified. If you want to remove the"
+echo "auto-load snippet, edit this file manually:"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "  ~/Library/Preferences/Autodesk/maya/scripts/userSetup.py"
+else
+    echo "  ~/maya/scripts/userSetup.py"
+fi

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,12 +16,7 @@
           "path": "pyproject.toml",
           "jsonpath": "$.project.version"
         },
-        "src/dcc_mcp_maya/__version__.py",
-        {
-          "type": "generic",
-          "path": "maya/plugin/dcc_mcp_maya.py",
-          "search-by-regex": "VERSION = \"[0-9]+\\.[0-9]+\\.[0-9]+\""
-        }
+        "src/dcc_mcp_maya/__version__.py"
       ]
     }
   },


### PR DESCRIPTION
## Summary

- Add CI workflow to build per-platform ZIP packages (win64, linux, macos) containing a Maya `.mod` module with dcc-mcp-maya + dcc-mcp-core bundled offline
- Users can double-click `install.bat`/`install.sh` to deploy the module into Maya without requiring pip or internet access
- Plugin version now reads from `dcc_mcp_maya.__version__` instead of hardcoding, removing release-please sync burden

## Changes

### New files
- `packaging/assemble_mod.py` — CI script to assemble .mod directory, download dcc-mcp-core wheels (abi3 + cp37), and create ZIP
- `packaging/install.bat` / `install.sh` — Offline deployment scripts (copy module dir + userSetup.py)
- `packaging/uninstall.bat` / `uninstall.sh` — Clean removal scripts

### Modified files
- `.github/workflows/release.yml` — Add `build-mod` matrix job (win64/linux/macos) and `attach-mod-release` job
- `maya/plugin/dcc_mcp_maya.py` — Read VERSION from `dcc_mcp_maya.__version__` at runtime
- `release-please-config.json` — Remove plugin VERSION from extra-files (no longer needed)

## .mod Module Structure (in ZIP)

```
dcc-mcp-maya/
  dcc_mcp_maya.mod           ← Maya module descriptor
  plug-ins/
    dcc_mcp_maya.py           ← Maya plugin
  scripts/
    userSetup.py              ← Auto-load snippet
  python/
    dcc_mcp_maya/             ← Python package
    dcc_mcp_core/             ← Extracted from wheel (abi3 + cp37 extensions)
  install.bat / install.sh
  uninstall.bat / uninstall.sh
  README.txt
```

## Test plan
- [ ] Verify CI workflow syntax is valid
- [ ] Test `assemble_mod.py` locally with `--platform win64 --version 0.3.0`
- [ ] Verify .mod file format is correct for Maya 2022-2025
- [ ] Verify install.bat correctly deploys module on Windows