### PR TITLE
chore(deps): upgrade dcc-mcp-core to >=0.12.18; use skill module helpers in api.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "dcc-mcp-core>=0.12.12,<1.0.0",
+    "dcc-mcp-core>=0.12.18,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_maya/api.py
+++ b/src/dcc_mcp_maya/api.py
@@ -8,9 +8,8 @@ Instead of repeating the same boilerplate in every script, import from here:
 Key helpers
 -----------
 ``maya_success(message, **context)``
-    Build a success ActionResultModel dict, identical to
-    ``success_result(message, **context).to_dict()`` but without any extra
-    import in the script body.
+    Build a success result dict backed by ``dcc_mcp_core.skill.skill_success``
+    (pure-Python, zero compiled-extension dependency).
 
 ``maya_error(message, error, **context)``
     Build an error ActionResultModel dict.
@@ -107,9 +106,9 @@ def maya_success(message: str, prompt: Optional[str] = None, **context: Any) -> 
 
         return maya_success("Created sphere", object_name="pSphere1", radius=1.0)
     """
-    from dcc_mcp_core import success_result  # noqa: PLC0415
+    from dcc_mcp_core.skill import skill_success  # noqa: PLC0415
 
-    return success_result(message, prompt=prompt, **context).to_dict()
+    return skill_success(message, prompt=prompt, **context)
 
 
 def maya_error(
@@ -139,15 +138,15 @@ def maya_error(
             possible_solutions=["Check the object name", "Use list_objects to see available nodes"],
         )
     """
-    from dcc_mcp_core import error_result  # noqa: PLC0415
+    from dcc_mcp_core.skill import skill_error  # noqa: PLC0415
 
-    return error_result(
+    return skill_error(
         message,
         error,
         prompt=prompt,
         possible_solutions=possible_solutions,
         **context,
-    ).to_dict()
+    )
 
 
 def maya_warning(message: str, warning: str = "", prompt: Optional[str] = None, **context: Any) -> Dict[str, Any]:
@@ -177,9 +176,9 @@ def maya_warning(message: str, warning: str = "", prompt: Optional[str] = None, 
             object_name="pSphere1",
         )
     """
-    from dcc_mcp_core import success_result  # noqa: PLC0415
+    from dcc_mcp_core.skill import skill_warning  # noqa: PLC0415
 
-    return success_result(message, prompt=prompt, warning=warning, **context).to_dict()
+    return skill_warning(message, warning=warning, prompt=prompt, **context)
 
 
 def maya_from_exception(
@@ -213,16 +212,16 @@ def maya_from_exception(
             logger.exception("create_sphere failed")
             return maya_from_exception(exc, "Failed to create sphere")
     """
-    from dcc_mcp_core import from_exception  # noqa: PLC0415
+    from dcc_mcp_core.skill import skill_exception  # noqa: PLC0415
 
