### PR TITLE
fix(packaging): replace pip download with PyPI JSON API for cross-platform wheel retrieval

### DIFF
--- a/packaging/assemble_mod.py
+++ b/packaging/assemble_mod.py
@@ -16,108 +16,164 @@ from __future__ import annotations
 
 import argparse
 import shutil
-import subprocess
-import sys
 import tempfile
 from pathlib import Path
 
 
-def run(cmd: list[str], **kwargs) -> str:
-    """Run a subprocess and return stdout."""
-    result = subprocess.run(cmd, capture_output=True, text=True, check=True, **kwargs)
-    return result.stdout.strip()
-
-
 def resolve_core_version(project_root: Path) -> str:
-    """Read the dcc-mcp-core minimum version from pyproject.toml."""
+    """Resolve the best available dcc-mcp-core version from PyPI.
+
+    Reads the minimum version from pyproject.toml, then queries PyPI
+    for the latest compatible version.  Falls back to the minimum
+    version when PyPI is unreachable.
+    """
     import re
 
     toml_path = project_root / "pyproject.toml"
     content = toml_path.read_text(encoding="utf-8")
     m = re.search(r"dcc-mcp-core>=(\d+\.\d+\.\d+)", content)
-    if m:
-        return m.group(1)
-    m = re.search(r"dcc-mcp-core>=([\d.]+)", content)
-    if m:
-        return m.group(1)
-    raise RuntimeError("Cannot find dcc-mcp-core version in pyproject.toml")
+    if not m:
+        m = re.search(r"dcc-mcp-core>=([\d.]+)", content)
+    if not m:
+        raise RuntimeError("Cannot find dcc-mcp-core version in pyproject.toml")
+    min_version = m.group(1)
+
+    # Try to get the latest version from PyPI so we download a version
+    # that actually has compiled wheels for all platforms.
+    try:
+        import json
+        import urllib.request
+
+        url = "https://pypi.org/pypi/dcc-mcp-core/json"
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            data = json.loads(resp.read())
+        latest = data.get("info", {}).get("version", "")
+        if latest and _version_gte(latest, min_version):
+            print(f"  PyPI latest dcc-mcp-core: {latest} (>= {min_version})")
+            return latest
+    except Exception as exc:
+        print(f"  Warning: could not query PyPI for latest version ({exc}), using minimum {min_version}")
+
+    return min_version
+
+
+def _version_gte(ver: str, minimum: str) -> bool:
+    """Return True if *ver* >= *minimum* (simple dotted comparison)."""
+    v_parts = [int(x) for x in ver.split(".")]
+    m_parts = [int(x) for x in minimum.split(".")]
+    return v_parts >= m_parts
 
 
 def download_core_wheels(version: str, platform: str, dest: Path) -> list[Path]:
     """Download dcc-mcp-core wheels for the target platform.
 
+    Uses the PyPI JSON API to find the exact wheel URLs, then downloads
+    them directly with urllib.  This avoids ``pip download`` cross-platform
+    tag-filtering issues (e.g. ``--python-tag`` is not a valid pip option,
+    and ``--platform`` filtering is unreliable when the runner OS differs
+    from the target platform).
+
     Downloads both abi3 (cp38+, covers Maya 2023+) and cp37 (Maya 2022)
     wheels where available.
     """
-    # Wheel specs: (python_tag, abi_tag, pip_platform_tag)
-    wheel_specs: list[tuple[str, str, str]] = []
+    import json
+    import urllib.request
+
+    # Wheel filename patterns per platform.
+    # Each entry: (substring that must appear in filename, description)
+    wheel_patterns: list[tuple[str, str]] = []
 
     if platform == "win64":
