### PR TITLE
feat: add SKILL.md lint checker and fix merge conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.12"
 
       - name: Install ruff
         run: pip install ruff
@@ -59,3 +59,20 @@ jobs:
 
       - name: Run ruff format check
         run: ruff format --check src/ tests/
+
+  lint-skills:
+    name: Lint Skills
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Lint SKILL.md files
+        run: python tools/lint_skills.py --error-only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "hatchling",
     "build",
     "tomli; python_version < '3.11'",  # tomllib backport for Python < 3.11
+    "pyyaml>=5.0",  # YAML parsing for SKILL.md test validation
 ]
 
 [project.urls]

--- a/src/dcc_mcp_maya/__init__.py
+++ b/src/dcc_mcp_maya/__init__.py
@@ -45,6 +45,7 @@ from dcc_mcp_maya.api import (
     maya_error,
     maya_from_exception,
     maya_success,
+    maya_warning,
     missing_param_error,
     object_transform_from_node,
     require_any_param,
@@ -66,6 +67,7 @@ __all__ = [
     # Skill authoring helpers
     "maya_success",
     "maya_error",
+    "maya_warning",
     "maya_from_exception",
     "require_cmds",
     "get_cmds",

--- a/src/dcc_mcp_maya/api.py
+++ b/src/dcc_mcp_maya/api.py
@@ -150,6 +150,38 @@ def maya_error(
     ).to_dict()
 
 
+def maya_warning(message: str, warning: str = "", prompt: Optional[str] = None, **context: Any) -> Dict[str, Any]:
+    """Return a success ActionResultModel dict with a warning note.
+
+    The result is a *success* (``success=True``) but includes a ``warning``
+    key in the context to inform the AI agent of a non-fatal issue.
+
+    Corresponds to ``dcc_mcp_core.skill.skill_warning``.
+
+    Args:
+        message: Human-readable success message.
+        warning: Short description of the non-fatal warning.
+        prompt: Optional follow-up hint shown to the AI agent.
+        **context: Arbitrary key/value pairs stored in ``result["context"]``.
+
+    Returns:
+        Serialised ``ActionResultModel`` dict (``success=True``, with
+        ``context["warning"]`` set).
+
+    Example::
+
+        return maya_warning(
+            "Material assigned with fallback",
+            warning="Arnold not available; used Lambert instead",
+            prompt="Install Arnold for physically-based shading.",
+            object_name="pSphere1",
+        )
+    """
+    from dcc_mcp_core import success_result  # noqa: PLC0415
+
+    return success_result(message, prompt=prompt, warning=warning, **context).to_dict()
+
+
 def maya_from_exception(
     exc: BaseException,
     message: str = "Maya operation failed",
@@ -691,6 +723,7 @@ def bounding_box_from_node(cmds: Any, node_name: str) -> Dict[str, Any]:
 __all__ = [
     "maya_success",
     "maya_error",
+    "maya_warning",
     "maya_from_exception",
     "require_cmds",
     "get_cmds",

--- a/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
@@ -7,6 +7,49 @@ tags: [maya, animation, keyframe, timeline]
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
 depends: []
+tools:
+  - name: set_keyframe
+    description: "Set a keyframe on an object at the given time"
+    source_file: scripts/set_keyframe.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: get_keyframes
+    description: "Get all keyframe times for an object / attribute"
+    source_file: scripts/get_keyframes.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: set_timeline
+    description: "Set the playback and animation timeline range"
+    source_file: scripts/set_timeline.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: get_current_time
+    description: "Get the current frame number"
+    source_file: scripts/get_current_time.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: set_current_time
+    description: "Set the current frame number"
+    source_file: scripts/set_current_time.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: delete_keyframes
+    description: "Delete keyframes from an object within an optional frame range"
+    source_file: scripts/delete_keyframes.py
+    read_only: false
+    destructive: true
+    idempotent: false
+  - name: bake_simulation
+    description: "Bake simulation / constraints to keyframes on objects"
+    source_file: scripts/bake_simulation.py
+    read_only: false
+    destructive: false
+    idempotent: false
 ---
 
 # maya-animation

--- a/src/dcc_mcp_maya/skills/maya-annotation/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-annotation/SKILL.md
@@ -1,16 +1,9 @@
 ---
 name: maya-annotation
-<<<<<<< HEAD
-description: "Maya annotation node listing and management"
-dcc: maya
-version: "1.0.0"
-tags: [maya, annotation, viewport, label]
-=======
 description: "Maya viewport annotations — create, update, list and remove text/arrow annotation nodes"
 dcc: maya
 version: "1.0.0"
 tags: [maya, annotation, viewport, text]
->>>>>>> origin/main
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
 depends: []
@@ -18,13 +11,6 @@ depends: []
 
 # maya-annotation
 
-<<<<<<< HEAD
-Maya annotation skill. Provides actions for querying annotation nodes in Maya.
-
-## Scripts
-
-- `list_annotations` — List all annotation nodes in the scene with their text and transform info
-=======
 Maya annotation skill. Provides actions for creating and managing annotation nodes
 (text notes attached to objects or positions in the viewport).
 
@@ -34,4 +20,3 @@ Maya annotation skill. Provides actions for creating and managing annotation nod
 - `list_annotations` — List all annotation nodes in the scene
 - `update_annotation` — Change the text or position of an existing annotation
 - `delete_annotation` — Delete an annotation node
->>>>>>> origin/main

--- a/src/dcc_mcp_maya/skills/maya-audio/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-audio/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: maya-audio
-<<<<<<< HEAD
-description: "Maya audio and sound node management"
-=======
 description: "Maya audio — import audio files, set timeline audio, list and remove audio nodes"
->>>>>>> origin/main
 dcc: maya
 version: "1.0.0"
 tags: [maya, audio, sound, timeline]
@@ -15,13 +11,6 @@ depends: []
 
 # maya-audio
 
-<<<<<<< HEAD
-Maya audio skill. Provides actions for querying sound nodes in Maya.
-
-## Scripts
-
-- `list_audio` — List all sound nodes in the scene with their file path and timeline offset
-=======
 Maya audio skill. Provides actions for importing audio files into Maya, attaching
 them to the timeline, and managing sound nodes.
 
@@ -31,4 +20,3 @@ them to the timeline, and managing sound nodes.
 - `list_audio` — List all sound nodes in the scene
 - `set_timeline_audio` — Set the active timeline audio node
 - `remove_audio` — Delete a sound node from the scene
->>>>>>> origin/main

--- a/src/dcc_mcp_maya/skills/maya-cache/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-cache/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: maya-cache
-<<<<<<< HEAD
-description: "Maya geometry cache node listing and management"
-=======
 description: "Maya geometry cache — create, attach, list and delete geometry caches for mesh deformations"
->>>>>>> origin/main
 dcc: maya
 version: "1.0.0"
 tags: [maya, cache, geometry, simulation]
@@ -15,13 +11,6 @@ depends: []
 
 # maya-cache
 
-<<<<<<< HEAD
-Maya cache skill. Provides actions for querying geometry cache nodes in Maya.
-
-## Scripts
-
-- `list_geometry_caches` — List cache nodes attached to a mesh (or all cacheFile nodes if no mesh specified)
-=======
 Maya cache skill. Provides actions for baking geometry deformations to disk cache
 files and attaching cached data back to meshes. Useful for preserving simulations
 and speeding up playback.
@@ -32,4 +21,3 @@ and speeding up playback.
 - `attach_geometry_cache` — Attach an existing cache file to a mesh
 - `list_geometry_caches` — List cache nodes attached to a mesh
 - `delete_geometry_cache` — Delete a geometry cache node and optionally its files
->>>>>>> origin/main

--- a/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
@@ -7,6 +7,55 @@ tags: [maya, geometry, primitives, create]
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
 depends: []
+tools:
+  - name: create_sphere
+    description: "Create a polygon sphere"
+    source_file: scripts/create_sphere.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: create_cube
+    description: "Create a polygon cube"
+    source_file: scripts/create_cube.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: create_cylinder
+    description: "Create a polygon cylinder"
+    source_file: scripts/create_cylinder.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: create_plane
+    description: "Create a polygon plane"
+    source_file: scripts/create_plane.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: delete_objects
+    description: "Delete objects from the Maya scene"
+    source_file: scripts/delete_objects.py
+    read_only: false
+    destructive: true
+    idempotent: false
+  - name: set_transform
+    description: "Set translate/rotate/scale on an object"
+    source_file: scripts/set_transform.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: get_transform
+    description: "Get translate/rotate/scale of an object"
+    source_file: scripts/get_transform.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: rename_object
+    description: "Rename an object in the scene"
+    source_file: scripts/rename_object.py
+    read_only: false
+    destructive: false
+    idempotent: true
 ---
 
 # maya-primitives

--- a/src/dcc_mcp_maya/skills/maya-render/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-render/SKILL.md
@@ -7,6 +7,25 @@ tags: [maya, render, playblast, settings]
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
 depends: []
+tools:
+  - name: set_render_settings
+    description: "Set render parameters (resolution, frame range, renderer, image format)"
+    source_file: scripts/set_render_settings.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: get_render_settings
+    description: "Query current render settings"
+    source_file: scripts/get_render_settings.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: playblast
+    description: "Capture a viewport screenshot as a base64-encoded PNG"
+    source_file: scripts/playblast.py
+    read_only: true
+    destructive: false
+    idempotent: false
 ---
 
 # maya-render

--- a/src/dcc_mcp_maya/skills/maya-scene/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scene/SKILL.md
@@ -7,6 +7,55 @@ tags: [maya, scene, hierarchy]
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
 depends: []
+tools:
+  - name: new_scene
+    description: "Create a new empty Maya scene"
+    source_file: scripts/new_scene.py
+    read_only: false
+    destructive: true
+    idempotent: false
+  - name: save_scene
+    description: "Save the current Maya scene"
+    source_file: scripts/save_scene.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: open_scene
+    description: "Open a Maya scene file from disk"
+    source_file: scripts/open_scene.py
+    read_only: false
+    destructive: true
+    idempotent: false
+  - name: list_objects
+    description: "List objects in the current Maya scene"
+    source_file: scripts/list_objects.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: get_selection
+    description: "Return the current Maya selection"
+    source_file: scripts/get_selection.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: set_selection
+    description: "Set the active Maya selection"
+    source_file: scripts/set_selection.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: get_scene_info
+    description: "Return a hierarchical DAG description of the current scene"
+    source_file: scripts/get_scene_info.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: get_session_info
+    description: "Return Maya version, scene path, and basic session statistics"
+    source_file: scripts/get_session_info.py
+    read_only: true
+    destructive: false
+    idempotent: true
 ---
 
 # maya-scene

--- a/tests/test_lint_skills.py
+++ b/tests/test_lint_skills.py
@@ -1,0 +1,416 @@
+"""Unit tests for tools/lint_skills.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+# Make tools/ importable
+sys.path.insert(0, str(Path(__file__).parent.parent / "tools"))
+import lint_skills  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_skill_dir(tmp_path: Path, skill_name: str, skill_md: str, scripts: list[str] | None = None) -> Path:
+    """Create a minimal skill directory for testing."""
+    skill_dir = tmp_path / skill_name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+    if scripts:
+        scripts_dir = skill_dir / "scripts"
+        scripts_dir.mkdir()
+        for script in scripts:
+            (scripts_dir / script).write_text("# placeholder", encoding="utf-8")
+    return skill_dir
+
+
+CLEAN_FRONTMATTER = dedent("""\
+    ---
+    name: maya-test
+    description: "Test skill for unit tests"
+    dcc: maya
+    version: "1.0.0"
+    tags: [maya, test]
+    license: "MIT"
+    depends: []
+    ---
+
+    # maya-test
+
+    Test description.
+""")
+
+
+# ---------------------------------------------------------------------------
+# check_conflict_markers
+# ---------------------------------------------------------------------------
+
+
+class TestCheckConflictMarkers:
+    def test_no_conflict(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_conflict_markers(skill_dir, "maya-test", CLEAN_FRONTMATTER)
+        assert issues == []
+
+    def test_with_conflict(self, tmp_path):
+        conflict_content = dedent("""\
+            ---
+            name: maya-test
+            <<<<<<< HEAD
+            description: "old"
+            =======
+            description: "new"
+            >>>>>>> origin/main
+            dcc: maya
+            ---
+        """)
+        skill_dir = make_skill_dir(tmp_path, "maya-test", conflict_content)
+        issues = lint_skills.check_conflict_markers(skill_dir, "maya-test", conflict_content)
+        assert len(issues) == 1
+        assert issues[0].rule == "CONFLICT_MARKER"
+        assert issues[0].severity == "ERROR"
+
+    def test_fix_removes_conflict(self, tmp_path):
+        conflict_content = dedent("""\
+            ---
+            name: maya-test
+            <<<<<<< HEAD
+            description: "old"
+            =======
+            description: "new"
+            >>>>>>> origin/main
+            ---
+        """)
+        skill_dir = make_skill_dir(tmp_path, "maya-test", conflict_content)
+        n = lint_skills.fix_conflict_markers(skill_dir)
+        assert n == 1
+        resolved = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        assert "<<<<<<" not in resolved
+        assert 'description: "new"' in resolved
+
+    def test_fix_returns_zero_if_clean(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        n = lint_skills.fix_conflict_markers(skill_dir)
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# check_frontmatter_parseable
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFrontmatterParseable:
+    def test_valid_frontmatter(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues, fm = lint_skills.check_frontmatter_parseable(skill_dir, "maya-test", CLEAN_FRONTMATTER)
+        assert issues == []
+        assert fm is not None
+        assert fm["name"] == "maya-test"
+
+    def test_missing_opening_dashes(self, tmp_path):
+        content = "name: maya-test\ndcc: maya\n"
+        skill_dir = make_skill_dir(tmp_path, "maya-test", content)
+        issues, fm = lint_skills.check_frontmatter_parseable(skill_dir, "maya-test", content)
+        assert any(i.rule == "NO_FRONTMATTER" for i in issues)
+        assert fm is None
+
+    def test_missing_closing_dashes(self, tmp_path):
+        content = "---\nname: maya-test\ndcc: maya\n"
+        skill_dir = make_skill_dir(tmp_path, "maya-test", content)
+        issues, fm = lint_skills.check_frontmatter_parseable(skill_dir, "maya-test", content)
+        assert any(i.rule == "NO_FRONTMATTER" for i in issues)
+        assert fm is None
+
+
+# ---------------------------------------------------------------------------
+# check_name_field
+# ---------------------------------------------------------------------------
+
+
+class TestCheckNameField:
+    def _make_fm(self, name):
+        return {"name": name, "dcc": "maya"}
+
+    def test_valid_name(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_name_field(skill_dir, "maya-test", self._make_fm("maya-test"))
+        assert issues == []
+
+    def test_missing_name(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_name_field(skill_dir, "maya-test", {})
+        assert any(i.rule == "NO_NAME" and i.severity == "ERROR" for i in issues)
+
+    def test_name_mismatch(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_name_field(skill_dir, "maya-test", self._make_fm("maya-other"))
+        assert any(i.rule == "NAME_MISMATCH" and i.severity == "ERROR" for i in issues)
+
+    def test_name_too_long(self, tmp_path):
+        long_name = "maya-" + "a" * 60
+        skill_dir = make_skill_dir(tmp_path, long_name, CLEAN_FRONTMATTER)
+        issues = lint_skills.check_name_field(skill_dir, long_name, self._make_fm(long_name))
+        assert any(i.rule == "NAME_FORMAT" for i in issues)
+
+    def test_name_starts_with_hyphen(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_name_field(skill_dir, "-maya-test", self._make_fm("-maya-test"))
+        assert any(i.rule == "NAME_FORMAT" for i in issues)
+
+    def test_name_ends_with_hyphen(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_name_field(skill_dir, "maya-test-", self._make_fm("maya-test-"))
+        assert any(i.rule == "NAME_FORMAT" for i in issues)
+
+    def test_name_consecutive_hyphens(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_name_field(skill_dir, "maya--test", self._make_fm("maya--test"))
+        assert any(i.rule == "NAME_FORMAT" for i in issues)
+
+    def test_name_invalid_chars(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_name_field(skill_dir, "Maya_Test", self._make_fm("Maya_Test"))
+        assert any(i.rule == "NAME_FORMAT" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# check_dcc_field
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDccField:
+    def test_valid_maya_dcc(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_dcc_field(skill_dir, "maya-test", {"dcc": "maya"})
+        assert issues == []
+
+    def test_wrong_dcc_for_project(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_dcc_field(skill_dir, "maya-test", {"dcc": "blender"})
+        assert any(i.rule == "WRONG_DCC" and i.severity == "ERROR" for i in issues)
+
+    def test_unknown_dcc(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_dcc_field(skill_dir, "maya-test", {"dcc": "unknown_app"})
+        assert any(i.rule == "UNKNOWN_DCC" for i in issues)
+        assert any(i.rule == "WRONG_DCC" for i in issues)
+
+    def test_default_python_dcc(self, tmp_path):
+        """dcc defaults to 'python' if not set — should trigger WRONG_DCC for this project."""
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_dcc_field(skill_dir, "maya-test", {})
+        assert any(i.rule == "WRONG_DCC" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# check_version_field
+# ---------------------------------------------------------------------------
+
+
+class TestCheckVersionField:
+    def test_valid_version(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        for ver in ["1.0.0", "2.3.4", "0.1"]:
+            issues = lint_skills.check_version_field(skill_dir, "maya-test", {"version": ver})
+            assert issues == [], f"Expected no issues for version '{ver}'"
+
+    def test_invalid_version(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        for ver in ["v1.0.0", "1.0.0.0", "latest", "abc"]:
+            issues = lint_skills.check_version_field(skill_dir, "maya-test", {"version": ver})
+            assert any(i.rule == "BAD_VERSION" for i in issues), f"Expected BAD_VERSION for '{ver}'"
+
+
+# ---------------------------------------------------------------------------
+# check_description_field
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDescriptionField:
+    def test_valid_description(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_description_field(skill_dir, "maya-test", {"description": "A skill"})
+        assert issues == []
+
+    def test_missing_description(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_description_field(skill_dir, "maya-test", {})
+        assert any(i.rule == "MISSING_DESC" for i in issues)
+
+    def test_empty_description(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_description_field(skill_dir, "maya-test", {"description": ""})
+        assert any(i.rule == "MISSING_DESC" for i in issues)
+
+    def test_description_too_long(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        long_desc = "A" * 1025
+        issues = lint_skills.check_description_field(skill_dir, "maya-test", {"description": long_desc})
+        assert any(i.rule == "DESC_TOO_LONG" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# check_scripts_section
+# ---------------------------------------------------------------------------
+
+
+class TestCheckScriptsSection:
+    def test_no_scripts_dir(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_scripts_section(skill_dir, "maya-test", CLEAN_FRONTMATTER)
+        assert issues == []
+
+    def test_scripts_with_section(self, tmp_path):
+        content = CLEAN_FRONTMATTER + "\n## Scripts\n\n- `my_script` — does stuff\n"
+        skill_dir = make_skill_dir(tmp_path, "maya-test", content, scripts=["my_script.py"])
+        issues = lint_skills.check_scripts_section(skill_dir, "maya-test", content)
+        assert issues == []
+
+    def test_scripts_without_section(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER, scripts=["my_script.py"])
+        issues = lint_skills.check_scripts_section(skill_dir, "maya-test", CLEAN_FRONTMATTER)
+        assert any(i.rule == "MISSING_SCRIPTS_SECTION" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# check_tools_source_files
+# ---------------------------------------------------------------------------
+
+
+class TestCheckToolsSourceFiles:
+    def test_no_tools(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_tools_source_files(skill_dir, "maya-test", {})
+        assert issues == []
+
+    def test_tools_source_exists(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER, scripts=["do_thing.py"])
+        fm = {"tools": [{"name": "do_thing", "source_file": "scripts/do_thing.py"}]}
+        issues = lint_skills.check_tools_source_files(skill_dir, "maya-test", fm)
+        assert issues == []
+
+    def test_tools_source_missing(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        fm = {"tools": [{"name": "do_thing", "source_file": "scripts/do_thing.py"}]}
+        issues = lint_skills.check_tools_source_files(skill_dir, "maya-test", fm)
+        assert any(i.rule == "TOOL_SOURCE_MISSING" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# check_depends_exist
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDependsExist:
+    def test_no_depends(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        issues = lint_skills.check_depends_exist(skill_dir, "maya-test", {}, {"maya-other"})
+        assert issues == []
+
+    def test_depends_exists(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        fm = {"depends": ["maya-scene"]}
+        issues = lint_skills.check_depends_exist(skill_dir, "maya-test", fm, {"maya-scene", "maya-test"})
+        assert issues == []
+
+    def test_depends_missing(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        fm = {"depends": ["maya-nonexistent"]}
+        issues = lint_skills.check_depends_exist(skill_dir, "maya-test", fm, {"maya-scene"})
+        assert any(i.rule == "MISSING_DEPENDS" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# check_duplicate_action_names (cross-skill)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDuplicateActionNames:
+    def test_no_duplicates(self, tmp_path):
+        info_a = lint_skills.SkillInfo(
+            name="skill-a",
+            skill_dir=tmp_path / "skill-a",
+            scripts=[tmp_path / "skill-a" / "scripts" / "alpha.py"],
+        )
+        info_b = lint_skills.SkillInfo(
+            name="skill-b",
+            skill_dir=tmp_path / "skill-b",
+            scripts=[tmp_path / "skill-b" / "scripts" / "beta.py"],
+        )
+        issues = lint_skills.check_duplicate_action_names([info_a, info_b])
+        assert issues == []
+
+    def test_with_duplicates(self, tmp_path):
+        info_a = lint_skills.SkillInfo(
+            name="skill-a",
+            skill_dir=tmp_path / "skill-a",
+            scripts=[tmp_path / "skill-a" / "scripts" / "shared.py"],
+        )
+        info_b = lint_skills.SkillInfo(
+            name="skill-b",
+            skill_dir=tmp_path / "skill-b",
+            scripts=[tmp_path / "skill-b" / "scripts" / "shared.py"],
+        )
+        issues = lint_skills.check_duplicate_action_names([info_a, info_b])
+        assert len(issues) == 2  # one per skill
+        assert all(i.rule == "DUPLICATE_SCRIPT_STEM" for i in issues)
+        assert all(i.severity == "WARNING" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# lint_all integration
+# ---------------------------------------------------------------------------
+
+
+class TestLintAll:
+    def test_clean_skill_passes(self, tmp_path):
+        make_skill_dir(tmp_path, "maya-clean", CLEAN_FRONTMATTER.replace("maya-test", "maya-clean"))
+        issues = lint_skills.lint_all(tmp_path)
+        errors = [i for i in issues if i.severity == "ERROR"]
+        assert errors == []
+
+    def test_conflict_marker_is_error(self, tmp_path):
+        conflict_md = dedent("""\
+            ---
+            name: maya-bad
+            <<<<<<< HEAD
+            description: "old"
+            =======
+            description: "new"
+            >>>>>>> origin/main
+            dcc: maya
+            ---
+        """)
+        make_skill_dir(tmp_path, "maya-bad", conflict_md)
+        issues = lint_skills.lint_all(tmp_path)
+        assert any(i.rule == "CONFLICT_MARKER" and i.severity == "ERROR" for i in issues)
+
+    def test_fix_resolves_conflicts(self, tmp_path):
+        conflict_md = dedent("""\
+            ---
+            name: maya-bad
+            <<<<<<< HEAD
+            description: "old"
+            =======
+            description: "new"
+            >>>>>>> origin/main
+            dcc: maya
+            version: "1.0.0"
+            ---
+        """)
+        make_skill_dir(tmp_path, "maya-bad", conflict_md)
+        issues = lint_skills.lint_all(tmp_path, fix=True)
+        conflict_issues = [i for i in issues if i.rule == "CONFLICT_MARKER"]
+        assert conflict_issues == []
+
+    def test_error_only_filter(self, tmp_path):
+        # Skill with a warning only (missing scripts section)
+        content = CLEAN_FRONTMATTER.replace("maya-test", "maya-ok")
+        make_skill_dir(tmp_path, "maya-ok", content, scripts=["do_thing.py"])
+        issues = lint_skills.lint_all(tmp_path, error_only=True)
+        warnings = [i for i in issues if i.severity == "WARNING"]
+        assert warnings == []

--- a/tests/test_skills_round33.py
+++ b/tests/test_skills_round33.py
@@ -1,0 +1,488 @@
+"""Round-33 tests: cover remaining api.py & server.py uncovered lines.
+
+Coverage targets
+----------------
+- api.py lines 212-214  : require_cmds() ImportError path
+- api.py lines 228-230  : get_cmds() ImportError path
+- api.py build_context_dict, ensure_valid_name, scene_object_from_node,
+         object_transform_from_node, bounding_box_from_node
+- server.py line 164    : registry property when _server has no _registry attr
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import sys
+from unittest.mock import MagicMock, patch
+
+# Import third-party modules
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cmds(**overrides):
+    """Return a MagicMock that quacks like maya.cmds."""
+    cmds = MagicMock()
+    for k, v in overrides.items():
+        setattr(cmds, k, v)
+    return cmds
+
+
+# ---------------------------------------------------------------------------
+# require_cmds — ImportError path (api.py lines 212-214)
+# ---------------------------------------------------------------------------
+
+
+class TestRequireCmds:
+    def test_yields_cmds_when_available(self):
+        """require_cmds() yields a cmds-like module when Maya is importable."""
+        from dcc_mcp_maya.api import require_cmds
+
+        mock_cmds = MagicMock()
+        mock_maya = MagicMock()
+        mock_maya.cmds = mock_cmds
+        with patch.dict(sys.modules, {"maya": mock_maya, "maya.cmds": mock_cmds}):
+            with require_cmds() as cmds:
+                # cmds should be some object (the mock that Python's import resolved to)
+                assert cmds is not None
+
+    def test_raises_import_error_when_maya_missing(self):
+        """require_cmds() raises ImportError when maya.cmds is not installed."""
+        from dcc_mcp_maya.api import require_cmds
+
+        with patch.dict(sys.modules, {"maya": None, "maya.cmds": None}):
+            with pytest.raises((ImportError, Exception)):
+                with require_cmds() as _cmds:
+                    pass
+
+    def test_require_cmds_is_context_manager(self):
+        """require_cmds() is a context manager (has __enter__/__exit__)."""
+        import contextlib
+
+        from dcc_mcp_maya.api import require_cmds
+
+        assert isinstance(require_cmds, contextlib._GeneratorContextManager.__class__) or callable(require_cmds)
+
+
+# ---------------------------------------------------------------------------
+# get_cmds — ImportError path (api.py lines 228-230)
+# ---------------------------------------------------------------------------
+
+
+class TestGetCmds:
+    def test_returns_cmds_module_when_available(self):
+        """get_cmds() returns a cmds-like module when Maya is importable."""
+        from dcc_mcp_maya.api import get_cmds
+
+        mock_cmds = MagicMock()
+        mock_maya = MagicMock()
+        mock_maya.cmds = mock_cmds
+        with patch.dict(sys.modules, {"maya": mock_maya, "maya.cmds": mock_cmds}):
+            cmds = get_cmds()
+            assert cmds is not None
+
+    def test_raises_import_error_when_maya_missing(self):
+        """get_cmds() raises ImportError when maya.cmds is absent."""
+        from dcc_mcp_maya.api import get_cmds
+
+        with patch.dict(sys.modules, {"maya": None, "maya.cmds": None}):
+            with pytest.raises((ImportError, Exception)):
+                get_cmds()
+
+    def test_get_cmds_is_callable(self):
+        """get_cmds is a regular callable (not a context manager)."""
+        from dcc_mcp_maya.api import get_cmds
+
+        assert callable(get_cmds)
+
+
+# ---------------------------------------------------------------------------
+# ensure_valid_name (api.py)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureValidName:
+    def test_returns_none_for_valid_name(self):
+        from dcc_mcp_maya.api import ensure_valid_name
+
+        assert ensure_valid_name("pSphere1") is None
+
+    def test_returns_none_for_any_non_empty_string(self):
+        from dcc_mcp_maya.api import ensure_valid_name
+
+        assert ensure_valid_name("my_node_123") is None
+
+    def test_returns_error_for_empty_string(self):
+        from dcc_mcp_maya.api import ensure_valid_name
+
+        result = ensure_valid_name("")
+        assert result is not None
+        assert result["success"] is False
+
+    def test_returns_error_for_whitespace_only(self):
+        from dcc_mcp_maya.api import ensure_valid_name
+
+        result = ensure_valid_name("   ")
+        assert result is not None
+        assert result["success"] is False
+
+    def test_returns_error_for_none(self):
+        from dcc_mcp_maya.api import ensure_valid_name
+
+        result = ensure_valid_name(None)
+        assert result is not None
+        assert result["success"] is False
+
+    def test_error_mentions_param_name(self):
+        from dcc_mcp_maya.api import ensure_valid_name
+
+        result = ensure_valid_name("", param="layer_name")
+        assert "layer_name" in result["message"]
+
+    def test_returns_error_for_false(self):
+        from dcc_mcp_maya.api import ensure_valid_name
+
+        result = ensure_valid_name(False, param="node")
+        assert result is not None
+        assert result["success"] is False
+
+    def test_default_param_name_in_error(self):
+        from dcc_mcp_maya.api import ensure_valid_name
+
+        result = ensure_valid_name("")
+        assert "name" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# build_context_dict (api.py)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildContextDict:
+    def test_excludes_none_values(self):
+        from dcc_mcp_maya.api import build_context_dict
+
+        result = build_context_dict(name="pSphere1", parent=None)
+        assert "name" in result
+        assert "parent" not in result
+
+    def test_keeps_falsy_non_none_values(self):
+        from dcc_mcp_maya.api import build_context_dict
+
+        result = build_context_dict(count=0, enabled=False, name="")
+        assert result["count"] == 0
+        assert result["enabled"] is False
+        assert result["name"] == ""
+
+    def test_returns_empty_dict_when_all_none(self):
+        from dcc_mcp_maya.api import build_context_dict
+
+        result = build_context_dict(a=None, b=None)
+        assert result == {}
+
+    def test_returns_all_when_no_none(self):
+        from dcc_mcp_maya.api import build_context_dict
+
+        result = build_context_dict(x=1, y=2, z=3)
+        assert result == {"x": 1, "y": 2, "z": 3}
+
+    def test_empty_kwargs_returns_empty_dict(self):
+        from dcc_mcp_maya.api import build_context_dict
+
+        result = build_context_dict()
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# scene_object_from_node (api.py)
+# ---------------------------------------------------------------------------
+
+
+class TestSceneObjectFromNode:
+    def _make_cmds_for_node(self, long_name, object_type="transform", parents=None, visible=True):
+        cmds = MagicMock()
+        cmds.objectType.return_value = object_type
+        cmds.listRelatives.return_value = parents or []
+        cmds.getAttr.return_value = visible
+        return cmds
+
+    def test_basic_top_level_transform(self):
+        from dcc_mcp_maya.api import scene_object_from_node
+
+        cmds = self._make_cmds_for_node("|pSphere1", "transform", parents=[], visible=True)
+        result = scene_object_from_node(cmds, "|pSphere1")
+        assert result["name"] == "pSphere1"
+        assert result["long_name"] == "|pSphere1"
+        assert result["object_type"] == "transform"
+        assert result["parent"] is None
+        assert result["visible"] is True
+        assert result["metadata"] == {}
+
+    def test_nested_node_extracts_short_name(self):
+        from dcc_mcp_maya.api import scene_object_from_node
+
+        cmds = self._make_cmds_for_node("|group1|pSphere1")
+        result = scene_object_from_node(cmds, "|group1|pSphere1")
+        assert result["name"] == "pSphere1"
+        assert result["long_name"] == "|group1|pSphere1"
+
+    def test_node_with_parent(self):
+        from dcc_mcp_maya.api import scene_object_from_node
+
+        cmds = self._make_cmds_for_node("|group1|child", parents=["|group1"])
+        result = scene_object_from_node(cmds, "|group1|child")
+        assert result["parent"] == "|group1"
+
+    def test_visibility_false(self):
+        from dcc_mcp_maya.api import scene_object_from_node
+
+        cmds = self._make_cmds_for_node("|hidden_node", visible=False)
+        cmds.getAttr.return_value = False
+        result = scene_object_from_node(cmds, "|hidden_node")
+        assert result["visible"] is False
+
+    def test_visibility_exception_defaults_to_true(self):
+        from dcc_mcp_maya.api import scene_object_from_node
+
+        cmds = MagicMock()
+        cmds.objectType.return_value = "transform"
+        cmds.listRelatives.return_value = []
+        cmds.getAttr.side_effect = RuntimeError("no attr")
+        result = scene_object_from_node(cmds, "|pSphere1")
+        assert result["visible"] is True
+
+    def test_node_without_pipe_in_name(self):
+        from dcc_mcp_maya.api import scene_object_from_node
+
+        cmds = self._make_cmds_for_node("pSphere1")
+        result = scene_object_from_node(cmds, "pSphere1")
+        assert result["name"] == "pSphere1"
+        assert result["long_name"] == "pSphere1"
+
+
+# ---------------------------------------------------------------------------
+# object_transform_from_node (api.py)
+# ---------------------------------------------------------------------------
+
+
+class TestObjectTransformFromNode:
+    def _make_cmds_with_xform(self, translate, rotate, scale):
+        cmds = MagicMock()
+
+        def getAttr(attr):
+            if ".translate" in attr:
+                return [translate]
+            if ".rotate" in attr:
+                return [rotate]
+            if ".scale" in attr:
+                return [scale]
+            return [0.0]
+
+        cmds.getAttr.side_effect = getAttr
+        return cmds
+
+    def test_basic_transform(self):
+        from dcc_mcp_maya.api import object_transform_from_node
+
+        cmds = self._make_cmds_with_xform(
+            translate=(1.0, 2.0, 3.0),
+            rotate=(10.0, 20.0, 30.0),
+            scale=(1.5, 1.5, 1.5),
+        )
+        result = object_transform_from_node(cmds, "pSphere1")
+        assert result["translate"] == [1.0, 2.0, 3.0]
+        assert result["rotate"] == [10.0, 20.0, 30.0]
+        assert result["scale"] == [1.5, 1.5, 1.5]
+
+    def test_zero_transform(self):
+        from dcc_mcp_maya.api import object_transform_from_node
+
+        cmds = self._make_cmds_with_xform((0, 0, 0), (0, 0, 0), (1, 1, 1))
+        result = object_transform_from_node(cmds, "pCube1")
+        assert result["translate"] == [0.0, 0.0, 0.0]
+        assert result["scale"] == [1.0, 1.0, 1.0]
+
+    def test_values_are_floats(self):
+        from dcc_mcp_maya.api import object_transform_from_node
+
+        cmds = self._make_cmds_with_xform((1, 2, 3), (4, 5, 6), (7, 8, 9))
+        result = object_transform_from_node(cmds, "node1")
+        for key in ("translate", "rotate", "scale"):
+            for v in result[key]:
+                assert isinstance(v, float)
+
+    def test_negative_values(self):
+        from dcc_mcp_maya.api import object_transform_from_node
+
+        cmds = self._make_cmds_with_xform((-1.0, -2.5, 0.0), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0))
+        result = object_transform_from_node(cmds, "node2")
+        assert result["translate"] == [-1.0, -2.5, 0.0]
+
+
+# ---------------------------------------------------------------------------
+# bounding_box_from_node (api.py)
+# ---------------------------------------------------------------------------
+
+
+class TestBoundingBoxFromNode:
+    def _make_cmds_with_bb(self, bb):
+        cmds = MagicMock()
+        cmds.exactWorldBoundingBox.return_value = bb
+        return cmds
+
+    def test_basic_bounding_box(self):
+        from dcc_mcp_maya.api import bounding_box_from_node
+
+        cmds = self._make_cmds_with_bb([0.0, 0.0, 0.0, 2.0, 4.0, 6.0])
+        result = bounding_box_from_node(cmds, "pBox")
+        assert result["min"] == [0.0, 0.0, 0.0]
+        assert result["max"] == [2.0, 4.0, 6.0]
+        assert result["center"] == [1.0, 2.0, 3.0]
+        assert result["size"] == [2.0, 4.0, 6.0]
+
+    def test_center_computed_correctly(self):
+        from dcc_mcp_maya.api import bounding_box_from_node
+
+        cmds = self._make_cmds_with_bb([-1.0, -2.0, -3.0, 1.0, 2.0, 3.0])
+        result = bounding_box_from_node(cmds, "node")
+        assert result["center"] == [0.0, 0.0, 0.0]
+
+    def test_size_computed_correctly(self):
+        from dcc_mcp_maya.api import bounding_box_from_node
+
+        cmds = self._make_cmds_with_bb([1.0, 2.0, 3.0, 5.0, 6.0, 7.0])
+        result = bounding_box_from_node(cmds, "node")
+        assert result["size"] == [4.0, 4.0, 4.0]
+
+    def test_values_are_floats(self):
+        from dcc_mcp_maya.api import bounding_box_from_node
+
+        cmds = self._make_cmds_with_bb([0, 0, 0, 1, 1, 1])
+        result = bounding_box_from_node(cmds, "node")
+        for key in ("min", "max", "center", "size"):
+            for v in result[key]:
+                assert isinstance(v, float)
+
+    def test_calls_exact_world_bounding_box(self):
+        from dcc_mcp_maya.api import bounding_box_from_node
+
+        cmds = self._make_cmds_with_bb([0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+        bounding_box_from_node(cmds, "myCube")
+        cmds.exactWorldBoundingBox.assert_called_once_with("myCube")
+
+    def test_asymmetric_bounding_box(self):
+        from dcc_mcp_maya.api import bounding_box_from_node
+
+        cmds = self._make_cmds_with_bb([0.0, 1.0, 2.0, 10.0, 3.0, 8.0])
+        result = bounding_box_from_node(cmds, "node")
+        assert result["size"] == [10.0, 2.0, 6.0]
+        assert result["center"] == [5.0, 2.0, 5.0]
+
+
+# ---------------------------------------------------------------------------
+# server.py line 164 — registry property when _server has no _registry attr
+# ---------------------------------------------------------------------------
+
+
+class TestServerRegistryProperty:
+    """Cover the registry property fallback (server.py line 164)."""
+
+    def test_registry_returns_none_when_no_internal_registry(self):
+        """When _server has no _registry attr, registry property returns None."""
+        import importlib
+
+        for mod in list(sys.modules):
+            if "dcc_mcp_maya" in mod:
+                del sys.modules[mod]
+
+        mock_maya = MagicMock()
+        modules = {
+            "maya": mock_maya,
+            "maya.cmds": MagicMock(),
+            "maya.mel": MagicMock(),
+            "maya.utils": MagicMock(),
+        }
+        with patch.dict(sys.modules, modules):
+            srv_mod2 = importlib.import_module("dcc_mcp_maya.server")
+            server = srv_mod2.MayaMcpServer(port=0)
+            # Replace the Rust McpHttpServer with a plain Python object that has no _registry
+            plain_obj = object()
+            server._server = plain_obj
+            result = server.registry
+            assert result is None
+
+    def test_registry_returns_registry_when_attr_exists(self):
+        """When _server has _registry, registry property returns it."""
+        import importlib
+
+        for mod in list(sys.modules):
+            if "dcc_mcp_maya" in mod:
+                del sys.modules[mod]
+
+        mock_maya = MagicMock()
+        modules = {
+            "maya": mock_maya,
+            "maya.cmds": MagicMock(),
+            "maya.mel": MagicMock(),
+            "maya.utils": MagicMock(),
+        }
+        with patch.dict(sys.modules, modules):
+            srv_mod = importlib.import_module("dcc_mcp_maya.server")
+            server = srv_mod.MayaMcpServer(port=0)
+            # Replace Rust object with a simple namespace that has _registry
+            fake_registry = MagicMock()
+
+            class FakeServer:
+                _registry = fake_registry
+
+            server._server = FakeServer()
+            result = server.registry
+            assert result is fake_registry
+
+
+# ---------------------------------------------------------------------------
+# Public API re-export verification for new helpers
+# ---------------------------------------------------------------------------
+
+
+class TestApiPublicReexportRound33:
+    """Verify that all new helpers are exported from dcc_mcp_maya namespace."""
+
+    def test_ensure_valid_name_in_api(self):
+        from dcc_mcp_maya.api import ensure_valid_name
+
+        assert callable(ensure_valid_name)
+
+    def test_build_context_dict_in_api(self):
+        from dcc_mcp_maya.api import build_context_dict
+
+        assert callable(build_context_dict)
+
+    def test_scene_object_from_node_in_api(self):
+        from dcc_mcp_maya.api import scene_object_from_node
+
+        assert callable(scene_object_from_node)
+
+    def test_object_transform_from_node_in_api(self):
+        from dcc_mcp_maya.api import object_transform_from_node
+
+        assert callable(object_transform_from_node)
+
+    def test_bounding_box_from_node_in_api(self):
+        from dcc_mcp_maya.api import bounding_box_from_node
+
+        assert callable(bounding_box_from_node)
+
+    def test_require_cmds_callable(self):
+        from dcc_mcp_maya.api import require_cmds
+
+        assert callable(require_cmds)
+
+    def test_get_cmds_callable(self):
+        from dcc_mcp_maya.api import get_cmds
+
+        assert callable(get_cmds)

--- a/tests/test_skills_round34.py
+++ b/tests/test_skills_round34.py
@@ -1,0 +1,273 @@
+"""Round 34 — maya_warning helper + SKILL.md tools: field validation.
+
+Covers:
+- maya_warning(): success=True with context["warning"] key
+- maya_warning imported from dcc_mcp_maya top-level package
+- maya_warning in api.__all__
+- SKILL.md tools: field structure (ToolDeclaration-compatible)
+- 4 updated SKILL.md files contain valid tools: arrays
+"""
+
+# Import built-in modules
+import os
+
+# Import third-party modules
+import pytest
+
+# ---------------------------------------------------------------------------
+# TestMayaWarning
+# ---------------------------------------------------------------------------
+
+
+class TestMayaWarning:
+    """Tests for the maya_warning() helper added in Round 34."""
+
+    def test_returns_success_true(self):
+        from dcc_mcp_maya.api import maya_warning
+
+        result = maya_warning("Done with caveat", warning="fallback used")
+        assert result["success"] is True
+
+    def test_message_preserved(self):
+        from dcc_mcp_maya.api import maya_warning
+
+        result = maya_warning("Operation complete", warning="minor issue")
+        assert result["message"] == "Operation complete"
+
+    def test_warning_in_context(self):
+        from dcc_mcp_maya.api import maya_warning
+
+        result = maya_warning("Applied", warning="Arnold not available; used Lambert")
+        assert "warning" in result["context"]
+        assert "Arnold not available" in result["context"]["warning"]
+
+    def test_empty_warning_allowed(self):
+        from dcc_mcp_maya.api import maya_warning
+
+        result = maya_warning("Done")
+        assert result["success"] is True
+        assert result["context"].get("warning", "") == ""
+
+    def test_prompt_forwarded(self):
+        from dcc_mcp_maya.api import maya_warning
+
+        result = maya_warning(
+            "Done",
+            warning="check log",
+            prompt="Review the output before proceeding.",
+        )
+        assert result.get("prompt") == "Review the output before proceeding."
+
+    def test_extra_context_forwarded(self):
+        from dcc_mcp_maya.api import maya_warning
+
+        result = maya_warning(
+            "Assigned",
+            warning="fallback",
+            object_name="pSphere1",
+            material="lambert1",
+        )
+        assert result["context"]["object_name"] == "pSphere1"
+        assert result["context"]["material"] == "lambert1"
+
+    def test_no_error_key(self):
+        from dcc_mcp_maya.api import maya_warning
+
+        result = maya_warning("Done", warning="minor")
+        # Should not have a non-None error field (it's a success variant)
+        assert result.get("error") is None
+
+    def test_importable_from_top_level(self):
+        import dcc_mcp_maya
+
+        assert hasattr(dcc_mcp_maya, "maya_warning")
+        assert callable(dcc_mcp_maya.maya_warning)
+
+    def test_top_level_returns_same_shape(self):
+        import dcc_mcp_maya
+
+        result = dcc_mcp_maya.maya_warning("Done", warning="test warning")
+        assert result["success"] is True
+        assert "warning" in result["context"]
+
+    def test_in_api_all(self):
+        from dcc_mcp_maya import api
+
+        assert "maya_warning" in api.__all__
+
+    def test_in_package_all(self):
+        import dcc_mcp_maya
+
+        assert "maya_warning" in dcc_mcp_maya.__all__
+
+
+# ---------------------------------------------------------------------------
+# TestSkillMdToolsField
+# ---------------------------------------------------------------------------
+
+SKILLS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "src",
+    "dcc_mcp_maya",
+    "skills",
+)
+
+SKILL_NAMES_WITH_TOOLS = [
+    "maya-scene",
+    "maya-primitives",
+    "maya-animation",
+    "maya-render",
+]
+
+
+class TestSkillMdToolsField:
+    """Validate that the 4 updated SKILL.md files contain valid tools: arrays."""
+
+    def _read_skill_md(self, skill_name):
+        skill_md = os.path.join(SKILLS_DIR, skill_name, "SKILL.md")
+        assert os.path.exists(skill_md), "SKILL.md not found: {}".format(skill_md)
+        with open(skill_md, encoding="utf-8") as fh:
+            return fh.read()
+
+    def _parse_frontmatter(self, content):
+        """Extract YAML frontmatter between --- delimiters."""
+        # Import built-in modules
+        import re
+
+        match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+        assert match, "No YAML frontmatter found"
+        # Import third-party modules
+        import yaml
+
+        return yaml.safe_load(match.group(1))
+
+    @pytest.mark.parametrize("skill_name", SKILL_NAMES_WITH_TOOLS)
+    def test_tools_key_present(self, skill_name):
+        content = self._read_skill_md(skill_name)
+        fm = self._parse_frontmatter(content)
+        assert "tools" in fm, "tools: field missing in {}".format(skill_name)
+
+    @pytest.mark.parametrize("skill_name", SKILL_NAMES_WITH_TOOLS)
+    def test_tools_is_list(self, skill_name):
+        content = self._read_skill_md(skill_name)
+        fm = self._parse_frontmatter(content)
+        assert isinstance(fm["tools"], list), "tools: must be a list in {}".format(skill_name)
+        assert len(fm["tools"]) > 0, "tools: list must not be empty in {}".format(skill_name)
+
+    @pytest.mark.parametrize("skill_name", SKILL_NAMES_WITH_TOOLS)
+    def test_each_tool_has_required_fields(self, skill_name):
+        content = self._read_skill_md(skill_name)
+        fm = self._parse_frontmatter(content)
+        for tool in fm["tools"]:
+            assert "name" in tool, "tool missing 'name' in {}".format(skill_name)
+            assert "description" in tool, "tool missing 'description' in {}".format(skill_name)
+            assert "source_file" in tool, "tool missing 'source_file' in {}".format(skill_name)
+
+    @pytest.mark.parametrize("skill_name", SKILL_NAMES_WITH_TOOLS)
+    def test_tool_annotations_present(self, skill_name):
+        content = self._read_skill_md(skill_name)
+        fm = self._parse_frontmatter(content)
+        for tool in fm["tools"]:
+            assert "read_only" in tool, "tool '{}' missing read_only in {}".format(
+                tool.get("name", "?"), skill_name
+            )
+            assert "destructive" in tool, "tool '{}' missing destructive in {}".format(
+                tool.get("name", "?"), skill_name
+            )
+            assert "idempotent" in tool, "tool '{}' missing idempotent in {}".format(
+                tool.get("name", "?"), skill_name
+            )
+
+    @pytest.mark.parametrize("skill_name", SKILL_NAMES_WITH_TOOLS)
+    def test_source_file_under_scripts(self, skill_name):
+        content = self._read_skill_md(skill_name)
+        fm = self._parse_frontmatter(content)
+        for tool in fm["tools"]:
+            sf = tool.get("source_file", "")
+            assert sf.startswith("scripts/"), (
+                "source_file '{}' must start with 'scripts/' in {}".format(sf, skill_name)
+            )
+
+    def test_maya_scene_tool_count(self):
+        content = self._read_skill_md("maya-scene")
+        fm = self._parse_frontmatter(content)
+        assert len(fm["tools"]) >= 8
+
+    def test_maya_primitives_tool_count(self):
+        content = self._read_skill_md("maya-primitives")
+        fm = self._parse_frontmatter(content)
+        assert len(fm["tools"]) == 8
+
+    def test_maya_animation_tool_count(self):
+        content = self._read_skill_md("maya-animation")
+        fm = self._parse_frontmatter(content)
+        assert len(fm["tools"]) >= 7
+
+    def test_maya_render_tool_count(self):
+        content = self._read_skill_md("maya-render")
+        fm = self._parse_frontmatter(content)
+        assert len(fm["tools"]) == 3
+
+    def test_readonly_tools_not_destructive(self):
+        """read_only=True tools should not be destructive."""
+        for skill_name in SKILL_NAMES_WITH_TOOLS:
+            content = self._read_skill_md(skill_name)
+            fm = self._parse_frontmatter(content)
+            for tool in fm["tools"]:
+                if tool.get("read_only") is True:
+                    assert tool.get("destructive") is False, (
+                        "read_only tool '{}' in {} should not be destructive".format(
+                            tool.get("name"), skill_name
+                        )
+                    )
+
+    def test_tool_names_match_source_file_stems(self):
+        """Each tool's name should match the stem of its source_file."""
+        for skill_name in SKILL_NAMES_WITH_TOOLS:
+            content = self._read_skill_md(skill_name)
+            fm = self._parse_frontmatter(content)
+            for tool in fm["tools"]:
+                stem = os.path.splitext(os.path.basename(tool.get("source_file", "")))[0]
+                assert tool["name"] == stem, (
+                    "Tool name '{}' doesn't match source_file stem '{}' in {}".format(
+                        tool["name"], stem, skill_name
+                    )
+                )
+
+
+# ---------------------------------------------------------------------------
+# TestApiAllConsistency
+# ---------------------------------------------------------------------------
+
+
+class TestApiAllConsistency:
+    """Verify api.__all__ is consistent with the symbols it exports."""
+
+    def test_all_exported_symbols_callable_or_class(self):
+        from dcc_mcp_maya import api
+
+        for name in api.__all__:
+            assert hasattr(api, name), "'{}' in __all__ but not found in api module".format(name)
+            obj = getattr(api, name)
+            assert callable(obj) or isinstance(obj, type), (
+                "'{}' should be callable or a class".format(name)
+            )
+
+    def test_maya_warning_in_api_all_and_callable(self):
+        from dcc_mcp_maya import api
+
+        assert "maya_warning" in api.__all__
+        assert callable(api.maya_warning)
+
+    def test_package_all_superset_of_api_all(self):
+        """dcc_mcp_maya.__all__ should include every entry in api.__all__ except MayaCmds."""
+        import dcc_mcp_maya
+        from dcc_mcp_maya import api
+
+        excluded = {"MayaCmds"}
+        for name in api.__all__:
+            if name not in excluded:
+                assert name in dcc_mcp_maya.__all__, (
+                    "'{}' in api.__all__ but missing from dcc_mcp_maya.__all__".format(name)
+                )

--- a/tests/test_skills_round34.py
+++ b/tests/test_skills_round34.py
@@ -169,15 +169,11 @@ class TestSkillMdToolsField:
         content = self._read_skill_md(skill_name)
         fm = self._parse_frontmatter(content)
         for tool in fm["tools"]:
-            assert "read_only" in tool, "tool '{}' missing read_only in {}".format(
-                tool.get("name", "?"), skill_name
-            )
+            assert "read_only" in tool, "tool '{}' missing read_only in {}".format(tool.get("name", "?"), skill_name)
             assert "destructive" in tool, "tool '{}' missing destructive in {}".format(
                 tool.get("name", "?"), skill_name
             )
-            assert "idempotent" in tool, "tool '{}' missing idempotent in {}".format(
-                tool.get("name", "?"), skill_name
-            )
+            assert "idempotent" in tool, "tool '{}' missing idempotent in {}".format(tool.get("name", "?"), skill_name)
 
     @pytest.mark.parametrize("skill_name", SKILL_NAMES_WITH_TOOLS)
     def test_source_file_under_scripts(self, skill_name):
@@ -185,9 +181,7 @@ class TestSkillMdToolsField:
         fm = self._parse_frontmatter(content)
         for tool in fm["tools"]:
             sf = tool.get("source_file", "")
-            assert sf.startswith("scripts/"), (
-                "source_file '{}' must start with 'scripts/' in {}".format(sf, skill_name)
-            )
+            assert sf.startswith("scripts/"), "source_file '{}' must start with 'scripts/' in {}".format(sf, skill_name)
 
     def test_maya_scene_tool_count(self):
         content = self._read_skill_md("maya-scene")
@@ -217,9 +211,7 @@ class TestSkillMdToolsField:
             for tool in fm["tools"]:
                 if tool.get("read_only") is True:
                     assert tool.get("destructive") is False, (
-                        "read_only tool '{}' in {} should not be destructive".format(
-                            tool.get("name"), skill_name
-                        )
+                        "read_only tool '{}' in {} should not be destructive".format(tool.get("name"), skill_name)
                     )
 
     def test_tool_names_match_source_file_stems(self):
@@ -229,10 +221,8 @@ class TestSkillMdToolsField:
             fm = self._parse_frontmatter(content)
             for tool in fm["tools"]:
                 stem = os.path.splitext(os.path.basename(tool.get("source_file", "")))[0]
-                assert tool["name"] == stem, (
-                    "Tool name '{}' doesn't match source_file stem '{}' in {}".format(
-                        tool["name"], stem, skill_name
-                    )
+                assert tool["name"] == stem, "Tool name '{}' doesn't match source_file stem '{}' in {}".format(
+                    tool["name"], stem, skill_name
                 )
 
 
@@ -250,9 +240,7 @@ class TestApiAllConsistency:
         for name in api.__all__:
             assert hasattr(api, name), "'{}' in __all__ but not found in api module".format(name)
             obj = getattr(api, name)
-            assert callable(obj) or isinstance(obj, type), (
-                "'{}' should be callable or a class".format(name)
-            )
+            assert callable(obj) or isinstance(obj, type), "'{}' should be callable or a class".format(name)
 
     def test_maya_warning_in_api_all_and_callable(self):
         from dcc_mcp_maya import api
@@ -268,6 +256,6 @@ class TestApiAllConsistency:
         excluded = {"MayaCmds"}
         for name in api.__all__:
             if name not in excluded:
-                assert name in dcc_mcp_maya.__all__, (
-                    "'{}' in api.__all__ but missing from dcc_mcp_maya.__all__".format(name)
+                assert name in dcc_mcp_maya.__all__, "'{}' in api.__all__ but missing from dcc_mcp_maya.__all__".format(
+                    name
                 )

--- a/tools/lint_skills.py
+++ b/tools/lint_skills.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+"""Lint SKILL.md files in the dcc-mcp-maya skills directory.
+
+Usage:
+    python tools/lint_skills.py                    # lint all skills
+    python tools/lint_skills.py --fix              # auto-fix conflict markers
+    python tools/lint_skills.py --error-only       # only report ERRORs
+    python tools/lint_skills.py --skills-root path # custom skills root
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SUPPORTED_SCRIPT_EXTENSIONS: Set[str] = {
+    ".py",
+    ".mel",
+    ".ms",
+    ".bat",
+    ".cmd",
+    ".sh",
+    ".bash",
+    ".ps1",
+    ".vbs",
+    ".jsx",
+    ".js",
+}
+
+VALID_DCC_VALUES: Set[str] = {
+    "maya",
+    "blender",
+    "houdini",
+    "3dsmax",
+    "unreal",
+    "unity",
+    "python",
+}
+
+# For this project all skills must target maya
+PROJECT_DCC = "maya"
+
+CONFLICT_MARKER_RE = re.compile(r"^(<{7}|={7}|>{7})", re.MULTILINE)
+CONFLICT_FULL_RE = re.compile(
+    r"<<<<<<< HEAD\n(.*?)=======\n(.*?)>>>>>>> origin/main\n",
+    re.DOTALL,
+)
+SEMVER_RE = re.compile(r"^\d+\.\d+(\.\d+)?(-[\w.]+)?(\+[\w.]+)?$")
+NAME_VALID_RE = re.compile(r"^[a-z0-9-]+$")
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LintIssue:
+    skill: str  # skill directory name
+    file: str  # relative path from project root
+    severity: str  # "ERROR" | "WARNING"
+    rule: str  # rule code
+    message: str
+
+
+@dataclass
+class SkillInfo:
+    name: str
+    skill_dir: Path
+    scripts: List[Path] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# YAML frontmatter parsing (PyYAML with stdlib fallback)
+# ---------------------------------------------------------------------------
+
+
+def _parse_yaml_minimal(yaml_text: str) -> Optional[dict]:
+    """Minimal YAML key:value parser (no nesting, no lists) as stdlib fallback."""
+    result: dict = {}
+    for line in yaml_text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" in line:
+            key, _, val = line.partition(":")
+            val = val.strip().strip('"').strip("'")
+            result[key.strip()] = val
+    return result
+
+
+def extract_frontmatter(content: str) -> Optional[dict]:
+    """Extract and parse YAML frontmatter bounded by --- delimiters."""
+    if not content.startswith("---"):
+        return None
+    # Find the closing ---
+    end = content.find("\n---", 3)
+    if end == -1:
+        return None
+    yaml_text = content[4:end]
+    try:
+        import yaml  # type: ignore[import]
+
+        data = yaml.safe_load(yaml_text)
+        return data if isinstance(data, dict) else None
+    except Exception:
+        # Try minimal fallback
+        return _parse_yaml_minimal(yaml_text)
+
+
+# ---------------------------------------------------------------------------
+# Individual rule checks
+# ---------------------------------------------------------------------------
+
+
+def check_conflict_markers(skill_dir: Path, skill_name: str, content: str) -> List[LintIssue]:
+    issues: List[LintIssue] = []
+    if CONFLICT_MARKER_RE.search(content):
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=str(skill_dir / "SKILL.md"),
+                severity="ERROR",
+                rule="CONFLICT_MARKER",
+                message="Unresolved git merge conflict markers found in SKILL.md",
+            )
+        )
+    return issues
+
+
+def check_frontmatter_parseable(
+    skill_dir: Path, skill_name: str, content: str
+) -> Tuple[List[LintIssue], Optional[dict]]:
+    """Returns (issues, frontmatter_dict_or_None)."""
+    issues: List[LintIssue] = []
+
+    if not content.startswith("---"):
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=str(skill_dir / "SKILL.md"),
+                severity="ERROR",
+                rule="NO_FRONTMATTER",
+                message="SKILL.md does not start with --- (missing YAML frontmatter)",
+            )
+        )
+        return issues, None
+
+    if content.find("\n---", 3) == -1:
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=str(skill_dir / "SKILL.md"),
+                severity="ERROR",
+                rule="NO_FRONTMATTER",
+                message="SKILL.md frontmatter closing --- not found",
+            )
+        )
+        return issues, None
+
+    fm = extract_frontmatter(content)
+    if fm is None:
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=str(skill_dir / "SKILL.md"),
+                severity="ERROR",
+                rule="NO_FRONTMATTER",
+                message="SKILL.md YAML frontmatter could not be parsed",
+            )
+        )
+    return issues, fm
+
+
+def check_name_field(skill_dir: Path, skill_name: str, fm: dict) -> List[LintIssue]:
+    issues: List[LintIssue] = []
+    file_path = str(skill_dir / "SKILL.md")
+    name = fm.get("name")
+
+    if not name:
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=file_path,
+                severity="ERROR",
+                rule="NO_NAME",
+                message="frontmatter missing required 'name' field",
+            )
+        )
+        return issues
+
+    name = str(name)
+
+    if name != skill_name:
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=file_path,
+                severity="ERROR",
+                rule="NAME_MISMATCH",
+                message=f"name '{name}' does not match directory name '{skill_name}'",
+            )
+        )
+
+    if len(name) > 64:
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=file_path,
+                severity="WARNING",
+                rule="NAME_FORMAT",
+                message=f"name '{name}' exceeds 64 chars (agentskills.io limit)",
+            )
+        )
+
+    if name.startswith("-") or name.endswith("-"):
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=file_path,
+                severity="WARNING",
+                rule="NAME_FORMAT",
+                message=f"name '{name}' must not start or end with a hyphen",
+            )
+        )
+
+    if "--" in name:
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=file_path,
+                severity="WARNING",
+                rule="NAME_FORMAT",
+                message=f"name '{name}' must not contain consecutive hyphens",
+            )
+        )
+
+    if not NAME_VALID_RE.match(name):
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=file_path,
+                severity="WARNING",
+                rule="NAME_FORMAT",
+                message=f"name '{name}' should be lowercase letters, digits, and hyphens only",
+            )
+        )
+
+    return issues
+
+
+def check_dcc_field(skill_dir: Path, skill_name: str, fm: dict) -> List[LintIssue]:
+    issues: List[LintIssue] = []
+    file_path = str(skill_dir / "SKILL.md")
+    dcc = fm.get("dcc", "python")
+
+    if dcc not in VALID_DCC_VALUES:
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=file_path,
+                severity="WARNING",
+                rule="UNKNOWN_DCC",
+                message=f"dcc '{dcc}' is not a known value (expected one of: {', '.join(sorted(VALID_DCC_VALUES))})",
+            )
+        )
+
+    if dcc != PROJECT_DCC:
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=file_path,
+                severity="ERROR",
+                rule="WRONG_DCC",
+                message=f"dcc '{dcc}' should be '{PROJECT_DCC}' for this project",
+            )
+        )
+
+    return issues
+
+
+def check_version_field(skill_dir: Path, skill_name: str, fm: dict) -> List[LintIssue]:
+    issues: List[LintIssue] = []
+    version = fm.get("version", "1.0.0")
+    if version and not SEMVER_RE.match(str(version)):
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=str(skill_dir / "SKILL.md"),
+                severity="WARNING",
+                rule="BAD_VERSION",
+                message=f"version '{version}' does not follow semver (e.g. '1.0.0')",
+            )
+        )
+    return issues
+
+
+def check_description_field(skill_dir: Path, skill_name: str, fm: dict) -> List[LintIssue]:
+    issues: List[LintIssue] = []
+    file_path = str(skill_dir / "SKILL.md")
+    desc = fm.get("description", "")
+
+    if not desc:
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=file_path,
+                severity="WARNING",
+                rule="MISSING_DESC",
+                message="'description' field is empty or missing",
+            )
+        )
+    elif len(str(desc)) > 1024:
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=file_path,
+                severity="WARNING",
+                rule="DESC_TOO_LONG",
+                message=f"description length {len(str(desc))} exceeds 1024 chars (agentskills.io limit)",
+            )
+        )
+
+    return issues
+
+
+def check_scripts_section(skill_dir: Path, skill_name: str, content: str) -> List[LintIssue]:
+    """Warn if scripts/ contains files but SKILL.md body has no ## Scripts section."""
+    issues: List[LintIssue] = []
+    scripts_dir = skill_dir / "scripts"
+    if not scripts_dir.is_dir():
+        return issues
+
+    script_files = [f for f in scripts_dir.iterdir() if f.is_file() and f.suffix.lower() in SUPPORTED_SCRIPT_EXTENSIONS]
+    if not script_files:
+        return issues
+
+    # Check body (after closing frontmatter ---)
+    end = content.find("\n---", 3)
+    body = content[end + 4 :] if end != -1 else content
+
+    if "## Scripts" not in body and "##Scripts" not in body:
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=str(skill_dir / "SKILL.md"),
+                severity="WARNING",
+                rule="MISSING_SCRIPTS_SECTION",
+                message=f"{len(script_files)} script(s) found in scripts/ but no '## Scripts' section in SKILL.md body",
+            )
+        )
+    return issues
+
+
+def check_tools_source_files(skill_dir: Path, skill_name: str, fm: dict) -> List[LintIssue]:
+    """Warn if tools[].source_file paths don't exist in scripts/ dir."""
+    issues: List[LintIssue] = []
+    tools = fm.get("tools", [])
+    if not tools or not isinstance(tools, list):
+        return issues
+
+    for tool_entry in tools:
+        if not isinstance(tool_entry, dict):
+            continue
+        source_file = tool_entry.get("source_file", "")
+        if not source_file:
+            continue
+        # source_file is relative to skill_dir
+        full_path = skill_dir / source_file
+        if not full_path.exists():
+            issues.append(
+                LintIssue(
+                    skill=skill_name,
+                    file=str(skill_dir / "SKILL.md"),
+                    severity="WARNING",
+                    rule="TOOL_SOURCE_MISSING",
+                    message=f"tools entry source_file '{source_file}' not found at {full_path}",
+                )
+            )
+    return issues
+
+
+def check_depends_exist(
+    skill_dir: Path,
+    skill_name: str,
+    fm: dict,
+    all_skill_names: Set[str],
+) -> List[LintIssue]:
+    """Warn if depends[] references skill names that don't exist."""
+    issues: List[LintIssue] = []
+    depends = fm.get("depends", [])
+    if not depends or not isinstance(depends, list):
+        return issues
+
+    for dep in depends:
+        dep_str = str(dep).strip()
+        if dep_str and dep_str not in all_skill_names:
+            issues.append(
+                LintIssue(
+                    skill=skill_name,
+                    file=str(skill_dir / "SKILL.md"),
+                    severity="WARNING",
+                    rule="MISSING_DEPENDS",
+                    message=f"depends references '{dep_str}' which is not a known skill",
+                )
+            )
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Cross-skill checks
+# ---------------------------------------------------------------------------
+
+
+def check_duplicate_action_names(
+    all_skills_info: List[SkillInfo],
+) -> List[LintIssue]:
+    """Warn when two skills share the same script stem (action name collision)."""
+    issues: List[LintIssue] = []
+    # stem -> list of (skill_name, script_path)
+    stem_map: Dict[str, List[Tuple[str, Path]]] = {}
+
+    for info in all_skills_info:
+        for script in info.scripts:
+            stem = script.stem
+            stem_map.setdefault(stem, []).append((info.name, script))
+
+    for stem, occurrences in stem_map.items():
+        if len(occurrences) > 1:
+            skill_list = ", ".join(f"{s} ({p.name})" for s, p in occurrences)
+            for skill_name, script_path in occurrences:
+                issues.append(
+                    LintIssue(
+                        skill=skill_name,
+                        file=str(script_path),
+                        severity="WARNING",
+                        rule="DUPLICATE_SCRIPT_STEM",
+                        message=f"script stem '{stem}' appears in multiple skills: {skill_list}",
+                    )
+                )
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Single-skill linter
+# ---------------------------------------------------------------------------
+
+
+def collect_scripts(skill_dir: Path) -> List[Path]:
+    """Return all script files in skill_dir/scripts/."""
+    scripts_dir = skill_dir / "scripts"
+    if not scripts_dir.is_dir():
+        return []
+    return sorted(f for f in scripts_dir.iterdir() if f.is_file() and f.suffix.lower() in SUPPORTED_SCRIPT_EXTENSIONS)
+
+
+def lint_skill(
+    skill_dir: Path,
+    all_skill_names: Set[str],
+) -> Tuple[List[LintIssue], SkillInfo]:
+    """Run all per-skill checks. Returns issues and SkillInfo for cross-skill checks."""
+    skill_name = skill_dir.name
+    skill_md = skill_dir / "SKILL.md"
+
+    info = SkillInfo(name=skill_name, skill_dir=skill_dir, scripts=collect_scripts(skill_dir))
+
+    if not skill_md.exists():
+        return [
+            LintIssue(
+                skill=skill_name,
+                file=str(skill_md),
+                severity="ERROR",
+                rule="NO_FRONTMATTER",
+                message="SKILL.md does not exist",
+            )
+        ], info
+
+    content = skill_md.read_text(encoding="utf-8")
+    issues: List[LintIssue] = []
+
+    # Check for conflict markers first — if present, YAML won't parse cleanly
+    issues += check_conflict_markers(skill_dir, skill_name, content)
+    if any(i.rule == "CONFLICT_MARKER" for i in issues):
+        # Skip remaining checks that require parseable frontmatter
+        return issues, info
+
+    fm_issues, fm = check_frontmatter_parseable(skill_dir, skill_name, content)
+    issues += fm_issues
+    if fm is None:
+        return issues, info
+
+    issues += check_name_field(skill_dir, skill_name, fm)
+    issues += check_dcc_field(skill_dir, skill_name, fm)
+    issues += check_version_field(skill_dir, skill_name, fm)
+    issues += check_description_field(skill_dir, skill_name, fm)
+    issues += check_scripts_section(skill_dir, skill_name, content)
+    issues += check_tools_source_files(skill_dir, skill_name, fm)
+    issues += check_depends_exist(skill_dir, skill_name, fm, all_skill_names)
+
+    return issues, info
+
+
+# ---------------------------------------------------------------------------
+# Auto-fix
+# ---------------------------------------------------------------------------
+
+
+def fix_conflict_markers(skill_dir: Path) -> int:
+    """Resolve conflict markers in SKILL.md by keeping origin/main side. Returns count."""
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return 0
+    content = skill_md.read_text(encoding="utf-8")
+    count = len(CONFLICT_FULL_RE.findall(content))
+    if count == 0:
+        return 0
+    resolved = CONFLICT_FULL_RE.sub(r"\2", content)
+    skill_md.write_text(resolved, encoding="utf-8")
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Main linter runner
+# ---------------------------------------------------------------------------
+
+
+def lint_all(
+    skills_root: Path,
+    fix: bool = False,
+    error_only: bool = False,
+) -> List[LintIssue]:
+    """Lint all skills under skills_root. If fix=True, auto-fix conflict markers first."""
+    skill_dirs = sorted(d for d in skills_root.iterdir() if d.is_dir())
+    all_skill_names: Set[str] = {d.name for d in skill_dirs}
+
+    if fix:
+        fixed_total = 0
+        for skill_dir in skill_dirs:
+            n = fix_conflict_markers(skill_dir)
+            if n:
+                print(f"  [FIX] {skill_dir.name}/SKILL.md: {n} conflict(s) resolved")
+                fixed_total += n
+        if fixed_total:
+            print(f"  Fixed {fixed_total} conflict(s) total.\n")
+
+    all_issues: List[LintIssue] = []
+    all_info: List[SkillInfo] = []
+
+    for skill_dir in skill_dirs:
+        issues, info = lint_skill(skill_dir, all_skill_names)
+        all_issues += issues
+        all_info.append(info)
+
+    # Cross-skill checks
+    all_issues += check_duplicate_action_names(all_info)
+
+    if error_only:
+        all_issues = [i for i in all_issues if i.severity == "ERROR"]
+
+    return all_issues
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def print_report(issues: List[LintIssue], skills_root: Path) -> None:
+    """Print a human-readable lint report."""
+    if not issues:
+        print("All SKILL.md files passed lint checks.")
+        return
+
+    # Group by skill
+    by_skill: Dict[str, List[LintIssue]] = {}
+    for issue in issues:
+        by_skill.setdefault(issue.skill, []).append(issue)
+
+    error_count = sum(1 for i in issues if i.severity == "ERROR")
+    warning_count = sum(1 for i in issues if i.severity == "WARNING")
+
+    for skill_name, skill_issues in sorted(by_skill.items()):
+        print(f"\n{skill_name}:")
+        for issue in skill_issues:
+            prefix = "  ERROR  " if issue.severity == "ERROR" else "  WARN   "
+            # Make file path relative to CWD for readability
+            try:
+                rel_file = Path(issue.file).relative_to(Path.cwd())
+            except ValueError:
+                rel_file = Path(issue.file)
+            print(f"{prefix}[{issue.rule}] {rel_file}: {issue.message}")
+
+    print(f"\n--- Summary: {error_count} error(s), {warning_count} warning(s) across {len(by_skill)} skill(s) ---")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Lint SKILL.md files in the dcc-mcp-maya skills directory.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Auto-fix unresolved git merge conflict markers (keeps origin/main side)",
+    )
+    parser.add_argument(
+        "--skills-root",
+        default="src/dcc_mcp_maya/skills",
+        help="Path to skills directory (default: src/dcc_mcp_maya/skills)",
+    )
+    parser.add_argument(
+        "--error-only",
+        action="store_true",
+        help="Only report ERRORs, suppress WARNINGs",
+    )
+    args = parser.parse_args()
+
+    skills_root = Path(args.skills_root)
+    if not skills_root.is_dir():
+        print(f"ERROR: skills root '{skills_root}' does not exist or is not a directory", file=sys.stderr)
+        sys.exit(2)
+
+    issues = lint_all(skills_root, fix=args.fix, error_only=args.error_only)
+    print_report(issues, skills_root)
+
+    error_count = sum(1 for i in issues if i.severity == "ERROR")
+    sys.exit(0 if error_count == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Fix 3 merge conflicts**: Resolved unresolved git conflict markers in `maya-annotation`, `maya-audio`, and `maya-cache` SKILL.md files by keeping the `origin/main` side (richer CRUD descriptions with more scripts)
- **Add `tools/lint_skills.py`**: Standalone SKILL.md linter with 14 rule checks covering conflict markers, frontmatter validation, name format/matching, DCC field, version semver, description length, scripts section presence, tools source file existence, dependency references, and cross-skill duplicate action names
- **Add `tests/test_lint_skills.py`**: 40 unit tests covering all rule codes
- **Update CI**: Add `lint-skills` job (`python tools/lint_skills.py --error-only`) and fix Python version typo in `lint` job (3.14 → 3.12)

## Lint Rules

| Rule | Severity | Description |
|------|----------|-------------|
| `CONFLICT_MARKER` | ERROR | Unresolved `<<<<<<<`/`=======`/`>>>>>>>` markers |
| `NO_FRONTMATTER` | ERROR | Missing or unparseable YAML frontmatter |
| `NO_NAME` | ERROR | `name` field missing |
| `NAME_MISMATCH` | ERROR | `name` doesn't match directory name |
| `WRONG_DCC` | ERROR | `dcc` != `"maya"` for this project |
| `NAME_FORMAT` | WARNING | name violates charset/hyphen/length rules |
| `UNKNOWN_DCC` | WARNING | `dcc` not in known DCC values set |
| `BAD_VERSION` | WARNING | `version` not semver |
| `MISSING_DESC` | WARNING | `description` empty/missing |
| `DESC_TOO_LONG` | WARNING | `description` > 1024 chars |
| `MISSING_SCRIPTS_SECTION` | WARNING | Scripts on disk but no `## Scripts` section |
| `TOOL_SOURCE_MISSING` | WARNING | `tools[].source_file` not found on disk |
| `MISSING_DEPENDS` | WARNING | `depends[]` references non-existent skill |
| `DUPLICATE_SCRIPT_STEM` | WARNING | Same script stem across multiple skills |

## Test plan
- [x] All 40 unit tests pass (`pytest tests/test_lint_skills.py`)
- [x] Ruff lint + format check pass on new files
- [x] Full test suite passes (2427 passed, 5 skipped)
- [x] `python tools/lint_skills.py` reports 0 errors on all 64 skills
- [ ] CI `lint-skills` job goes green