-    return from_exception(
-        error_message=str(exc),
+    return skill_exception(
+        exc,
         message=message,
         prompt=prompt,
         include_traceback=include_traceback,
         possible_solutions=possible_solutions,
         **context,
-    ).to_dict()
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/get_frame_range.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/get_frame_range.py
@@ -63,9 +63,7 @@ def get_frame_range() -> dict:
         return skill_success(
             "Frame range: {:.0f} - {:.0f} @ {:.0f} fps".format(start, end, fps),
             frame_range=frame_range,
-            prompt=(
-                "Use set_timeline to change the range, or set_keyframe to add a key at the current time."
-            ),
+            prompt=("Use set_timeline to change the range, or set_keyframe to add a key at the current time."),
         )
     except ImportError:
         return skill_error("Maya not available", "maya.cmds could not be imported")

--- a/src/dcc_mcp_maya/skills/maya-hdri/scripts/load_hdri.py
+++ b/src/dcc_mcp_maya/skills/maya-hdri/scripts/load_hdri.py
@@ -86,9 +86,7 @@ def load_hdri(
         if backend == "native" and use_arnold:
             # Arnold was requested but fell back to native; warn the user
             return maya_warning(
-                "HDRI loaded from '{}' using native backend (Arnold fallback)".format(
-                    os.path.basename(file_path)
-                ),
+                "HDRI loaded from '{}' using native backend (Arnold fallback)".format(os.path.basename(file_path)),
                 warning="Arnold (mtoa) was not available; used directionalLight as fallback.",
                 prompt="Install Arnold (MtoA) for physically-based sky dome. Use set_hdri_exposure to adjust.",
                 light_node=light_transform,

--- a/tests/test_skills_round42.py
+++ b/tests/test_skills_round42.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_maya_mock(mtoa_loaded: bool = False):
     """Return (mock_maya, mock_cmds) with pluginInfo configured."""
     mock_cmds = MagicMock()
@@ -91,6 +92,7 @@ def _load_create_render_pass(mtoa_loaded: bool):
 # ---------------------------------------------------------------------------
 # Tests: create_hdri_dome
 # ---------------------------------------------------------------------------
+
 
 class TestCreateHdriDomeArnoldFallback:
     """create_hdri_dome — Arnold (mtoa) not loaded → ambientLight fallback + warning."""
@@ -191,6 +193,7 @@ class TestCreateHdriDomeStructural:
 
     def _source(self):
         import os
+
         path = os.path.join(
             os.path.dirname(__file__),
             "..",
@@ -216,6 +219,7 @@ class TestCreateHdriDomeStructural:
 # ---------------------------------------------------------------------------
 # Tests: create_render_pass
 # ---------------------------------------------------------------------------
+
 
 class TestCreateRenderPassArnoldFallback:
     """create_render_pass — renderer=arnold but mtoa not loaded → renderPass + warning."""
@@ -355,6 +359,7 @@ class TestCreateRenderPassStructural:
 
     def _source(self):
         import os
+
         path = os.path.join(
             os.path.dirname(__file__),
             "..",

--- a/tests/test_skills_round44.py
+++ b/tests/test_skills_round44.py
@@ -22,11 +22,12 @@ _MOD_COUNTER = [0]
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _load_script(skill_dir, script_name):
     """Load a skill script directly from its file path."""
     _MOD_COUNTER[0] += 1
     script_path = _SKILLS_ROOT / skill_dir / "scripts" / "{}.py".format(script_name)
-    mod_name = "skill_r44_{}_{}_{}" .format(skill_dir.replace("-", "_"), script_name, _MOD_COUNTER[0])
+    mod_name = "skill_r44_{}_{}_{}".format(skill_dir.replace("-", "_"), script_name, _MOD_COUNTER[0])
     spec = importlib.util.spec_from_file_location(mod_name, str(script_path))
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
@@ -68,9 +69,17 @@ def _run_get_frame_range(cmds_mock=None, **kwargs):
 def _caps_to_dict(caps):
     """Convert DccCapabilities to a plain dict using attribute access."""
     keys = [
-        "scene_manager", "transform", "hierarchy", "selection",
-        "render_capture", "snapshot", "undo_redo", "file_operations",
-        "has_embedded_python", "progress_reporting", "scene_info",
+        "scene_manager",
+        "transform",
+        "hierarchy",
+        "selection",
+        "render_capture",
+        "snapshot",
+        "undo_redo",
+        "file_operations",
+        "has_embedded_python",
+        "progress_reporting",
+        "scene_info",
     ]
     return {k: getattr(caps, k) for k in keys if hasattr(caps, k)}
 
@@ -78,6 +87,7 @@ def _caps_to_dict(caps):
 # ===========================================================================
 # 1. capabilities.py
 # ===========================================================================
+
 
 class TestMayaCapabilitiesFactory:
     """Tests for dcc_mcp_maya.capabilities.maya_capabilities()."""
@@ -169,6 +179,7 @@ class TestMayaCapabilitiesDict:
 # 2. server.py MayaMcpServer.get_capabilities()
 # ===========================================================================
 
+
 def _import_server_module():
     cmds_mock = _mock_maya_cmds()
     mods = _make_modules(cmds_mock)
@@ -177,6 +188,7 @@ def _import_server_module():
         del sys.modules[mod_name]
     with patch.dict(sys.modules, mods):
         import importlib
+
         mod = importlib.import_module(mod_name)
     return mod
 
@@ -226,6 +238,7 @@ class TestServerGetCapabilities:
 # 3. Public re-exports
 # ===========================================================================
 
+
 class TestPublicReexports:
     """Verify maya_capabilities is accessible from top-level and api module."""
 
@@ -263,39 +276,32 @@ class TestPublicReexports:
 # 4. get_frame_range skill
 # ===========================================================================
 
+
 class TestGetFrameRangeHappyPath:
     """Happy path tests for get_frame_range skill."""
 
     def test_success_result(self):
         cmds = _mock_maya_cmds()
-        cmds.playbackOptions.side_effect = lambda **kw: (
-            1.0 if kw.get("minTime") else 120.0
-        )
+        cmds.playbackOptions.side_effect = lambda **kw: 1.0 if kw.get("minTime") else 120.0
         result = _run_get_frame_range(cmds)
         assert result["success"] is True
 
     def test_frame_range_in_context(self):
         cmds = _mock_maya_cmds()
-        cmds.playbackOptions.side_effect = lambda **kw: (
-            1.0 if kw.get("minTime") else 120.0
-        )
+        cmds.playbackOptions.side_effect = lambda **kw: 1.0 if kw.get("minTime") else 120.0
         result = _run_get_frame_range(cmds)
         assert "frame_range" in result.get("context", {})
 
     def test_film_fps_24(self):
         cmds = _mock_maya_cmds()
-        cmds.playbackOptions.side_effect = lambda **kw: (
-            1.0 if kw.get("minTime") else 120.0
-        )
+        cmds.playbackOptions.side_effect = lambda **kw: 1.0 if kw.get("minTime") else 120.0
         cmds.currentUnit.return_value = "film"
         result = _run_get_frame_range(cmds)
         assert result["context"]["frame_range"]["fps"] == 24.0
 
     def test_pal_fps_25(self):
         cmds = _mock_maya_cmds()
-        cmds.playbackOptions.side_effect = lambda **kw: (
-            1.0 if kw.get("minTime") else 100.0
-        )
+        cmds.playbackOptions.side_effect = lambda **kw: 1.0 if kw.get("minTime") else 100.0
         cmds.currentUnit.return_value = "pal"
         result = _run_get_frame_range(cmds)
         assert result["context"]["frame_range"]["fps"] == 25.0
@@ -452,4 +458,4 @@ class TestGetFrameRangeStructural:
     def test_has_prompt_in_skill_success(self):
         path = _SKILLS_ROOT / "maya-animation" / "scripts" / "get_frame_range.py"
         source = path.read_text(encoding="utf-8")
-        assert 'prompt=' in source
+        assert "prompt=" in source

--- a/tests/test_skills_round45.py
+++ b/tests/test_skills_round45.py
@@ -20,10 +20,6 @@ from __future__ import annotations
 import sys
 from unittest.mock import MagicMock, patch
 
-# Import third-party modules
-import pytest
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -76,21 +72,21 @@ class TestSearchSkills:
         reg.search_actions.return_value = []
         server.search_skills(category="mesh")
         call_kwargs = reg.search_actions.call_args
-        assert call_kwargs.kwargs.get("dcc_name") == "maya"
+        assert call_kwargs[1].get("dcc_name") == "maya"
 
     def test_explicit_dcc_name_is_forwarded(self):
         server, reg = _make_server_with_registry()
         reg.search_actions.return_value = []
         server.search_skills(dcc_name="houdini")
         call_kwargs = reg.search_actions.call_args
-        assert call_kwargs.kwargs.get("dcc_name") == "houdini"
+        assert call_kwargs[1].get("dcc_name") == "houdini"
 
     def test_tags_forwarded(self):
         server, reg = _make_server_with_registry()
         reg.search_actions.return_value = []
         server.search_skills(tags=["rigging", "ik"])
         call_kwargs = reg.search_actions.call_args
-        assert call_kwargs.kwargs.get("tags") == ["rigging", "ik"]
+        assert call_kwargs[1].get("tags") == ["rigging", "ik"]
 
     def test_returns_empty_when_registry_none(self):
         server = _make_server()
@@ -222,14 +218,14 @@ class TestGetSkillTags:
         reg.get_tags.return_value = []
         server.get_skill_tags()
         call_kwargs = reg.get_tags.call_args
-        assert call_kwargs.kwargs.get("dcc_name") == "maya"
+        assert call_kwargs[1].get("dcc_name") == "maya"
 
     def test_explicit_dcc_forwarded(self):
         server, reg = _make_server_with_registry()
         reg.get_tags.return_value = []
         server.get_skill_tags(dcc_name="blender")
         call_kwargs = reg.get_tags.call_args
-        assert call_kwargs.kwargs.get("dcc_name") == "blender"
+        assert call_kwargs[1].get("dcc_name") == "blender"
 
     def test_returns_empty_on_exception(self):
         server, reg = _make_server_with_registry()

--- a/tests/test_skills_round45.py
+++ b/tests/test_skills_round45.py
@@ -36,6 +36,7 @@ def _make_server():
         for mod in [k for k in sys.modules if "dcc_mcp_maya" in k]:
             del sys.modules[mod]
         import importlib
+
         server_mod = importlib.import_module("dcc_mcp_maya.server")
         server = server_mod.MayaMcpServer(port=19900)
 
@@ -264,6 +265,7 @@ class TestRankServices:
         mock_tm = MagicMock()
         mock_tm.rank_services.return_value = []
         import importlib
+
         with patch.dict(sys.modules, {"dcc_mcp_core": MagicMock()}):
             server_mod = importlib.import_module("dcc_mcp_maya.server")
         server_mod.MayaMcpServer.rank_services(mock_tm, dcc_type="houdini")
@@ -399,6 +401,7 @@ class TestGetSkillInfo:
 class TestServerStructural:
     def test_is_skill_loaded_in_server_class(self):
         import importlib
+
         with patch.dict(sys.modules, {"dcc_mcp_core": MagicMock()}):
             for mod in [k for k in sys.modules if "dcc_mcp_maya" in k]:
                 del sys.modules[mod]
@@ -407,6 +410,7 @@ class TestServerStructural:
 
     def test_get_skill_info_in_server_class(self):
         import importlib
+
         with patch.dict(sys.modules, {"dcc_mcp_core": MagicMock()}):
             for mod in [k for k in sys.modules if "dcc_mcp_maya" in k]:
                 del sys.modules[mod]
@@ -415,6 +419,7 @@ class TestServerStructural:
 
     def test_search_skills_in_server_class(self):
         import importlib
+
         with patch.dict(sys.modules, {"dcc_mcp_core": MagicMock()}):
             for mod in [k for k in sys.modules if "dcc_mcp_maya" in k]:
                 del sys.modules[mod]
@@ -423,6 +428,7 @@ class TestServerStructural:
 
     def test_find_skills_in_server_class(self):
         import importlib
+
         with patch.dict(sys.modules, {"dcc_mcp_core": MagicMock()}):
             for mod in [k for k in sys.modules if "dcc_mcp_maya" in k]:
                 del sys.modules[mod]
@@ -431,6 +437,7 @@ class TestServerStructural:
 
     def test_rank_services_is_static(self):
         import importlib
+
         with patch.dict(sys.modules, {"dcc_mcp_core": MagicMock()}):
             for mod in [k for k in sys.modules if "dcc_mcp_maya" in k]:
                 del sys.modules[mod]
@@ -442,6 +449,7 @@ class TestServerStructural:
 
     def test_find_best_service_is_static(self):
         import importlib
+
         with patch.dict(sys.modules, {"dcc_mcp_core": MagicMock()}):
             for mod in [k for k in sys.modules if "dcc_mcp_maya" in k]:
                 del sys.modules[mod]


### PR DESCRIPTION
## Summary

- Bump `dcc-mcp-core` lower bound from `>=0.12.12` to `>=0.12.18`
- Replace `success_result(...).to_dict()` / `error_result(...).to_dict()` / `from_exception(...).to_dict()` calls in `api.py` with the pure-Python `dcc_mcp_core.skill` helpers (`skill_success`, `skill_error`, `skill_warning`, `skill_exception`)
- Removes hard dependency on the compiled Rust `_core` extension in DCC environments where only the pure-Python wheel is installed

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `dcc-mcp-core>=0.12.12` → `>=0.12.18` |
| `src/dcc_mcp_maya/api.py` | `maya_success/error/warning/from_exception` now delegate to `dcc_mcp_core.skill` helpers |

## Test plan

- [x] `python -m pytest tests/ -m "not e2e and not packaging"` → 3001 passed, 6 skipped ✓