-        wheel_specs = [
-            ("cp38", "abi3", "win_amd64"),
-            ("cp37", "cp37m", "win_amd64"),
+        wheel_patterns = [
+            ("cp38-abi3-win_amd64", "cp38-abi3, win_amd64"),
+            ("cp37-cp37m-win_amd64", "cp37-cp37m, win_amd64"),
         ]
     elif platform == "linux":
-        wheel_specs = [
-            ("cp38", "abi3", "manylinux_2_17_x86_64.manylinux2014_x86_64"),
-            ("cp37", "cp37m", "manylinux_2_17_x86_64.manylinux2014_x86_64"),
+        wheel_patterns = [
+            ("cp38-abi3-manylinux", "cp38-abi3, manylinux x86_64"),
+            ("cp37-cp37m-manylinux", "cp37-cp37m, manylinux x86_64"),
         ]
     elif platform == "macos":
         # No cp37 wheel on macOS — Maya 2022 not supported
-        wheel_specs = [
-            ("cp38", "abi3", "macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2"),
+        wheel_patterns = [
+            ("cp38-abi3-macosx", "cp38-abi3, macosx universal2"),
         ]
 
-    for py_tag, abi_tag, plat_tag in wheel_specs:
-        cmd = [
-            sys.executable,
-            "-m",
-            "pip",
-            "download",
-            f"dcc-mcp-core=={version}",
-            "--no-deps",
-            "--only-binary=:all:",
-            f"--platform={plat_tag}",
-            f"--python-tag={py_tag}",
-            f"--abi={abi_tag}",
-            "-d",
-            str(dest),
-        ]
-        print(f"  Downloading core wheel ({py_tag}-{abi_tag}, {plat_tag})...")
-        run(cmd)
+    # Query PyPI JSON API for available wheels
+    pypi_url = f"https://pypi.org/pypi/dcc-mcp-core/{version}/json"
+    print(f"  Querying PyPI: {pypi_url}")
+    with urllib.request.urlopen(pypi_url, timeout=30) as resp:
+        pypi_data = json.loads(resp.read())
+
+    releases = pypi_data.get("releases", {})
+    version_files = releases.get(version, [])
+    if not version_files:
+        # Fallback: use urls from the top-level data
+        version_files = pypi_data.get("urls", [])
+
+    # Build a map from filename → download URL
+    file_map: dict[str, str] = {f["filename"]: f["url"] for f in version_files if f.get("packagetype") == "bdist_wheel"}
+
+    for pattern, desc in wheel_patterns:
+        matching = [fn for fn in file_map if pattern in fn]
+        if not matching:
+            print(f"  Warning: no wheel matching '{pattern}' found on PyPI for v{version}")
+            continue
+        # Pick the first (should be exactly one)
+        filename = matching[0]
+        url = file_map[filename]
+        dest_file = dest / filename
+        if dest_file.exists():
+            print(f"  Already cached: {filename}")
+            continue
+        print(f"  Downloading {filename} ({desc})...")
+        urllib.request.urlretrieve(url, str(dest_file))
 
     wheels = list(dest.glob("dcc_mcp_core-*.whl"))
+    if not wheels:
+        raise RuntimeError(f"No dcc-mcp-core wheels could be downloaded for platform={platform}, version={version}")
     print(f"  Downloaded {len(wheels)} wheel(s)")
     return wheels
 
 
-def extract_wheel(wheel_path: Path, dest: Path, *, extensions_only: bool = False) -> None:
+def extract_wheel(wheel_path: Path, dest: Path, *, extensions_only: bool = False, alt_dest: Path | None = None) -> None:
     """Extract a wheel into dest.
 
+    Uses zipfile directly instead of ``pip install --target`` so that
+    cross-Python-version wheels (e.g. cp37 on a py312 runner) can be
+    extracted without compatibility errors.
+
     If extensions_only is True, only copy compiled extension files (.pyd/.so)
-    to avoid overwriting Python source files from the abi3 wheel.
+    to avoid overwriting Python source files from the abi3 wheel.  When
+    *alt_dest* is provided and a file would overwrite an existing one in
+    *dest*, the file is placed in *alt_dest* instead (used for cp37 wheels
+    whose extensions share the same filename as abi3 but target Maya 2022).
     """
-    with tempfile.TemporaryDirectory() as tmp:
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "--no-deps", "--target", tmp, str(wheel_path)],
-            check=True,
-            capture_output=True,
-        )
-        tmp_path = Path(tmp)
-        for item in tmp_path.rglob("*"):
-            if not item.is_file():
+    import zipfile
+
+    with zipfile.ZipFile(str(wheel_path)) as zf:
+        for info in zf.infolist():
+            if info.is_dir():
                 continue
-            rel = item.relative_to(tmp_path)
-            dest_file = dest / rel
+            # Skip the .dist-info directory — we only need the package files
+            parts = Path(info.filename).parts
+            if any(p.endswith(".dist-info") for p in parts):
+                continue
+            dest_file = dest / info.filename
             if extensions_only:
                 # Only copy compiled extensions (.pyd, .so, .dylib)
-                if item.suffix not in (".pyd", ".so", ".dylib"):
+                if dest_file.suffix not in (".pyd", ".so", ".dylib"):
                     continue
+                # If the file already exists (e.g. from the abi3 wheel),
+                # put the cp37 extension in an alternate directory instead
+                if dest_file.exists() and alt_dest is not None:
+                    dest_file = alt_dest / info.filename
             dest_file.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(item, dest_file)
+            with zf.open(info) as src, open(dest_file, "wb") as dst:
+                dst.write(src.read())
 
 
-def generate_mod_file(version: str, platform: str) -> str:
+def generate_mod_file(version: str, platform: str, has_cp37: bool = False) -> str:
     """Generate the .mod file content."""
     platform_str = {
         "win64": "win64",
@@ -133,7 +189,11 @@ def generate_mod_file(version: str, platform: str) -> str:
     lines = []
     for mv in maya_versions:
         lines.append(f"+ MAYAVERSION:{mv} PLATFORM:{platform_str} dcc_mcp_maya {version} .")
-        lines.append("PYTHONPATH+:=python")
+        # Maya 2022 uses python37/ if cp37 extensions are available
+        if mv == "2022" and has_cp37:
+            lines.append("PYTHONPATH+:=python37")
+        else:
+            lines.append("PYTHONPATH+:=python")
 
     return "\n".join(lines) + "\n"
 
@@ -152,8 +212,42 @@ def assemble(project_root: Path, version: str, platform: str, output: Path) -> P
     (module_dir / "scripts").mkdir(parents=True)
     (module_dir / "python").mkdir(parents=True)
 
+    # 5. Download and extract dcc_mcp_core (early, so we know if cp37 is available)
+    core_version = resolve_core_version(project_root)
+    print(f"  Resolved dcc-mcp-core version: >={core_version}")
+
+    has_cp37 = False
+    with tempfile.TemporaryDirectory() as wheel_cache:
+        wheels = download_core_wheels(core_version, platform, Path(wheel_cache))
+        # Sort: abi3 first (full extract), then cp37 (extensions only)
+        abi3_wheels = [w for w in wheels if "abi3" in w.name]
+        cp37_wheels = [w for w in wheels if "abi3" not in w.name]
+        for wheel in abi3_wheels:
+            print(f"  Extracting {wheel.name} (full)...")
+            extract_wheel(wheel, module_dir / "python")
+        if cp37_wheels:
+            # Create python37/ directory with symlinks/copies of pure Python
+            # and cp37 native extensions for Maya 2022 compatibility
+            python37_dir = module_dir / "python37"
+            python37_dir.mkdir(parents=True)
+            # Copy the entire python/ contents first, then overlay cp37 extensions
+            # (This ensures python37 has all the pure-Python code too)
+            python_dir = module_dir / "python"
+            for item in python_dir.iterdir():
+                dest_item = python37_dir / item.name
+                if item.is_dir():
+                    shutil.copytree(item, dest_item)
+                else:
+                    shutil.copy2(item, dest_item)
+            # Now overlay cp37 extensions
+            for wheel in cp37_wheels:
+                print(f"  Extracting {wheel.name} (cp37 overlay to python37/)...")
+                extract_wheel(wheel, python37_dir, extensions_only=True)
+                has_cp37 = True
+    print("  Extracted dcc_mcp_core to python/" + (" and python37/" if has_cp37 else ""))
+
     # 1. Generate .mod file
-    mod_content = generate_mod_file(version, platform)
+    mod_content = generate_mod_file(version, platform, has_cp37=has_cp37)
     (module_dir / "dcc_mcp_maya.mod").write_text(mod_content, encoding="utf-8")
     print(f"  Generated dcc_mcp_maya.mod (platform={platform}, version={version})")
 
@@ -167,30 +261,19 @@ def assemble(project_root: Path, version: str, platform: str, output: Path) -> P
     shutil.copy2(usersetup_src, module_dir / "scripts" / "userSetup.py")
     print("  Copied userSetup.py to scripts/")
 
-    # 4. Copy dcc_mcp_maya Python package
+    # 4. Copy dcc_mcp_maya Python package (to both python/ and python37/ if present)
     pkg_src = project_root / "src" / "dcc_mcp_maya"
     pkg_dest = module_dir / "python" / "dcc_mcp_maya"
     if pkg_dest.exists():
         shutil.rmtree(pkg_dest)
     shutil.copytree(pkg_src, pkg_dest)
     print("  Copied dcc_mcp_maya package to python/")
-
-    # 5. Download and extract dcc_mcp_core
-    core_version = resolve_core_version(project_root)
-    print(f"  Resolved dcc-mcp-core version: >={core_version}")
-
-    with tempfile.TemporaryDirectory() as wheel_cache:
-        wheels = download_core_wheels(core_version, platform, Path(wheel_cache))
-        # Sort: abi3 first (full extract), then cp37 (extensions only)
-        abi3_wheels = [w for w in wheels if "abi3" in w.name]
-        cp37_wheels = [w for w in wheels if "abi3" not in w.name]
-        for wheel in abi3_wheels:
-            print(f"  Extracting {wheel.name} (full)...")
-            extract_wheel(wheel, module_dir / "python")
-        for wheel in cp37_wheels:
-            print(f"  Extracting {wheel.name} (extensions only)...")
-            extract_wheel(wheel, module_dir / "python", extensions_only=True)
-    print("  Extracted dcc_mcp_core to python/")
+    if has_cp37:
+        pkg_dest_37 = module_dir / "python37" / "dcc_mcp_maya"
+        if pkg_dest_37.exists():
+            shutil.rmtree(pkg_dest_37)
+        shutil.copytree(pkg_src, pkg_dest_37)
+        print("  Copied dcc_mcp_maya package to python37/")
 
     # 6. Copy install/uninstall scripts and README
     packaging_dir = project_root / "packaging"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short -m 'not e2e and not packaging'"
 markers = [
     "e2e: end-to-end tests that require a real Maya standalone interpreter (tahv/mayapy)",
     "packaging: tests for packaging/assemble_mod.py that require network access to PyPI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ python_functions = ["test_*"]
 addopts = "-v --tb=short"
 markers = [
     "e2e: end-to-end tests that require a real Maya standalone interpreter (tahv/mayapy)",
+    "packaging: tests for packaging/assemble_mod.py that require network access to PyPI",
 ]
 
 [tool.coverage.run]

--- a/src/dcc_mcp_maya/__init__.py
+++ b/src/dcc_mcp_maya/__init__.py
@@ -36,6 +36,9 @@ from dcc_mcp_maya.__version__ import __version__
 from dcc_mcp_maya.api import (
     MissingParamError,
     batch_validate_nodes,
+    bounding_box_from_node,
+    build_context_dict,
+    ensure_valid_name,
     get_cmds,
     get_param_list,
     is_maya_available,
@@ -43,9 +46,11 @@ from dcc_mcp_maya.api import (
     maya_from_exception,
     maya_success,
     missing_param_error,
+    object_transform_from_node,
     require_any_param,
     require_cmds,
     require_param,
+    scene_object_from_node,
     validate_node_exists,
     validate_node_type,
     with_maya,
@@ -76,4 +81,11 @@ __all__ = [
     "validate_node_exists",
     "validate_node_type",
     "batch_validate_nodes",
+    # Name and context helpers
+    "ensure_valid_name",
+    "build_context_dict",
+    # Cross-DCC data model helpers
+    "scene_object_from_node",
+    "object_transform_from_node",
+    "bounding_box_from_node",
 ]

--- a/src/dcc_mcp_maya/api.py
+++ b/src/dcc_mcp_maya/api.py
@@ -519,6 +519,172 @@ def get_param_list(params: Any, key: str, default: Any = None) -> List[Any]:
 
 
 # ---------------------------------------------------------------------------
+# Name and context helpers
+# ---------------------------------------------------------------------------
+
+
+def ensure_valid_name(name: Any, param: str = "name") -> Optional[Dict[str, Any]]:
+    """Return an error dict if *name* is falsy or whitespace-only, else None.
+
+    Designed to guard skill functions that require a non-empty node name::
+
+        err = ensure_valid_name(layer_name, "layer_name")
+        if err:
+            return err
+
+    Args:
+        name: The value to validate (typically a ``str``).
+        param: The parameter name used in the error message.
+
+    Returns:
+        ``None`` when *name* is a non-empty string, otherwise a serialised
+        error dict.
+    """
+    if not name or (isinstance(name, str) and not name.strip()):
+        return maya_error(
+            "Invalid '{}': name must not be empty".format(param),
+            "'{}' received an empty or whitespace-only value".format(param),
+            possible_solutions=[
+                "Pass a non-empty string for '{}'".format(param),
+            ],
+        )
+    return None
+
+
+def build_context_dict(**kwargs: Any) -> Dict[str, Any]:
+    """Return a dict of *kwargs* with ``None``-valued keys removed.
+
+    Reduces ``if value is not None`` boilerplate in skill return statements::
+
+        return maya_success("Done", prompt="...", **build_context_dict(
+            object_name=name,
+            translate=translate,  # may be None
+        ))
+
+    Args:
+        **kwargs: Arbitrary key/value pairs.
+
+    Returns:
+        A new dict containing only entries whose value is not ``None``.
+    """
+    return {k: v for k, v in kwargs.items() if v is not None}
+
+
+# ---------------------------------------------------------------------------
+# Cross-DCC data model helpers
+# ---------------------------------------------------------------------------
+
+
+def scene_object_from_node(cmds: Any, long_name: str) -> Dict[str, Any]:
+    """Build a SceneObject-compatible dict from a Maya DAG transform node.
+
+    Returns a dictionary matching the ``SceneObject`` schema used by
+    ``dcc-mcp-core`` for cross-DCC scene exchange::
+
+        {
+            "name": "pSphere1",
+            "long_name": "|pSphere1",
+            "object_type": "transform",
+            "parent": None,
+            "visible": True,
+            "metadata": {},
+        }
+
+    Args:
+        cmds: The ``maya.cmds`` module.
+        long_name: Long DAG path of the node (e.g. ``"|group1|pSphere1"``).
+
+    Returns:
+        SceneObject-compatible dict.
+    """
+    short_name = long_name.rsplit("|", 1)[-1] if "|" in long_name else long_name
+    object_type = cmds.objectType(long_name)
+
+    # Determine parent (None for top-level transforms)
+    parents = cmds.listRelatives(long_name, parent=True, fullPath=True) or []
+    parent = parents[0] if parents else None
+
+    # Visibility — graceful fallback
+    try:
+        visible = bool(cmds.getAttr("{}.visibility".format(long_name)))
+    except Exception:
+        visible = True
+
+    return {
+        "name": short_name,
+        "long_name": long_name,
+        "object_type": object_type,
+        "parent": parent,
+        "visible": visible,
+        "metadata": {},
+    }
+
+
+def object_transform_from_node(cmds: Any, node_name: str) -> Dict[str, Any]:
+    """Build an ObjectTransform-compatible dict from a Maya transform node.
+
+    Returns::
+
+        {
+            "translate": [tx, ty, tz],
+            "rotate":    [rx, ry, rz],
+            "scale":     [sx, sy, sz],
+        }
+
+    All values are Python ``float``.
+
+    Args:
+        cmds: The ``maya.cmds`` module.
+        node_name: Name of the transform node.
+
+    Returns:
+        ObjectTransform-compatible dict.
+    """
+    tx, ty, tz = cmds.getAttr("{}.translate".format(node_name))[0]
+    rx, ry, rz = cmds.getAttr("{}.rotate".format(node_name))[0]
+    sx, sy, sz = cmds.getAttr("{}.scale".format(node_name))[0]
+    return {
+        "translate": [float(tx), float(ty), float(tz)],
+        "rotate": [float(rx), float(ry), float(rz)],
+        "scale": [float(sx), float(sy), float(sz)],
+    }
+
+
+def bounding_box_from_node(cmds: Any, node_name: str) -> Dict[str, Any]:
+    """Build a BoundingBox-compatible dict from a Maya node.
+
+    Uses ``exactWorldBoundingBox`` to compute the world-space AABB.
+
+    Returns::
+
+        {
+            "min":    [xmin, ymin, zmin],
+            "max":    [xmax, ymax, zmax],
+            "center": [cx,   cy,   cz  ],
+            "size":   [dx,   dy,   dz  ],
+        }
+
+    Args:
+        cmds: The ``maya.cmds`` module.
+        node_name: Name of the node.
+
+    Returns:
+        BoundingBox-compatible dict.
+    """
+    bb = cmds.exactWorldBoundingBox(node_name)
+    xmin, ymin, zmin, xmax, ymax, zmax = (float(v) for v in bb)
+    cx = (xmin + xmax) / 2.0
+    cy = (ymin + ymax) / 2.0
+    cz = (zmin + zmax) / 2.0
+    return {
+        "min": [xmin, ymin, zmin],
+        "max": [xmax, ymax, zmax],
+        "center": [cx, cy, cz],
+        "size": [xmax - xmin, ymax - ymin, zmax - zmin],
+    }
+
+
+# ---------------------------------------------------------------------------
 # Convenience re-exports so callers only need one import
 # ---------------------------------------------------------------------------
 
@@ -540,4 +706,11 @@ __all__ = [
     "validate_node_exists",
     "validate_node_type",
     "batch_validate_nodes",
+    # Name and context helpers
+    "ensure_valid_name",
+    "build_context_dict",
+    # Cross-DCC data model helpers
+    "scene_object_from_node",
+    "object_transform_from_node",
+    "bounding_box_from_node",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,13 @@
 """Shared test fixtures and helpers for dcc-mcp-maya tests.
 
 Provides:
+- ``SKILLS_ROOT`` — Path to ``src/dcc_mcp_maya/skills/``
 - ``load_skill_script(skill_dir, script_name)`` — load a skill script by path
 - ``make_mock_maya(cmds_attrs, mel_attrs)`` — build a (mock_maya, mock_cmds, mock_mel) triple
+- ``load_and_call(rel_path, mock_cmds, func_name, **kwargs)`` — load a skill script with
+  maya mocked, call ``func_name`` (default ``"main"``) with ``**kwargs``, return result dict
+- ``load_and_call_with_mel(rel_path, mock_cmds, mock_mel, func_name, **kwargs)`` — same as
+  ``load_and_call`` but also patches ``maya.mel``
 - ``mock_maya_modules`` — autouse fixture for server tests
 """
 
@@ -11,9 +16,10 @@ from __future__ import annotations
 
 # Import built-in modules
 import importlib.util
+import sys
 from pathlib import Path
-from typing import Dict, Optional, Tuple
-from unittest.mock import MagicMock
+from typing import Any, Dict, Optional, Tuple
+from unittest.mock import MagicMock, patch
 
 # Import third-party modules
 
@@ -42,6 +48,107 @@ def load_skill_script(skill_dir: str, script_name: str):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def load_and_call(
+    rel_path: str,
+    mock_cmds: Any,
+    func_name: str = "main",
+    **kwargs: Any,
+) -> dict:
+    """Load a skill script with Maya mocked and call *func_name* with *kwargs*.
+
+    Keeps the ``maya`` / ``maya.cmds`` mock active during **both** module load
+    and function invocation, which prevents ``ImportError`` inside scripts that
+    import ``maya.cmds`` at module level or inside the function body.
+
+    Args:
+        rel_path: Path relative to ``SKILLS_ROOT``, e.g.
+            ``"maya-scene/scripts/get_scene_info.py"``.
+        mock_cmds: A ``MagicMock`` configured to behave like ``maya.cmds``.
+        func_name: Name of the callable to invoke (default ``"main"``).
+        **kwargs: Keyword arguments forwarded to the called function.
+
+    Returns:
+        The result dict returned by the skill function.
+
+    Example::
+
+        result = load_and_call("maya-scene/scripts/create_object.py", mock_cmds, type="sphere")
+        assert result["success"] is True
+    """
+    _MOD_COUNTER[0] += 1
+    script_path = SKILLS_ROOT / rel_path
+    module_name = "skill_lac_{}_{}".format(rel_path.replace("/", "_").replace(".", "_"), _MOD_COUNTER[0])
+
+    mock_maya = MagicMock()
+    mock_maya.cmds = mock_cmds
+
+    fake_modules = {
+        "maya": mock_maya,
+        "maya.cmds": mock_cmds,
+        "maya.api": MagicMock(),
+        "maya.api.OpenMaya": MagicMock(),
+        "maya.utils": MagicMock(),
+    }
+
+    with patch.dict(sys.modules, fake_modules):
+        spec = importlib.util.spec_from_file_location(module_name, str(script_path))
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        func = getattr(mod, func_name)
+        return func(**kwargs)
+
+
+def load_and_call_with_mel(
+    rel_path: str,
+    mock_cmds: Any,
+    mock_mel: Optional[Any] = None,
+    func_name: str = "main",
+    **kwargs: Any,
+) -> dict:
+    """Like :func:`load_and_call` but also patches ``maya.mel``.
+
+    Required for scripts that call ``maya.mel.eval(...)`` or
+    ``import maya.mel as mel`` inside the function body.
+
+    Args:
+        rel_path: Path relative to ``SKILLS_ROOT``.
+        mock_cmds: A ``MagicMock`` configured to behave like ``maya.cmds``.
+        mock_mel: Optional ``MagicMock`` for ``maya.mel``.  A new one is
+            created if *None* is passed.
+        func_name: Name of the callable to invoke (default ``"main"``).
+        **kwargs: Keyword arguments forwarded to the called function.
+
+    Returns:
+        The result dict returned by the skill function.
+    """
+    if mock_mel is None:
+        mock_mel = MagicMock()
+
+    _MOD_COUNTER[0] += 1
+    script_path = SKILLS_ROOT / rel_path
+    module_name = "skill_lacm_{}_{}".format(rel_path.replace("/", "_").replace(".", "_"), _MOD_COUNTER[0])
+
+    mock_maya = MagicMock()
+    mock_maya.cmds = mock_cmds
+    mock_maya.mel = mock_mel
+
+    fake_modules = {
+        "maya": mock_maya,
+        "maya.cmds": mock_cmds,
+        "maya.mel": mock_mel,
+        "maya.api": MagicMock(),
+        "maya.api.OpenMaya": MagicMock(),
+        "maya.utils": MagicMock(),
+    }
+
+    with patch.dict(sys.modules, fake_modules):
+        spec = importlib.util.spec_from_file_location(module_name, str(script_path))
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        func = getattr(mod, func_name)
+        return func(**kwargs)
 
 
 def make_mock_maya(

--- a/tests/test_assemble_mod.py
+++ b/tests/test_assemble_mod.py
@@ -1,0 +1,631 @@
+"""Tests for packaging/assemble_mod.py — validates the .mod module assembly logic.
+
+These tests verify:
+- resolve_core_version: reads minimum version from pyproject.toml and resolves latest from PyPI
+- download_core_wheels: finds and downloads correct wheel files via PyPI JSON API
+- extract_wheel: correctly extracts wheel contents using zipfile
+- generate_mod_file: generates proper .mod content with python37 support
+- assemble: end-to-end assembly produces correct directory structure
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the module under test
+ASSEMBLE_MOD = Path(__file__).parent.parent / "packaging" / "assemble_mod.py"
+PROJECT_ROOT = Path(__file__).parent.parent
+
+# We import by executing the script as a module
+import importlib.util as _ilu  # noqa: E402
+
+_spec = _ilu.spec_from_file_location("assemble_mod", str(ASSEMBLE_MOD))
+assemble_mod = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(assemble_mod)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_fake_wheel(dest: Path, name: str, files: dict[str, bytes]) -> Path:
+    """Create a minimal wheel zip at *dest/name* containing *files*.
+
+    Automatically adds a .dist-info/METADATA entry so the wheel looks real.
+    If *files* already contains dist-info entries they will be preserved.
+    """
+    wheel_path = dest / name
+    with zipfile.ZipFile(str(wheel_path), "w") as zf:
+        for fname, content in files.items():
+            zf.writestr(fname, content)
+        # Add a minimal dist-info if not already present
+        dist_info_prefix = f"{name.split('-')[0]}-{name.split('-')[1]}.dist-info/"
+        if not any(f.startswith(dist_info_prefix) for f in files):
+            zf.writestr(f"{dist_info_prefix}METADATA", "Metadata-Version: 2.1\nName: dcc-mcp-core\n")
+    return wheel_path
+
+
+def _make_fake_pyproject(dest: Path, core_version: str = "0.12.12") -> Path:
+    """Create a minimal pyproject.toml at *dest*."""
+    toml_path = dest / "pyproject.toml"
+    toml_path.write_text(
+        f'[project]\ndependencies = [\n    "dcc-mcp-core>={core_version},<1.0.0",\n]\n',
+        encoding="utf-8",
+    )
+    return toml_path
+
+
+# ── _version_gte ─────────────────────────────────────────────────────────────
+
+
+class TestVersionGte:
+    def test_equal(self):
+        assert assemble_mod._version_gte("0.12.12", "0.12.12") is True
+
+    def test_greater(self):
+        assert assemble_mod._version_gte("0.12.17", "0.12.12") is True
+
+    def test_lesser(self):
+        assert assemble_mod._version_gte("0.12.11", "0.12.12") is False
+
+    def test_major_greater(self):
+        assert assemble_mod._version_gte("1.0.0", "0.12.12") is True
+
+
+# ── resolve_core_version ────────────────────────────────────────────────────
+
+
+class TestResolveCoreVersion:
+    def test_extracts_minimum_version(self, tmp_path):
+        _make_fake_pyproject(tmp_path, "0.12.15")
+        # Patch PyPI query to fail so we get the minimum version
+        with patch("urllib.request.urlopen", side_effect=Exception("offline")):
+            version = assemble_mod.resolve_core_version(tmp_path)
+        assert version == "0.12.15"
+
+    def test_uses_pypi_latest_when_available(self, tmp_path):
+        _make_fake_pyproject(tmp_path, "0.12.12")
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"info": {"version": "0.12.17"}}).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            version = assemble_mod.resolve_core_version(tmp_path)
+        assert version == "0.12.17"
+
+    def test_falls_back_when_pypi_version_too_old(self, tmp_path):
+        _make_fake_pyproject(tmp_path, "0.12.12")
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"info": {"version": "0.12.10"}}).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            version = assemble_mod.resolve_core_version(tmp_path)
+        # Should fall back to minimum version since 0.12.10 < 0.12.12
+        assert version == "0.12.12"
+
+    def test_raises_when_no_version_found(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\ndependencies = []\n", encoding="utf-8")
+        with pytest.raises(RuntimeError, match="Cannot find dcc-mcp-core version"):
+            assemble_mod.resolve_core_version(tmp_path)
+
+
+# ── download_core_wheels ────────────────────────────────────────────────────
+
+
+class TestDownloadCoreWheels:
+    def _mock_pypi_response(self, version: str = "0.12.17") -> dict:
+        """Build a minimal PyPI JSON response for dcc-mcp-core."""
+        return {
+            "info": {"version": version},
+            "urls": [
+                {
+                    "filename": f"dcc_mcp_core-{version}-cp38-abi3-win_amd64.whl",
+                    "url": f"https://example.com/dcc_mcp_core-{version}-cp38-abi3-win_amd64.whl",
+                    "packagetype": "bdist_wheel",
+                },
+                {
+                    "filename": f"dcc_mcp_core-{version}-cp37-cp37m-win_amd64.whl",
+                    "url": f"https://example.com/dcc_mcp_core-{version}-cp37-cp37m-win_amd64.whl",
+                    "packagetype": "bdist_wheel",
+                },
+                {
+                    "filename": f"dcc_mcp_core-{version}-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                    "url": f"https://example.com/dcc_mcp_core-{version}-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                    "packagetype": "bdist_wheel",
+                },
+                {
+                    "filename": f"dcc_mcp_core-{version}-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                    "url": f"https://example.com/dcc_mcp_core-{version}-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                    "packagetype": "bdist_wheel",
+                },
+                {
+                    "filename": f"dcc_mcp_core-{version}-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl",
+                    "url": f"https://example.com/dcc_mcp_core-{version}-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl",
+                    "packagetype": "bdist_wheel",
+                },
+            ],
+            "releases": {
+                version: [
+                    {
+                        "filename": f"dcc_mcp_core-{version}-cp38-abi3-win_amd64.whl",
+                        "url": f"https://example.com/dcc_mcp_core-{version}-cp38-abi3-win_amd64.whl",
+                        "packagetype": "bdist_wheel",
+                    },
+                    {
+                        "filename": f"dcc_mcp_core-{version}-cp37-cp37m-win_amd64.whl",
+                        "url": f"https://example.com/dcc_mcp_core-{version}-cp37-cp37m-win_amd64.whl",
+                        "packagetype": "bdist_wheel",
+                    },
+                    {
+                        "filename": f"dcc_mcp_core-{version}-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                        "url": f"https://example.com/dcc_mcp_core-{version}-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                        "packagetype": "bdist_wheel",
+                    },
+                    {
+                        "filename": f"dcc_mcp_core-{version}-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                        "url": f"https://example.com/dcc_mcp_core-{version}-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                        "packagetype": "bdist_wheel",
+                    },
+                    {
+                        "filename": f"dcc_mcp_core-{version}-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl",
+                        "url": f"https://example.com/dcc_mcp_core-{version}-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl",
+                        "packagetype": "bdist_wheel",
+                    },
+                ],
+            },
+        }
+
+    def test_win64_downloads_two_wheels(self, tmp_path):
+        pypi_data = self._mock_pypi_response()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(pypi_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        def fake_urlretrieve(url, dest):
+            # Create a minimal wheel file at dest
+            fname = Path(dest).name
+            if "abi3" in fname:
+                files = {"dcc_mcp_core/__init__.py": b"# abi3", "dcc_mcp_core/_core.pyd": b"\x00abi3"}
+            else:
+                files = {"dcc_mcp_core/__init__.py": b"# cp37", "dcc_mcp_core/_core.pyd": b"\x00cp37"}
+            _make_fake_wheel(Path(dest).parent, fname, files)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp), patch(
+            "urllib.request.urlretrieve", side_effect=fake_urlretrieve
+        ):
+            wheels = assemble_mod.download_core_wheels("0.12.17", "win64", tmp_path)
+        assert len(wheels) == 2
+        names = [w.name for w in wheels]
+        assert any("abi3" in n for n in names)
+        assert any("cp37" in n for n in names)
+
+    def test_linux_downloads_two_wheels(self, tmp_path):
+        pypi_data = self._mock_pypi_response()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(pypi_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        def fake_urlretrieve(url, dest):
+            fname = Path(dest).name
+            files = {"dcc_mcp_core/__init__.py": b"# linux", "dcc_mcp_core/_core.so": b"\x00linux"}
+            _make_fake_wheel(Path(dest).parent, fname, files)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp), patch(
+            "urllib.request.urlretrieve", side_effect=fake_urlretrieve
+        ):
+            wheels = assemble_mod.download_core_wheels("0.12.17", "linux", tmp_path)
+        assert len(wheels) == 2
+
+    def test_macos_downloads_one_wheel(self, tmp_path):
+        pypi_data = self._mock_pypi_response()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(pypi_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        def fake_urlretrieve(url, dest):
+            fname = Path(dest).name
+            files = {"dcc_mcp_core/__init__.py": b"# macos", "dcc_mcp_core/_core.so": b"\x00macos"}
+            _make_fake_wheel(Path(dest).parent, fname, files)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp), patch(
+            "urllib.request.urlretrieve", side_effect=fake_urlretrieve
+        ):
+            wheels = assemble_mod.download_core_wheels("0.12.17", "macos", tmp_path)
+        assert len(wheels) == 1
+        assert "abi3" in wheels[0].name
+
+    def test_raises_when_no_wheels_found(self, tmp_path):
+        pypi_data = {"info": {"version": "0.12.17"}, "urls": [], "releases": {"0.12.17": []}}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(pypi_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(RuntimeError, match="No dcc-mcp-core wheels"):
+                assemble_mod.download_core_wheels("0.12.17", "win64", tmp_path)
+
+    def test_warns_on_missing_pattern(self, tmp_path, capsys):
+        """If a wheel pattern has no match, a warning is printed but doesn't fail."""
+        pypi_data = {
+            "info": {"version": "0.12.17"},
+            "urls": [
+                {
+                    "filename": "dcc_mcp_core-0.12.17-cp38-abi3-win_amd64.whl",
+                    "url": "https://example.com/x.whl",
+                    "packagetype": "bdist_wheel",
+                }
+            ],
+            "releases": {
+                "0.12.17": [
+                    {
+                        "filename": "dcc_mcp_core-0.12.17-cp38-abi3-win_amd64.whl",
+                        "url": "https://example.com/x.whl",
+                        "packagetype": "bdist_wheel",
+                    }
+                ]
+            },
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(pypi_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        def fake_urlretrieve(url, dest):
+            files = {"dcc_mcp_core/__init__.py": b"# test", "dcc_mcp_core/_core.pyd": b"\x00"}
+            _make_fake_wheel(Path(dest).parent, Path(dest).name, files)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp), patch(
+            "urllib.request.urlretrieve", side_effect=fake_urlretrieve
+        ):
+            wheels = assemble_mod.download_core_wheels("0.12.17", "win64", tmp_path)
+        # Only abi3 wheel was available; cp37 was missing (warned)
+        assert len(wheels) == 1
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out or "cp37" in captured.out
+
+
+# ── extract_wheel ───────────────────────────────────────────────────────────
+
+
+class TestExtractWheel:
+    def test_extracts_python_files(self, tmp_path):
+        files = {
+            "dcc_mcp_core/__init__.py": b"print('hello')",
+            "dcc_mcp_core/skill.py": b"class Skill: pass",
+            "dcc_mcp_core-0.12.17.dist-info/METADATA": b"Metadata-Version: 2.1",
+        }
+        wheel = _make_fake_wheel(tmp_path, "dcc_mcp_core-0.12.17-cp38-abi3-win_amd64.whl", files)
+        dest = tmp_path / "out"
+        dest.mkdir()
+        assemble_mod.extract_wheel(wheel, dest)
+        assert (dest / "dcc_mcp_core" / "__init__.py").read_bytes() == b"print('hello')"
+        assert (dest / "dcc_mcp_core" / "skill.py").read_bytes() == b"class Skill: pass"
+        # dist-info should NOT be extracted
+        assert not (dest / "dcc_mcp_core-0.12.17.dist-info").exists()
+
+    def test_extensions_only_filters_non_extensions(self, tmp_path):
+        files = {
+            "dcc_mcp_core/__init__.py": b"print('hello')",
+            "dcc_mcp_core/_core.pyd": b"\x00binary",
+            "dcc_mcp_core/_core.so": b"\x00binary_linux",
+        }
+        wheel = _make_fake_wheel(tmp_path, "dcc_mcp_core-0.12.17-cp38-abi3-win_amd64.whl", files)
+        dest = tmp_path / "out"
+        dest.mkdir()
+        # Pre-create __init__.py to test that extensions_only skips it
+        (dest / "dcc_mcp_core").mkdir()
+        (dest / "dcc_mcp_core" / "__init__.py").write_bytes(b"existing")
+        assemble_mod.extract_wheel(wheel, dest, extensions_only=True)
+        # __init__.py should NOT be overwritten
+        assert (dest / "dcc_mcp_core" / "__init__.py").read_bytes() == b"existing"
+        # .pyd should be extracted
+        assert (dest / "dcc_mcp_core" / "_core.pyd").read_bytes() == b"\x00binary"
+
+    def test_skips_dist_info(self, tmp_path):
+        files = {
+            "dcc_mcp_core/__init__.py": b"# ok",
+            "dcc_mcp_core-0.12.17.dist-info/METADATA": b"Metadata",
+            "dcc_mcp_core-0.12.17.dist-info/RECORD": b"record",
+        }
+        wheel = _make_fake_wheel(tmp_path, "dcc_mcp_core-0.12.17-cp38-abi3-win_amd64.whl", files)
+        dest = tmp_path / "out"
+        dest.mkdir()
+        assemble_mod.extract_wheel(wheel, dest)
+        assert (dest / "dcc_mcp_core" / "__init__.py").exists()
+        assert not (dest / "dcc_mcp_core-0.12.17.dist-info").exists()
+
+
+# ── generate_mod_file ───────────────────────────────────────────────────────
+
+
+class TestGenerateModFile:
+    def test_win64_all_maya_versions(self):
+        content = assemble_mod.generate_mod_file("0.2.2", "win64", has_cp37=True)
+        lines = content.strip().split("\n")
+        assert len(lines) == 8  # 4 maya versions * 2 lines each
+        assert "MAYAVERSION:2022" in lines[0]
+        assert "python37" in lines[1]
+        assert "MAYAVERSION:2023" in lines[2]
+        assert "PYTHONPATH+:=python" in lines[3]
+
+    def test_win64_no_cp37(self):
+        content = assemble_mod.generate_mod_file("0.2.2", "win64", has_cp37=False)
+        # All should use python/ (no python37)
+        assert "python37" not in content
+
+    def test_macos_skips_2022(self):
+        content = assemble_mod.generate_mod_file("0.2.2", "macos", has_cp37=False)
+        assert "MAYAVERSION:2022" not in content
+        assert "MAYAVERSION:2023" in content
+
+    def test_linux_all_versions(self):
+        content = assemble_mod.generate_mod_file("0.2.2", "linux", has_cp37=True)
+        assert "MAYAVERSION:2022" in content
+        assert "python37" in content
+
+
+# ── assemble (integration) ──────────────────────────────────────────────────
+
+
+class TestAssemble:
+    def _setup_project(self, tmp_path: Path) -> Path:
+        """Create a minimal project structure for testing assemble()."""
+        project = tmp_path / "project"
+        project.mkdir()
+
+        # pyproject.toml
+        _make_fake_pyproject(project, "0.12.12")
+
+        # Maya plugin
+        plugin_dir = project / "maya" / "plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "dcc_mcp_maya.py").write_text("# plugin", encoding="utf-8")
+
+        # userSetup.py
+        maya_dir = project / "maya"
+        (maya_dir / "userSetup.py").write_text("# userSetup", encoding="utf-8")
+
+        # dcc_mcp_maya package
+        pkg_src = project / "src" / "dcc_mcp_maya"
+        pkg_src.mkdir(parents=True)
+        (pkg_src / "__init__.py").write_text("# maya package", encoding="utf-8")
+
+        # Packaging scripts
+        pkg_dir = project / "packaging"
+        pkg_dir.mkdir()
+        (pkg_dir / "install.bat").write_text("@echo install", encoding="utf-8")
+        (pkg_dir / "uninstall.bat").write_text("@echo uninstall", encoding="utf-8")
+        (pkg_dir / "install.sh").write_text("#!/bin/bash\necho install", encoding="utf-8")
+        (pkg_dir / "uninstall.sh").write_text("#!/bin/bash\necho uninstall", encoding="utf-8")
+        (pkg_dir / "README.txt").write_text("Readme", encoding="utf-8")
+
+        return project
+
+    def _mock_download_and_resolve(self, project: Path, tmp_path: Path):
+        """Return mock patches for resolve_core_version and download_core_wheels."""
+        # Create fake wheels
+        abi3_files = {
+            "dcc_mcp_core/__init__.py": b"# abi3 init",
+            "dcc_mcp_core/_core.pyd": b"\x00abi3_core",
+            "dcc_mcp_core/skill.py": b"class Skill: pass",
+        }
+        cp37_files = {
+            "dcc_mcp_core/__init__.py": b"# cp37 init",
+            "dcc_mcp_core/_core.pyd": b"\x00cp37_core",
+        }
+
+        def fake_download(version, platform, dest):
+            _make_fake_wheel(dest, f"dcc_mcp_core-{version}-cp38-abi3-win_amd64.whl", abi3_files)
+            if platform in ("win64", "linux"):
+                _make_fake_wheel(dest, f"dcc_mcp_core-{version}-cp37-cp37m-win_amd64.whl", cp37_files)
+            return list(dest.glob("dcc_mcp_core-*.whl"))
+
+        return fake_download
+
+    def test_win64_creates_python_and_python37(self, tmp_path):
+        project = self._setup_project(tmp_path)
+        output = tmp_path / "output"
+        output.mkdir()
+        fake_download = self._mock_download_and_resolve(project, tmp_path)
+
+        with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
+            assemble_mod, "download_core_wheels", side_effect=fake_download
+        ):
+            result = assemble_mod.assemble(project, "0.2.2", "win64", output)
+
+        # Check python/ directory
+        assert (result / "python" / "dcc_mcp_core" / "__init__.py").exists()
+        assert (result / "python" / "dcc_mcp_core" / "_core.pyd").exists()
+        assert (result / "python" / "dcc_mcp_maya" / "__init__.py").exists()
+
+        # Check python37/ directory (cp37 overlay)
+        assert (result / "python37" / "dcc_mcp_core" / "__init__.py").exists()
+        assert (result / "python37" / "dcc_mcp_maya" / "__init__.py").exists()
+
+        # Check .mod file uses python37 for Maya 2022
+        mod_content = (result / "dcc_mcp_maya.mod").read_text(encoding="utf-8")
+        assert "python37" in mod_content
+        lines = mod_content.strip().split("\n")
+        assert "PYTHONPATH+:=python37" in lines[1]  # Line after MAYAVERSION:2022
+
+    def test_macos_no_python37(self, tmp_path):
+        project = self._setup_project(tmp_path)
+        output = tmp_path / "output"
+        output.mkdir()
+
+        abi3_files = {
+            "dcc_mcp_core/__init__.py": b"# abi3",
+            "dcc_mcp_core/_core.so": b"\x00abi3",
+        }
+
+        def fake_download(version, platform, dest):
+            _make_fake_wheel(dest, f"dcc_mcp_core-{version}-cp38-abi3-macosx.whl", abi3_files)
+            return list(dest.glob("dcc_mcp_core-*.whl"))
+
+        with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
+            assemble_mod, "download_core_wheels", side_effect=fake_download
+        ):
+            result = assemble_mod.assemble(project, "0.2.2", "macos", output)
+
+        assert (result / "python" / "dcc_mcp_core").exists()
+        assert not (result / "python37").exists()
+
+    def test_mod_file_structure(self, tmp_path):
+        project = self._setup_project(tmp_path)
+        output = tmp_path / "output"
+        output.mkdir()
+        fake_download = self._mock_download_and_resolve(project, tmp_path)
+
+        with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
+            assemble_mod, "download_core_wheels", side_effect=fake_download
+        ):
+            result = assemble_mod.assemble(project, "0.2.2", "win64", output)
+
+        # Verify .mod file
+        mod = (result / "dcc_mcp_maya.mod").read_text(encoding="utf-8")
+        assert "MAYAVERSION:2022" in mod
+        assert "MAYAVERSION:2023" in mod
+        assert "MAYAVERSION:2024" in mod
+        assert "MAYAVERSION:2025" in mod
+        assert "PLATFORM:win64" in mod
+        assert "dcc_mcp_maya 0.2.2" in mod
+
+    def test_plugin_and_usersetup_copied(self, tmp_path):
+        project = self._setup_project(tmp_path)
+        output = tmp_path / "output"
+        output.mkdir()
+        fake_download = self._mock_download_and_resolve(project, tmp_path)
+
+        with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
+            assemble_mod, "download_core_wheels", side_effect=fake_download
+        ):
+            result = assemble_mod.assemble(project, "0.2.2", "win64", output)
+
+        assert (result / "plug-ins" / "dcc_mcp_maya.py").exists()
+        assert (result / "scripts" / "userSetup.py").exists()
+
+    def test_install_scripts_win64(self, tmp_path):
+        project = self._setup_project(tmp_path)
+        output = tmp_path / "output"
+        output.mkdir()
+        fake_download = self._mock_download_and_resolve(project, tmp_path)
+
+        with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
+            assemble_mod, "download_core_wheels", side_effect=fake_download
+        ):
+            result = assemble_mod.assemble(project, "0.2.2", "win64", output)
+
+        assert (result / "install.bat").exists()
+        assert (result / "uninstall.bat").exists()
+        assert not (result / "install.sh").exists()
+
+    def test_install_scripts_linux(self, tmp_path):
+        project = self._setup_project(tmp_path)
+        output = tmp_path / "output"
+        output.mkdir()
+
+        abi3_files = {"dcc_mcp_core/__init__.py": b"# test", "dcc_mcp_core/_core.so": b"\x00"}
+        cp37_files = {"dcc_mcp_core/__init__.py": b"# test", "dcc_mcp_core/_core.so": b"\x00cp37"}
+
+        def fake_download(version, platform, dest):
+            _make_fake_wheel(dest, f"dcc_mcp_core-{version}-cp38-abi3-manylinux.whl", abi3_files)
+            _make_fake_wheel(dest, f"dcc_mcp_core-{version}-cp37-cp37m-manylinux.whl", cp37_files)
+            return list(dest.glob("dcc_mcp_core-*.whl"))
+
+        with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
+            assemble_mod, "download_core_wheels", side_effect=fake_download
+        ):
+            result = assemble_mod.assemble(project, "0.2.2", "linux", output)
+
+        assert (result / "install.sh").exists()
+        assert (result / "uninstall.sh").exists()
+        assert not (result / "install.bat").exists()
+
+    def test_zip_created_by_main(self, tmp_path):
+        """Test that main() creates the ZIP archive."""
+        project = self._setup_project(tmp_path)
+        output = tmp_path / "output"
+        fake_download = self._mock_download_and_resolve(project, tmp_path)
+
+        with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
+            assemble_mod, "download_core_wheels", side_effect=fake_download
+        ):
+            # Call main with mocked args
+            import sys as real_sys
+
+            old_argv = real_sys.argv
+            try:
+                real_sys.argv = [
+                    "assemble_mod.py",
+                    "--version",
+                    "0.2.2",
+                    "--platform",
+                    "win64",
+                    "--output",
+                    str(output),
+                    "--project-root",
+                    str(project),
+                ]
+                assemble_mod.main()
+            finally:
+                real_sys.argv = old_argv
+
+        # Verify ZIP was created
+        zip_files = list(output.glob("*.zip"))
+        assert len(zip_files) == 1
+        assert "0.2.2-win64" in zip_files[0].name
+
+
+# ── Live integration test (requires network) ────────────────────────────────
+
+
+@pytest.mark.packaging
+class TestAssembleLive:
+    """Live tests that actually contact PyPI.
+
+    Run with: pytest tests/test_assemble_mod.py -m packaging -v
+
+    These are skipped by default because they require network access
+    and are slow.
+    """
+
+    def test_resolve_core_version_from_real_pypi(self):
+        """Verify resolve_core_version can reach real PyPI."""
+        version = assemble_mod.resolve_core_version(PROJECT_ROOT)
+        # Should return a version >= 0.12.12
+        assert assemble_mod._version_gte(version, "0.12.12")
+
+    def test_download_win64_wheels_from_pypi(self, tmp_path):
+        """Verify downloading real wheels for win64."""
+        version = assemble_mod.resolve_core_version(PROJECT_ROOT)
+        wheels = assemble_mod.download_core_wheels(version, "win64", tmp_path)
+        assert len(wheels) >= 1  # At least the abi3 wheel
+        names = [w.name for w in wheels]
+        assert any("abi3" in n for n in names)
+
+    def test_full_win64_assemble_from_pypi(self, tmp_path):
+        """End-to-end: assemble a .mod module using real PyPI wheels."""
+        output = tmp_path / "output"
+        output.mkdir()
+        result = assemble_mod.assemble(PROJECT_ROOT, "0.2.2", "win64", output)
+
+        # Verify core structure
+        assert (result / "dcc_mcp_maya.mod").exists()
+        assert (result / "python" / "dcc_mcp_core" / "__init__.py").exists()
+        assert (result / "python" / "dcc_mcp_core" / "_core.pyd").exists()
+        assert (result / "python" / "dcc_mcp_maya" / "__init__.py").exists()
+        assert (result / "plug-ins" / "dcc_mcp_maya.py").exists()
+        assert (result / "scripts" / "userSetup.py").exists()
+
+        # If cp37 wheels were available, python37/ should exist
+        if (result / "python37").exists():
+            assert (result / "python37" / "dcc_mcp_core" / "__init__.py").exists()
+            assert (result / "python37" / "dcc_mcp_maya" / "__init__.py").exists()

--- a/tests/test_skills_round10.py
+++ b/tests/test_skills_round10.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 # Import built-in modules
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 # Import third-party modules
 import pytest
@@ -21,7 +21,7 @@ import pytest
 # Add tests/ to sys.path so we can import conftest helpers directly
 sys.path.insert(0, str(Path(__file__).parent))
 
-from conftest import SKILLS_ROOT, load_and_call, load_and_call_with_mel, make_mock_maya  # noqa: E402
+from conftest import load_and_call, load_and_call_with_mel  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -583,9 +583,7 @@ class TestCreateDisplayLayerDeep:
     def test_visibility_false_calls_setattr(self):
         cmds = _make_cmds()
         cmds.createDisplayLayer.return_value = "layer1"
-        result = load_and_call(
-            "maya-display/scripts/create_display_layer.py", cmds, name="l", visibility=False
-        )
+        result = load_and_call("maya-display/scripts/create_display_layer.py", cmds, name="l", visibility=False)
         assert result["success"] is True
         cmds.setAttr.assert_called()
 
@@ -638,9 +636,7 @@ class TestDeleteDisplayLayerDeep:
         cmds = _make_cmds()
         cmds.objExists.return_value = True
         cmds.objectType.return_value = "transform"  # not displayLayer
-        result = load_and_call(
-            "maya-display/scripts/delete_display_layer.py", cmds, layer_name="pSphere1"
-        )
+        result = load_and_call("maya-display/scripts/delete_display_layer.py", cmds, layer_name="pSphere1")
         assert result["success"] is False
         assert "wrong node type" in result["message"].lower()
 
@@ -648,18 +644,14 @@ class TestDeleteDisplayLayerDeep:
         cmds = _make_cmds()
         cmds.objExists.return_value = True
         cmds.objectType.return_value = "displayLayer"
-        result = load_and_call(
-            "maya-display/scripts/delete_display_layer.py", cmds, layer_name="myLayer"
-        )
+        result = load_and_call("maya-display/scripts/delete_display_layer.py", cmds, layer_name="myLayer")
         assert result["success"] is True
         cmds.delete.assert_called()
 
     def test_default_layer_blocked(self):
         """defaultLayer should not be deletable."""
         cmds = _make_cmds()
-        result = load_and_call(
-            "maya-display/scripts/delete_display_layer.py", cmds, layer_name="defaultLayer"
-        )
+        result = load_and_call("maya-display/scripts/delete_display_layer.py", cmds, layer_name="defaultLayer")
         assert result["success"] is False
 
 

--- a/tests/test_skills_round10.py
+++ b/tests/test_skills_round10.py
@@ -1,718 +1,717 @@
-"""Round 10: unit tests for maya-render Skill scripts.
+"""Round 10 tests: conftest helpers + new api helpers + deep skill edge cases.
 
-Covers all 8 scripts under skills/maya-render/scripts/:
-  - set_render_settings
-  - get_render_settings
-  - get_scene_render_stats
-  - set_render_quality
-  - capture_viewport
-  - playblast
-  - import_file
-  - export_selection
-
-All Maya dependencies are mocked via sys.modules.
+Covers:
+- conftest.load_and_call / load_and_call_with_mel
+- api.ensure_valid_name / build_context_dict
+- api.scene_object_from_node / object_transform_from_node / bounding_box_from_node
+- Deep skill edge cases: maya-display, maya-primitives, maya-scene
 """
 
+# Import future modules
+from __future__ import annotations
+
 # Import built-in modules
-import base64
-import importlib.util
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+# Import third-party modules
+import pytest
+
+# Add tests/ to sys.path so we can import conftest helpers directly
+sys.path.insert(0, str(Path(__file__).parent))
+
+from conftest import SKILLS_ROOT, load_and_call, load_and_call_with_mel, make_mock_maya  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_maya" / "skills"
 
-
-def _load_script(skill_dir: str, script_name: str):
-    """Load a skill script by path, returning its module."""
-    path = SKILLS_ROOT / skill_dir / "scripts" / "{}.py".format(script_name)
-    spec = importlib.util.spec_from_file_location(script_name, path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-def _make_result(success: bool, message: str = "ok", **ctx):
-    """Create a minimal ActionResultModel-like mock with .to_dict()."""
-    obj = MagicMock()
-    obj.success = success
-    obj.message = message
-    data = {"success": success, "message": message, "context": ctx}
-    obj.to_dict.return_value = data
-    return obj
-
-
-def _patch_maya(extra_attrs=None):
-    """Return a context-manager that patches maya.cmds into sys.modules."""
+def _make_cmds(**overrides):
+    """Return a MagicMock that looks like maya.cmds with sensible defaults."""
     mock_cmds = MagicMock()
-    # sensible defaults
-    mock_cmds.getAttr.side_effect = lambda attr, **kw: {
-        "defaultResolution.width": 1920,
-        "defaultResolution.height": 1080,
-        "defaultRenderGlobals.startFrame": 1.0,
-        "defaultRenderGlobals.endFrame": 24.0,
-        "defaultRenderGlobals.currentRenderer": "mayaSoftware",
-        "defaultRenderGlobals.imageFormat": 32,
-        "defaultRenderGlobals.imageFilePrefix": "/renders/",
-    }.get(attr, 0)
-    mock_cmds.currentTime.return_value = 1.0
     mock_cmds.objExists.return_value = True
-    mock_cmds.file.return_value = "/some/path.fbx"
-    mock_cmds.ls.return_value = ["node1", "node2"]
-    if extra_attrs:
-        for k, v in extra_attrs.items():
-            setattr(mock_cmds, k, v)
-
-    mock_maya = MagicMock()
-    mock_maya.cmds = mock_cmds
-
-    patches = {
-        "maya": mock_maya,
-        "maya.cmds": mock_cmds,
-        "maya.api": MagicMock(),
-        "maya.utils": MagicMock(),
-    }
-    return patches, mock_cmds
+    mock_cmds.objectType.return_value = "transform"
+    mock_cmds.listRelatives.return_value = []
+    mock_cmds.getAttr.return_value = [(0.0, 0.0, 0.0)]
+    mock_cmds.exactWorldBoundingBox.return_value = [-1.0, -1.0, -1.0, 1.0, 1.0, 1.0]
+    for k, v in overrides.items():
+        setattr(mock_cmds, k, v)
+    return mock_cmds
 
 
 # ===========================================================================
-# set_render_settings
+# TestConfestLoadAndCall
 # ===========================================================================
 
 
-class TestSetRenderSettings:
-    """Tests for maya-render/scripts/set_render_settings.py."""
+class TestConftestLoadAndCall:
+    """Verify the load_and_call helper in conftest.py."""
 
-    def _run(self, mock_cmds, **kwargs):
-        patches, _ = _patch_maya()
-        patches["maya.cmds"] = mock_cmds
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_settings")
-            return mod.set_render_settings(**kwargs)
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
+    def test_returns_dict(self):
+        mock_cmds = _make_cmds()
+        mock_cmds.ls.return_value = []
+        result = load_and_call("maya-scene/scripts/get_scene_info.py", mock_cmds)
+        assert isinstance(result, dict)
 
-    def test_set_width_and_height(self):
-        patches, mock_cmds = _patch_maya()
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_settings")
-            result = mod.set_render_settings(width=1280, height=720)
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        mock_cmds.setAttr.assert_any_call("defaultResolution.width", 1280)
-        mock_cmds.setAttr.assert_any_call("defaultResolution.height", 720)
+    def test_propagates_kwargs(self):
+        mock_cmds = _make_cmds()
+        mock_cmds.ls.return_value = ["pSphere1"]
+        mock_cmds.objectType.return_value = "transform"
+        mock_cmds.getAttr.return_value = [(1.0, 2.0, 3.0)]
+        result = load_and_call("maya-scene/scripts/get_scene_info.py", mock_cmds, filter="transform")
+        assert isinstance(result, dict)
 
-    def test_set_renderer(self):
-        patches, mock_cmds = _patch_maya()
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_settings")
-            result = mod.set_render_settings(renderer="arnold")
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        mock_cmds.setAttr.assert_any_call("defaultRenderGlobals.currentRenderer", "arnold", type="string")
+    def test_success_key_present(self):
+        mock_cmds = _make_cmds()
+        mock_cmds.ls.return_value = []
+        result = load_and_call("maya-scene/scripts/get_scene_info.py", mock_cmds)
+        assert "success" in result
 
-    def test_set_frame_range(self):
-        patches, mock_cmds = _patch_maya()
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_settings")
-            result = mod.set_render_settings(start_frame=1, end_frame=50)
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
+    def test_unique_module_names(self):
+        """Each load_and_call invocation must not share a module object."""
+        mock_cmds = _make_cmds()
+        mock_cmds.ls.return_value = []
+        r1 = load_and_call("maya-scene/scripts/get_scene_info.py", mock_cmds)
+        r2 = load_and_call("maya-scene/scripts/get_scene_info.py", mock_cmds)
+        # Both should succeed independently
+        assert r1["success"] is True
+        assert r2["success"] is True
 
-    def test_set_image_format_png(self):
-        patches, mock_cmds = _patch_maya()
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_settings")
-            result = mod.set_render_settings(image_format="png")
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        mock_cmds.setAttr.assert_any_call("defaultRenderGlobals.imageFormat", 32)
 
-    def test_set_image_format_exr(self):
-        patches, mock_cmds = _patch_maya()
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_settings")
-            result = mod.set_render_settings(image_format="exr")
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        mock_cmds.setAttr.assert_any_call("defaultRenderGlobals.imageFormat", 40)
+class TestConftestLoadAndCallWithMel:
+    """Verify the load_and_call_with_mel helper."""
 
-    def test_no_settings_returns_error(self):
-        patches, mock_cmds = _patch_maya()
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_settings")
-            result = mod.set_render_settings()
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is False
-        assert "No settings" in result["message"]
+    def test_creates_default_mock_mel(self):
+        mock_cmds = _make_cmds()
+        mock_cmds.annotate = MagicMock(return_value="annotationShape1")
+        mock_cmds.listRelatives.return_value = ["annotation1"]
+        result = load_and_call_with_mel(
+            "maya-annotation/scripts/create_annotation.py",
+            mock_cmds,
+        )
+        assert isinstance(result, dict)
 
-    def test_set_output_path(self):
-        patches, mock_cmds = _patch_maya()
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_settings")
-            result = mod.set_render_settings(output_path="/renders/shot001")
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
+    def test_accepts_custom_mock_mel(self):
+        mock_cmds = _make_cmds()
+        mock_mel = MagicMock()
+        mock_cmds.annotate = MagicMock(return_value="annotationShape1")
+        mock_cmds.listRelatives.return_value = ["annotation1"]
+        result = load_and_call_with_mel(
+            "maya-annotation/scripts/create_annotation.py",
+            mock_cmds,
+            mock_mel=mock_mel,
+        )
+        assert isinstance(result, dict)
 
-    def test_exception_returns_error(self):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.setAttr.side_effect = RuntimeError("setAttr failed")
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_settings")
-            result = mod.set_render_settings(width=100)
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
+    def test_mel_available_inside_script(self):
+        """Scripts that import maya.mel should not raise ImportError."""
+        mock_cmds = _make_cmds()
+        mock_mel = MagicMock()
+        # add_toon_outline uses maya.mel internally
+        mock_cmds.ls.return_value = ["pCube1"]
+        mock_cmds.listRelatives.return_value = []
+        mock_cmds.filterExpand.return_value = []
+        mock_cmds.attributeQuery.return_value = True
+        mock_mel.eval.return_value = None
+        result = load_and_call_with_mel(
+            "maya-toon/scripts/add_toon_outline.py",
+            mock_cmds,
+            mock_mel=mock_mel,
+            objects=["pCube1"],
+        )
+        assert isinstance(result, dict)
+
+
+# ===========================================================================
+# TestEnsureValidName
+# ===========================================================================
+
+
+class TestEnsureValidName:
+    """Tests for api.ensure_valid_name."""
+
+    def setup_method(self):
+        from dcc_mcp_maya.api import ensure_valid_name
+
+        self.fn = ensure_valid_name
+
+    def test_none_returns_error(self):
+        result = self.fn(None)
+        assert result is not None
         assert result["success"] is False
 
-
-# ===========================================================================
-# get_render_settings
-# ===========================================================================
-
-
-class TestGetRenderSettings:
-    """Tests for maya-render/scripts/get_render_settings.py."""
-
-    def test_basic_success(self):
-        patches, mock_cmds = _patch_maya()
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "get_render_settings")
-            result = mod.get_render_settings()
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        assert "mayaSoftware" in result["message"]
-
-    def test_returns_format_name(self):
-        patches, mock_cmds = _patch_maya()
-        # format code 40 → exr
-        mock_cmds.getAttr.side_effect = lambda attr, **kw: {
-            "defaultResolution.width": 1920,
-            "defaultResolution.height": 1080,
-            "defaultRenderGlobals.startFrame": 1.0,
-            "defaultRenderGlobals.endFrame": 100.0,
-            "defaultRenderGlobals.currentRenderer": "arnold",
-            "defaultRenderGlobals.imageFormat": 40,
-            "defaultRenderGlobals.imageFilePrefix": "",
-        }.get(attr, 0)
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "get_render_settings")
-            result = mod.get_render_settings()
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        assert result["context"]["image_format"] == "exr"
-
-    def test_unknown_format_code(self):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.getAttr.side_effect = lambda attr, **kw: {
-            "defaultResolution.width": 800,
-            "defaultResolution.height": 600,
-            "defaultRenderGlobals.startFrame": 1.0,
-            "defaultRenderGlobals.endFrame": 10.0,
-            "defaultRenderGlobals.currentRenderer": "vray",
-            "defaultRenderGlobals.imageFormat": 99,
-            "defaultRenderGlobals.imageFilePrefix": None,
-        }.get(attr, 0)
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "get_render_settings")
-            result = mod.get_render_settings()
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        # unknown code rendered as string
-        assert result["context"]["image_format"] == "99"
-
-    def test_exception_returns_error(self):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.getAttr.side_effect = RuntimeError("no node")
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "get_render_settings")
-            result = mod.get_render_settings()
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
+    def test_empty_string_returns_error(self):
+        result = self.fn("")
+        assert result is not None
         assert result["success"] is False
 
-
-# ===========================================================================
-# get_scene_render_stats
-# ===========================================================================
-
-
-class TestGetSceneRenderStats:
-    """Tests for maya-render/scripts/get_scene_render_stats.py."""
-
-    def test_basic_success(self):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.objExists.return_value = True
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "get_scene_render_stats")
-            result = mod.get_scene_render_stats()
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        assert "mayaSoftware" in result["message"]
-
-    def test_quality_attrs_queried(self):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.objExists.return_value = True
-        mock_cmds.getAttr.side_effect = lambda attr, **kw: {
-            "defaultResolution.width": 1920,
-            "defaultResolution.height": 1080,
-            "defaultRenderGlobals.startFrame": 1.0,
-            "defaultRenderGlobals.endFrame": 24.0,
-            "defaultRenderGlobals.currentRenderer": "mayaSoftware",
-            "defaultRenderGlobals.imageFilePrefix": "",
-        }.get(attr, 4)
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "get_scene_render_stats")
-            result = mod.get_scene_render_stats()
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        assert "quality" in result["context"]
-
-    def test_quality_attrs_skipped_when_not_exist(self):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.objExists.return_value = False
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "get_scene_render_stats")
-            result = mod.get_scene_render_stats()
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        assert result["context"]["quality"] == {}
-
-    def test_exception_returns_error(self):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.getAttr.side_effect = RuntimeError("crashed")
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "get_scene_render_stats")
-            result = mod.get_scene_render_stats()
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
+    def test_whitespace_only_returns_error(self):
+        result = self.fn("   ")
+        assert result is not None
         assert result["success"] is False
 
+    def test_valid_name_returns_none(self):
+        assert self.fn("pSphere1") is None
 
-# ===========================================================================
-# set_render_quality
-# ===========================================================================
+    def test_single_char_valid(self):
+        assert self.fn("x") is None
 
+    def test_error_includes_param_name(self):
+        result = self.fn("", param="layer_name")
+        assert "layer_name" in result["message"]
 
-class TestSetRenderQuality:
-    """Tests for maya-render/scripts/set_render_quality.py."""
+    def test_default_param_name_is_name(self):
+        result = self.fn("")
+        assert "'name'" in result["message"]
 
-    def _run(self, preset="medium", objExists=True):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.objExists.return_value = objExists
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_quality")
-            return mod.set_render_quality(preset=preset), mock_cmds
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
+    def test_solutions_present(self):
+        result = self.fn("")
+        assert "possible_solutions" in result["context"]
 
-    def test_medium_preset(self):
-        result, _ = self._run("medium")
-        assert result["success"] is True
-        assert "medium" in result["message"]
+    def test_importable_from_top_level(self):
+        from dcc_mcp_maya import ensure_valid_name as fn
 
-    def test_low_preset(self):
-        result, _ = self._run("low")
-        assert result["success"] is True
+        assert callable(fn)
 
-    def test_high_preset(self):
-        result, _ = self._run("high")
-        assert result["success"] is True
+    def test_in_api_all(self):
+        import dcc_mcp_maya.api as api
 
-    def test_invalid_preset(self):
-        result, _ = self._run("ultra")
-        assert result["success"] is False
-        assert "ultra" in result["message"]
+        assert "ensure_valid_name" in api.__all__
 
-    def test_attrs_not_set_when_node_missing(self):
-        result, mock_cmds = self._run("high", objExists=False)
-        assert result["success"] is True
-        mock_cmds.setAttr.assert_not_called()
+    def test_in_package_all(self):
+        import dcc_mcp_maya
 
-    def test_exception_returns_error(self):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.objExists.return_value = True
-        mock_cmds.setAttr.side_effect = RuntimeError("locked")
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_quality")
-            result = mod.set_render_quality(preset="low")
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is False
-
-    def test_case_insensitive_preset(self):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.objExists.return_value = True
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "set_render_quality")
-            result = mod.set_render_quality(preset="HIGH")
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
+        assert "ensure_valid_name" in dcc_mcp_maya.__all__
 
 
 # ===========================================================================
-# capture_viewport
+# TestBuildContextDict
 # ===========================================================================
 
 
-class TestCaptureViewport:
-    """Tests for maya-render/scripts/capture_viewport.py."""
+class TestBuildContextDict:
+    """Tests for api.build_context_dict."""
 
-    def _run_with_tempfile(self, frame=1.0, width=1920, height=1080, raise_exc=None):
-        """Run capture_viewport with mocked tempfile/os/playblast."""
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.currentTime.return_value = frame
+    def setup_method(self):
+        from dcc_mcp_maya.api import build_context_dict
 
-        fake_img = b"\x89PNG\r\nfake"
-        fake_prefix = "/tmp/mcp_test"
+        self.fn = build_context_dict
 
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "capture_viewport")
-            with patch("tempfile.NamedTemporaryFile") as mock_ntf, patch("os.path.exists") as mock_exists, patch(
-                "builtins.open", create=True
-            ) as mock_open, patch("os.unlink"):
-                # tempfile mock
-                ntf_inst = MagicMock()
-                ntf_inst.__enter__ = lambda s: ntf_inst
-                ntf_inst.__exit__ = MagicMock(return_value=False)
-                ntf_inst.name = fake_prefix + ".png"
-                mock_ntf.return_value = ntf_inst
+    def test_removes_none_values(self):
+        result = self.fn(a=1, b=None, c="x")
+        assert "b" not in result
+        assert result == {"a": 1, "c": "x"}
 
-                mock_exists.return_value = True
+    def test_empty_returns_empty(self):
+        assert self.fn() == {}
 
-                # open mock
-                fh_mock = MagicMock()
-                fh_mock.__enter__ = lambda s: fh_mock
-                fh_mock.__exit__ = MagicMock(return_value=False)
-                fh_mock.read.return_value = fake_img
-                mock_open.return_value = fh_mock
+    def test_all_none_returns_empty(self):
+        assert self.fn(a=None, b=None) == {}
 
-                if raise_exc:
-                    mock_cmds.playblast.side_effect = raise_exc
+    def test_all_present_returns_all(self):
+        result = self.fn(x=1, y=2)
+        assert result == {"x": 1, "y": 2}
 
-                result = mod.capture_viewport(width=width, height=height, frame=frame)
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        return result, fake_img
+    def test_false_values_kept(self):
+        result = self.fn(a=False, b=0, c=None)
+        assert result == {"a": False, "b": 0}
 
-    def test_success_returns_base64_image(self):
-        result, fake_img = self._run_with_tempfile()
-        assert result["success"] is True
-        decoded = base64.b64decode(result["context"]["image"])
-        assert decoded == fake_img
+    def test_empty_string_kept(self):
+        # Empty strings are not None → kept
+        result = self.fn(name="", val=None)
+        assert result == {"name": ""}
 
-    def test_frame_defaults_to_current_time(self):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.currentTime.return_value = 5.0
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "capture_viewport")
-            with patch("tempfile.NamedTemporaryFile") as mock_ntf, patch("os.path.exists", return_value=True), patch(
-                "builtins.open", create=True
-            ) as mock_open, patch("os.unlink"):
-                ntf_inst = MagicMock()
-                ntf_inst.__enter__ = lambda s: ntf_inst
-                ntf_inst.__exit__ = MagicMock(return_value=False)
-                ntf_inst.name = "/tmp/cv.png"
-                mock_ntf.return_value = ntf_inst
-                fh = MagicMock()
-                fh.__enter__ = lambda s: fh
-                fh.__exit__ = MagicMock(return_value=False)
-                fh.read.return_value = b"data"
-                mock_open.return_value = fh
-                result = mod.capture_viewport()
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        assert result["context"]["frame"] == 5.0
+    def test_importable_from_top_level(self):
+        from dcc_mcp_maya import build_context_dict as fn
 
-    def test_playblast_exception_returns_error(self):
-        result, _ = self._run_with_tempfile(raise_exc=RuntimeError("playblast boom"))
-        assert result["success"] is False
+        assert callable(fn)
 
-    def test_custom_dimensions(self):
-        result, _ = self._run_with_tempfile(width=640, height=480)
-        assert result["success"] is True
-        assert result["context"]["width"] == 640
-        assert result["context"]["height"] == 480
+    def test_in_api_all(self):
+        import dcc_mcp_maya.api as api
+
+        assert "build_context_dict" in api.__all__
+
+    def test_in_package_all(self):
+        import dcc_mcp_maya
+
+        assert "build_context_dict" in dcc_mcp_maya.__all__
 
 
 # ===========================================================================
-# playblast
+# TestSceneObjectFromNode
 # ===========================================================================
 
 
-class TestPlayblast:
-    """Tests for maya-render/scripts/playblast.py."""
+class TestSceneObjectFromNode:
+    """Tests for api.scene_object_from_node."""
 
-    def _run(self, frame=1.0, width=1920, height=1080, percent=100, png_exists=True, raise_exc=None):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.currentTime.return_value = frame
-        fake_img = b"\x89PNG\r\nfakeblast"
+    def setup_method(self):
+        from dcc_mcp_maya.api import scene_object_from_node
 
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "playblast")
-            with patch("tempfile.NamedTemporaryFile") as mock_ntf, patch("os.path.exists") as mock_exists, patch(
-                "builtins.open", create=True
-            ) as mock_open, patch("os.unlink"):
-                ntf_inst = MagicMock()
-                ntf_inst.__enter__ = lambda s: ntf_inst
-                ntf_inst.__exit__ = MagicMock(return_value=False)
-                ntf_inst.name = "/tmp/mcp_blast_.png"
-                mock_ntf.return_value = ntf_inst
+        self.fn = scene_object_from_node
 
-                mock_exists.side_effect = lambda p: png_exists
+    def _make(self, **overrides):
+        mock_cmds = _make_cmds(**overrides)
+        return mock_cmds
 
-                fh = MagicMock()
-                fh.__enter__ = lambda s: fh
-                fh.__exit__ = MagicMock(return_value=False)
-                fh.read.return_value = fake_img
-                mock_open.return_value = fh
+    def test_name_extracted_from_long_name(self):
+        cmds = self._make()
+        cmds.objectType.return_value = "transform"
+        cmds.listRelatives.return_value = []
+        cmds.getAttr.return_value = True
+        result = self.fn(cmds, "|group1|pSphere1")
+        assert result["name"] == "pSphere1"
 
-                if raise_exc:
-                    mock_cmds.playblast.side_effect = raise_exc
+    def test_long_name_preserved(self):
+        cmds = self._make()
+        cmds.objectType.return_value = "transform"
+        cmds.listRelatives.return_value = []
+        cmds.getAttr.return_value = True
+        result = self.fn(cmds, "|group1|pSphere1")
+        assert result["long_name"] == "|group1|pSphere1"
 
-                result = mod.playblast(width=width, height=height, frame=frame, percent=percent)
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        return result, fake_img
+    def test_object_type_from_cmds(self):
+        cmds = self._make()
+        cmds.objectType.return_value = "mesh"
+        cmds.listRelatives.return_value = []
+        cmds.getAttr.return_value = True
+        result = self.fn(cmds, "pSphereShape1")
+        assert result["object_type"] == "mesh"
 
-    def test_success(self):
-        result, fake_img = self._run()
-        assert result["success"] is True
-        decoded = base64.b64decode(result["context"]["image"])
-        assert decoded == fake_img
+    def test_parent_none_for_top_level(self):
+        cmds = self._make()
+        cmds.listRelatives.return_value = []
+        cmds.getAttr.return_value = True
+        result = self.fn(cmds, "|pSphere1")
+        assert result["parent"] is None
 
-    def test_prompt_present(self):
-        result, _ = self._run()
-        assert result["success"] is True
-        # prompt is passed through success_result
-        assert "message" in result
+    def test_parent_set_when_has_parent(self):
+        cmds = self._make()
+        cmds.listRelatives.return_value = ["|group1"]
+        cmds.getAttr.return_value = True
+        result = self.fn(cmds, "|group1|pSphere1")
+        assert result["parent"] == "|group1"
 
-    def test_file_not_found_returns_error(self):
-        result, _ = self._run(png_exists=False)
-        assert result["success"] is False
-        assert "not found" in result["message"].lower() or "playblast" in result["message"].lower()
+    def test_visible_from_getattr(self):
+        cmds = self._make()
+        cmds.listRelatives.return_value = []
+        cmds.getAttr.return_value = True
+        result = self.fn(cmds, "pSphere1")
+        assert result["visible"] is True
 
-    def test_exception_returns_error(self):
-        result, _ = self._run(raise_exc=RuntimeError("headless not supported"))
-        assert result["success"] is False
+    def test_visible_false(self):
+        cmds = self._make()
+        cmds.listRelatives.return_value = []
+        cmds.getAttr.return_value = False
+        result = self.fn(cmds, "pSphere1")
+        assert result["visible"] is False
 
-    def test_custom_percent(self):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.currentTime.return_value = 1.0
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "playblast")
-            with patch("tempfile.NamedTemporaryFile") as mock_ntf, patch("os.path.exists", return_value=True), patch(
-                "builtins.open", create=True
-            ) as mock_open, patch("os.unlink"):
-                ntf_inst = MagicMock()
-                ntf_inst.__enter__ = lambda s: ntf_inst
-                ntf_inst.__exit__ = MagicMock(return_value=False)
-                ntf_inst.name = "/tmp/p.png"
-                mock_ntf.return_value = ntf_inst
-                fh = MagicMock()
-                fh.__enter__ = lambda s: fh
-                fh.__exit__ = MagicMock(return_value=False)
-                fh.read.return_value = b"img"
-                mock_open.return_value = fh
-                result = mod.playblast(percent=50)
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
-        assert result["success"] is True
-        call_kwargs = mock_cmds.playblast.call_args[1]
-        assert call_kwargs["percent"] == 50
+    def test_visible_fallback_on_exception(self):
+        cmds = self._make()
+        cmds.listRelatives.return_value = []
+        cmds.getAttr.side_effect = RuntimeError("no attr")
+        result = self.fn(cmds, "pSphere1")
+        assert result["visible"] is True  # fallback
+
+    def test_metadata_empty_dict(self):
+        cmds = self._make()
+        cmds.listRelatives.return_value = []
+        result = self.fn(cmds, "pSphere1")
+        assert result["metadata"] == {}
+
+    def test_no_pipe_in_name_uses_full(self):
+        cmds = self._make()
+        cmds.listRelatives.return_value = []
+        result = self.fn(cmds, "pSphere1")
+        assert result["name"] == "pSphere1"
+
+    def test_importable_from_top_level(self):
+        from dcc_mcp_maya import scene_object_from_node as fn
+
+        assert callable(fn)
+
+    def test_in_api_all(self):
+        import dcc_mcp_maya.api as api
+
+        assert "scene_object_from_node" in api.__all__
 
 
 # ===========================================================================
-# import_file
+# TestObjectTransformFromNode
 # ===========================================================================
 
 
-class TestImportFile:
-    """Tests for maya-render/scripts/import_file.py."""
+class TestObjectTransformFromNode:
+    """Tests for api.object_transform_from_node."""
 
-    def _run(self, file_path="/tmp/test.fbx", namespace=None, merge_namespaces=False, ls_return=None, raise_exc=None):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.ls.return_value = ls_return if ls_return is not None else ["node1"]
-        if raise_exc:
-            mock_cmds.file.side_effect = raise_exc
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "import_file")
-            return mod.import_file(
-                file_path=file_path,
-                namespace=namespace,
-                merge_namespaces=merge_namespaces,
-            ), mock_cmds
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
+    def setup_method(self):
+        from dcc_mcp_maya.api import object_transform_from_node
 
-    def test_basic_import(self):
-        result, mock_cmds = self._run(ls_return=["mesh1", "mesh2"])
-        assert result["success"] is True
-        assert result["context"]["count"] == 2
-        mock_cmds.file.assert_called_once()
+        self.fn = object_transform_from_node
 
-    def test_namespace_passed(self):
-        result, mock_cmds = self._run(namespace="my_ns")
-        assert result["success"] is True
-        call_kwargs = mock_cmds.file.call_args[1]
-        assert call_kwargs.get("namespace") == "my_ns"
+    def test_returns_translate(self):
+        cmds = _make_cmds()
+        cmds.getAttr.return_value = [(1.0, 2.0, 3.0)]
+        result = self.fn(cmds, "pSphere1")
+        assert result["translate"] == [1.0, 2.0, 3.0]
 
-    def test_merge_namespaces(self):
-        result, mock_cmds = self._run(merge_namespaces=True)
-        assert result["success"] is True
-        call_kwargs = mock_cmds.file.call_args[1]
-        assert call_kwargs.get("mergeNamespacesOnClash") is True
+    def test_returns_rotate(self):
+        cmds = _make_cmds()
+        cmds.getAttr.return_value = [(45.0, 0.0, 90.0)]
+        result = self.fn(cmds, "pSphere1")
+        assert result["rotate"] == [45.0, 0.0, 90.0]
 
-    def test_empty_import(self):
-        result, _ = self._run(ls_return=[])
+    def test_returns_scale(self):
+        cmds = _make_cmds()
+        cmds.getAttr.return_value = [(2.0, 2.0, 2.0)]
+        result = self.fn(cmds, "pSphere1")
+        assert result["scale"] == [2.0, 2.0, 2.0]
+
+    def test_all_keys_present(self):
+        cmds = _make_cmds()
+        cmds.getAttr.return_value = [(0.0, 0.0, 0.0)]
+        result = self.fn(cmds, "node")
+        assert set(result.keys()) == {"translate", "rotate", "scale"}
+
+    def test_values_are_float(self):
+        cmds = _make_cmds()
+        cmds.getAttr.return_value = [(1, 2, 3)]  # ints from mock
+        result = self.fn(cmds, "node")
+        for val in result["translate"]:
+            assert isinstance(val, float)
+
+    def test_importable_from_top_level(self):
+        from dcc_mcp_maya import object_transform_from_node as fn
+
+        assert callable(fn)
+
+    def test_in_api_all(self):
+        import dcc_mcp_maya.api as api
+
+        assert "object_transform_from_node" in api.__all__
+
+
+# ===========================================================================
+# TestBoundingBoxFromNode
+# ===========================================================================
+
+
+class TestBoundingBoxFromNode:
+    """Tests for api.bounding_box_from_node."""
+
+    def setup_method(self):
+        from dcc_mcp_maya.api import bounding_box_from_node
+
+        self.fn = bounding_box_from_node
+
+    def test_min_max_correct(self):
+        cmds = _make_cmds()
+        cmds.exactWorldBoundingBox.return_value = [-1.0, -2.0, -3.0, 1.0, 2.0, 3.0]
+        result = self.fn(cmds, "node")
+        assert result["min"] == [-1.0, -2.0, -3.0]
+        assert result["max"] == [1.0, 2.0, 3.0]
+
+    def test_center_computed(self):
+        cmds = _make_cmds()
+        cmds.exactWorldBoundingBox.return_value = [0.0, 0.0, 0.0, 2.0, 4.0, 6.0]
+        result = self.fn(cmds, "node")
+        assert result["center"] == [1.0, 2.0, 3.0]
+
+    def test_size_computed(self):
+        cmds = _make_cmds()
+        cmds.exactWorldBoundingBox.return_value = [0.0, 0.0, 0.0, 2.0, 4.0, 6.0]
+        result = self.fn(cmds, "node")
+        assert result["size"] == [2.0, 4.0, 6.0]
+
+    def test_asymmetric_bbox(self):
+        cmds = _make_cmds()
+        cmds.exactWorldBoundingBox.return_value = [1.0, 2.0, 3.0, 4.0, 6.0, 9.0]
+        result = self.fn(cmds, "node")
+        assert result["size"] == [3.0, 4.0, 6.0]
+        assert result["center"] == [2.5, 4.0, 6.0]
+
+    def test_all_keys_present(self):
+        cmds = _make_cmds()
+        cmds.exactWorldBoundingBox.return_value = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        result = self.fn(cmds, "node")
+        assert set(result.keys()) == {"min", "max", "center", "size"}
+
+    def test_importable_from_top_level(self):
+        from dcc_mcp_maya import bounding_box_from_node as fn
+
+        assert callable(fn)
+
+    def test_in_api_all(self):
+        import dcc_mcp_maya.api as api
+
+        assert "bounding_box_from_node" in api.__all__
+
+
+# ===========================================================================
+# TestDeepSkillEdgeCases — using load_and_call
+# ===========================================================================
+
+
+class TestGetSceneInfoDeep:
+    """Deep tests for maya-scene/get_scene_info.py using load_and_call.
+
+    get_scene_info(include_transforms=True) lists all 'transform' nodes.
+    """
+
+    def test_empty_scene(self):
+        cmds = _make_cmds()
+        cmds.ls.return_value = []
+        result = load_and_call("maya-scene/scripts/get_scene_info.py", cmds)
         assert result["success"] is True
         assert result["context"]["count"] == 0
 
-    def test_exception_returns_error(self):
-        result, _ = self._run(raise_exc=RuntimeError("file not found"))
+    def test_include_transforms_true(self):
+        cmds = _make_cmds()
+        cmds.ls.return_value = ["pSphere1"]
+        cmds.objectType.return_value = "transform"
+        cmds.listRelatives.return_value = []
+        cmds.getAttr.return_value = [(0.0, 0.0, 0.0)]
+        result = load_and_call("maya-scene/scripts/get_scene_info.py", cmds, include_transforms=True)
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        # node should have translate/rotate/scale
+        node = result["context"]["nodes"][0]
+        assert "translate" in node
+
+    def test_include_transforms_false_skips_xform(self):
+        cmds = _make_cmds()
+        cmds.ls.return_value = ["pSphere1"]
+        cmds.listRelatives.return_value = []
+        result = load_and_call("maya-scene/scripts/get_scene_info.py", cmds, include_transforms=False)
+        assert result["success"] is True
+        node = result["context"]["nodes"][0]
+        assert "translate" not in node
+
+    def test_exception_handled(self):
+        cmds = _make_cmds()
+        cmds.ls.side_effect = RuntimeError("scene locked")
+        result = load_and_call("maya-scene/scripts/get_scene_info.py", cmds)
         assert result["success"] is False
-        assert "file not found" in result["message"].lower() or "failed" in result["message"].lower()
+
+    def test_count_matches_nodes_list(self):
+        cmds = _make_cmds()
+        cmds.ls.return_value = ["a", "b", "c"]
+        cmds.listRelatives.return_value = []
+        cmds.getAttr.return_value = [(0.0, 0.0, 0.0)]
+        result = load_and_call("maya-scene/scripts/get_scene_info.py", cmds)
+        assert result["context"]["count"] == len(result["context"]["nodes"])
+
+
+class TestCreateSphereDeep:
+    """Deep tests for maya-primitives/create_sphere.py using load_and_call."""
+
+    def test_default_creates_sphere(self):
+        cmds = _make_cmds()
+        cmds.polySphere.return_value = ["pSphere1", "polySphere1"]
+        result = load_and_call("maya-primitives/scripts/create_sphere.py", cmds)
+        assert result["success"] is True
+        assert result["context"]["object_name"] == "pSphere1"
+
+    def test_custom_radius(self):
+        cmds = _make_cmds()
+        cmds.polySphere.return_value = ["pSphere1", "polySphere1"]
+        result = load_and_call("maya-primitives/scripts/create_sphere.py", cmds, radius=2.5)
+        assert result["success"] is True
+        cmds.polySphere.assert_called_once()
+        call_kwargs = cmds.polySphere.call_args[1]
+        assert call_kwargs.get("radius") == 2.5
+
+    def test_name_passed_calls_rename(self):
+        cmds = _make_cmds()
+        cmds.polySphere.return_value = ["pSphere1", "polySphere1"]
+        cmds.rename.return_value = "myBall"
+        result = load_and_call("maya-primitives/scripts/create_sphere.py", cmds, name="myBall")
+        assert result["success"] is True
+        cmds.rename.assert_called_once()
+
+    def test_exception_returns_error(self):
+        cmds = _make_cmds()
+        cmds.polySphere.side_effect = RuntimeError("maya crash")
+        result = load_and_call("maya-primitives/scripts/create_sphere.py", cmds)
+        assert result["success"] is False
+
+    def test_object_name_in_context(self):
+        cmds = _make_cmds()
+        cmds.polySphere.return_value = ["myBall", "polySphere1"]
+        cmds.rename.return_value = "myBall"
+        result = load_and_call("maya-primitives/scripts/create_sphere.py", cmds, name="myBall")
+        assert "object_name" in result["context"]
+
+
+class TestCreateCubeDeep:
+    """Deep tests for maya-primitives/create_cube.py using load_and_call."""
+
+    def test_default_creates_cube(self):
+        cmds = _make_cmds()
+        cmds.polyCube.return_value = ["pCube1", "polyCube1"]
+        result = load_and_call("maya-primitives/scripts/create_cube.py", cmds)
+        assert result["success"] is True
+
+    def test_exception_returns_error(self):
+        cmds = _make_cmds()
+        cmds.polyCube.side_effect = RuntimeError("fail")
+        result = load_and_call("maya-primitives/scripts/create_cube.py", cmds)
+        assert result["success"] is False
+
+
+class TestCreateDisplayLayerDeep:
+    """Deep tests for maya-display/create_display_layer.py using load_and_call.
+
+    create_display_layer(name=None, objects=None, visibility=True)
+    """
+
+    def test_named_layer_success(self):
+        cmds = _make_cmds()
+        cmds.createDisplayLayer.return_value = "myLayer"
+        result = load_and_call("maya-display/scripts/create_display_layer.py", cmds, name="myLayer")
+        assert result["success"] is True
+        assert result["context"]["layer_name"] == "myLayer"
+
+    def test_no_name_uses_maya_generated(self):
+        cmds = _make_cmds()
+        cmds.createDisplayLayer.return_value = "layer1"
+        result = load_and_call("maya-display/scripts/create_display_layer.py", cmds)
+        assert result["success"] is True
+
+    def test_visibility_false_calls_setattr(self):
+        cmds = _make_cmds()
+        cmds.createDisplayLayer.return_value = "layer1"
+        result = load_and_call(
+            "maya-display/scripts/create_display_layer.py", cmds, name="l", visibility=False
+        )
+        assert result["success"] is True
+        cmds.setAttr.assert_called()
+
+    def test_objects_added_to_layer(self):
+        cmds = _make_cmds()
+        cmds.createDisplayLayer.return_value = "layer1"
+        cmds.objExists.return_value = True
+        result = load_and_call(
+            "maya-display/scripts/create_display_layer.py",
+            cmds,
+            name="l",
+            objects=["pSphere1"],
+        )
+        assert result["success"] is True
+        assert "pSphere1" in result["context"]["objects_added"]
+
+    def test_missing_objects_not_added(self):
+        cmds = _make_cmds()
+        cmds.createDisplayLayer.return_value = "layer1"
+        cmds.objExists.return_value = False
+        result = load_and_call(
+            "maya-display/scripts/create_display_layer.py",
+            cmds,
+            name="l",
+            objects=["ghost"],
+        )
+        assert result["success"] is True
+        assert result["context"]["objects_added"] == []
+
+    def test_exception_returns_error(self):
+        cmds = _make_cmds()
+        cmds.createDisplayLayer.side_effect = RuntimeError("cannot create")
+        result = load_and_call("maya-display/scripts/create_display_layer.py", cmds, name="l")
+        assert result["success"] is False
+
+
+class TestDeleteDisplayLayerDeep:
+    """Deep tests for maya-display/delete_display_layer.py using load_and_call.
+
+    delete_display_layer(layer_name, remove_objects=False)
+    """
+
+    def test_missing_node_returns_error(self):
+        cmds = _make_cmds()
+        cmds.objExists.return_value = False
+        result = load_and_call("maya-display/scripts/delete_display_layer.py", cmds, layer_name="ghost")
+        assert result["success"] is False
+
+    def test_wrong_type_returns_error(self):
+        cmds = _make_cmds()
+        cmds.objExists.return_value = True
+        cmds.objectType.return_value = "transform"  # not displayLayer
+        result = load_and_call(
+            "maya-display/scripts/delete_display_layer.py", cmds, layer_name="pSphere1"
+        )
+        assert result["success"] is False
+        assert "wrong node type" in result["message"].lower()
+
+    def test_happy_path(self):
+        cmds = _make_cmds()
+        cmds.objExists.return_value = True
+        cmds.objectType.return_value = "displayLayer"
+        result = load_and_call(
+            "maya-display/scripts/delete_display_layer.py", cmds, layer_name="myLayer"
+        )
+        assert result["success"] is True
+        cmds.delete.assert_called()
+
+    def test_default_layer_blocked(self):
+        """defaultLayer should not be deletable."""
+        cmds = _make_cmds()
+        result = load_and_call(
+            "maya-display/scripts/delete_display_layer.py", cmds, layer_name="defaultLayer"
+        )
+        assert result["success"] is False
 
 
 # ===========================================================================
-# export_selection
+# TestApiPublicExportsRound10
 # ===========================================================================
 
 
-class TestExportSelection:
-    """Tests for maya-render/scripts/export_selection.py."""
+class TestApiPublicExportsRound10:
+    """Verify all 5 new helpers are properly exported."""
 
-    def _run(self, file_path="/tmp/out.fbx", file_type="FBX export", file_return=None, raise_exc=None):
-        patches, mock_cmds = _patch_maya()
-        mock_cmds.file.return_value = file_return or file_path
-        if raise_exc:
-            mock_cmds.file.side_effect = raise_exc
-        for k, v in patches.items():
-            sys.modules[k] = v
-        try:
-            mod = _load_script("maya-render", "export_selection")
-            return mod.export_selection(file_path=file_path, file_type=file_type), mock_cmds
-        finally:
-            for k in patches:
-                sys.modules.pop(k, None)
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "ensure_valid_name",
+            "build_context_dict",
+            "scene_object_from_node",
+            "object_transform_from_node",
+            "bounding_box_from_node",
+        ],
+    )
+    def test_importable_from_dcc_mcp_maya(self, name):
+        import dcc_mcp_maya
 
-    def test_basic_export(self):
-        result, mock_cmds = self._run()
-        assert result["success"] is True
-        call_kwargs = mock_cmds.file.call_args[1]
-        assert call_kwargs.get("exportSelected") is True
-        assert call_kwargs.get("force") is True
+        assert hasattr(dcc_mcp_maya, name), "{} missing from top-level package".format(name)
 
-    def test_custom_file_type(self):
-        result, mock_cmds = self._run(file_type="OBJexport")
-        assert result["success"] is True
-        call_kwargs = mock_cmds.file.call_args[1]
-        assert call_kwargs.get("type") == "OBJexport"
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "ensure_valid_name",
+            "build_context_dict",
+            "scene_object_from_node",
+            "object_transform_from_node",
+            "bounding_box_from_node",
+        ],
+    )
+    def test_in_api_all(self, name):
+        import dcc_mcp_maya.api as api
 
-    def test_result_contains_file_path(self):
-        result, _ = self._run(file_path="/renders/selection.fbx")
-        assert result["success"] is True
-        assert result["context"]["file_path"] == "/renders/selection.fbx"
+        assert name in api.__all__
 
-    def test_exception_returns_error(self):
-        result, _ = self._run(raise_exc=RuntimeError("nothing selected"))
-        assert result["success"] is False
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "ensure_valid_name",
+            "build_context_dict",
+            "scene_object_from_node",
+            "object_transform_from_node",
+            "bounding_box_from_node",
+        ],
+    )
+    def test_in_package_all(self, name):
+        import dcc_mcp_maya
 
-    def test_maya_ascii_export(self):
-        result, mock_cmds = self._run(file_type="mayaAscii")
-        assert result["success"] is True
-        call_kwargs = mock_cmds.file.call_args[1]
-        assert call_kwargs["type"] == "mayaAscii"
+        assert name in dcc_mcp_maya.__all__


### PR DESCRIPTION
## Summary

- Fix `assemble_mod.py` CI failure caused by using `--python-tag` which is not a valid `pip download` option (exit code 2)
- Replace `pip download` with PyPI JSON API + `urllib.request.urlretrieve` for reliable cross-platform wheel downloads, bypassing pip's platform tag filtering issues
- Replace `pip install --target` with `zipfile` extraction so cp37 wheels can be extracted on Python 3.12 runners
- `resolve_core_version` now queries PyPI for the latest compatible version instead of pinning to the minimum from pyproject.toml
- Create `python37/` directory for Maya 2022 (cp37) extensions, with `.mod` file routing `MAYAVERSION:2022` → `python37/`

## Test plan

- [x] 27 unit tests covering: version resolution, wheel download, wheel extraction, .mod generation, full assembly
- [x] 3 live packaging tests (`@pytest.mark.packaging`) verifying real PyPI connectivity
- [x] All existing 2303 tests pass with no regressions
- [x] `ruff check` and `ruff format` pass
- [ ] CI green (unit tests + e2e)