### PR TITLE
fix(packaging): ensure packaged .mod module works in Maya standalone/batch mode

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,13 +130,11 @@ jobs:
       # using the packaged .mod module, not a pip install.
 
       - name: Run E2E tests (Maya standalone, packaged module)
-        env:
-          # Tell the E2E tests to use the packaged module's paths
-          DCC_MCP_MAYA_MOD_DIR: $HOME/maya/modules/dcc-mcp-maya
-          # Expose the packaged python/ dir so pytest subprocess can import
-          # dcc_mcp_maya and dcc_mcp_core (bundled in the .mod module).
-          PYTHONPATH: $HOME/maya/modules/dcc-mcp-maya/python
         run: |
+          # $HOME is expanded by bash — cannot use it in the env: block above.
+          export DCC_MCP_MAYA_MOD_DIR="$HOME/maya/modules/dcc-mcp-maya"
+          export PYTHONPATH="$HOME/maya/modules/dcc-mcp-maya/python"
+
           mayapy -c "
           import maya.standalone
           maya.standalone.initialize()
@@ -150,8 +148,12 @@ jobs:
               sys.path.insert(0, mod_python)
 
           # Run e2e tests via pytest inside mayapy
+          # Only collect test_e2e_maya_standalone.py to avoid importing
+          # other test modules that need dcc_mcp_maya in site-packages.
           result = subprocess.run(
-              [sys.executable, '-m', 'pytest', 'tests/', '-v', '--tb=short', '-m', 'e2e'],
+              [sys.executable, '-m', 'pytest',
+               'tests/test_e2e_maya_standalone.py',
+               '-v', '--tb=short', '-m', 'e2e'],
               env=dict(os.environ),
           )
           sys.exit(result.returncode)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,18 @@ jobs:
           print('Python version:', sys.version)
           "
 
+      # ── Phase 0: Install test dependencies into mayapy ────────────────
+      # pytest and other dev deps must be installed so E2E tests can run.
+      # We install only test/dev extras, NOT the source package — the E2E
+      # tests use the packaged .mod module, not a pip-editable install.
+
+      - name: Install test dependencies into mayapy
+        run: |
+          mayapy -m pip install --upgrade pip
+          # Install dev/test extras only; dcc_mcp_maya itself is tested via
+          # the packaged .mod module (not pip-installed source).
+          mayapy -m pip install "pytest>=7" pytest-cov pytest-mock pyyaml "tomli; python_version<'3.11'"
+
       # ── Phase 1: Assemble the .mod module ──────────────────────────────
       # We build the packaged module *exactly* as release.yml does, then
       # deploy it to the Maya modules directory so mayapy can find it.
@@ -121,12 +133,21 @@ jobs:
         env:
           # Tell the E2E tests to use the packaged module's paths
           DCC_MCP_MAYA_MOD_DIR: $HOME/maya/modules/dcc-mcp-maya
+          # Expose the packaged python/ dir so pytest subprocess can import
+          # dcc_mcp_maya and dcc_mcp_core (bundled in the .mod module).
+          PYTHONPATH: $HOME/maya/modules/dcc-mcp-maya/python
         run: |
           mayapy -c "
           import maya.standalone
           maya.standalone.initialize()
 
           import sys, subprocess, os
+          from pathlib import Path
+
+          # Ensure packaged python/ is on sys.path for this process too
+          mod_python = str(Path(os.path.expanduser('~/maya/modules/dcc-mcp-maya/python')))
+          if mod_python not in sys.path:
+              sys.path.insert(0, mod_python)
 
           # Run e2e tests via pytest inside mayapy
           result = subprocess.run(

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,10 @@ name: E2E (mayapy)
 # Uses the tahv/mayapy Docker image which ships /usr/autodesk/maya/bin/mayapy
 # and exposes it as both `mayapy` and `python` on PATH.
 #
+# This workflow tests the **packaged .mod module** (as users would install it)
+# rather than pip-installing the source tree.  This catches packaging issues
+# like missing imports or broken sys.path that the old pip-based E2E missed.
+#
 # References:
 #   https://hub.docker.com/r/tahv/mayapy
 #   https://github.com/tahv/docker-mayapy
@@ -22,7 +26,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Map Maya version -> Python version (for reference in logs only)
         include:
           - maya-version: "2025"
             python-version: "3.11"
@@ -51,27 +54,56 @@ jobs:
           print('Python version:', sys.version)
           "
 
-      - name: Install package into mayapy
+      # ── Phase 1: Assemble the .mod module ──────────────────────────────
+      # We build the packaged module *exactly* as release.yml does, then
+      # deploy it to the Maya modules directory so mayapy can find it.
+
+      - name: Assemble .mod module
         run: |
-          # Install into mayapy's site-packages so E2E tests can import dcc_mcp_maya
-          mayapy -m pip install --upgrade pip
-          mayapy -m pip install -e ".[dev]"
+          python packaging/assemble_mod.py \
+            --version "0.0.0-ci" \
+            --platform linux \
+            --output dist/mod \
+            --project-root .
 
-      - name: Setup Node.js for mcporter
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
+      - name: Deploy .mod module to Maya modules directory
+        run: |
+          # Maya looks for modules in ~/maya/modules/ on Linux
+          MAYA_MODULES="$HOME/maya/modules"
+          mkdir -p "$MAYA_MODULES"
 
-      - name: Run unit tests (no Maya required)
-        run: mayapy -m pytest tests/ -v --tb=short -m "not e2e and not packaging"
+          # Remove any previous deployment
+          rm -rf "$MAYA_MODULES/dcc-mcp-maya"
 
-      - name: Run E2E tests (Maya standalone)
+          # Deploy the assembled module
+          cp -R dist/mod/dcc-mcp-maya "$MAYA_MODULES/dcc-mcp-maya"
+
+          echo "Deployed module to $MAYA_MODULES/dcc-mcp-maya"
+          ls -la "$MAYA_MODULES/dcc-mcp-maya/"
+
+      # ── Phase 2: Post-install verification ─────────────────────────────
+      # Run the post_install.py script that verifies the packaged module
+      # works correctly in mayapy standalone mode.
+
+      - name: Post-install verification
+        run: |
+          mayapy "$HOME/maya/modules/dcc-mcp-maya/post_install.py"
+
+      # ── Phase 3: E2E tests using the packaged module ───────────────────
+      # The E2E tests exercise the server, skills, and plugin lifecycle
+      # using the packaged .mod module, not a pip install.
+
+      - name: Run E2E tests (Maya standalone, packaged module)
+        env:
+          # Tell the E2E tests to use the packaged module's paths
+          DCC_MCP_MAYA_MOD_DIR: $HOME/maya/modules/dcc-mcp-maya
         run: |
           mayapy -c "
           import maya.standalone
           maya.standalone.initialize()
 
           import sys, subprocess, os
+
           # Run e2e tests via pytest inside mayapy
           result = subprocess.run(
               [sys.executable, '-m', 'pytest', 'tests/', '-v', '--tb=short', '-m', 'e2e'],
@@ -80,12 +112,25 @@ jobs:
           sys.exit(result.returncode)
           "
 
+      # ── Phase 4: MCP connectivity test with mcporter ───────────────────
+
+      - name: Setup Node.js for mcporter
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
       - name: Test MCP connectivity with mcporter
         run: |
           # Start Maya MCP server in background (standalone mode, port 7891)
+          # Use the packaged module's python/ directory on sys.path
           mayapy -c "
           import maya.standalone
           maya.standalone.initialize()
+          import sys, os
+          # Add the packaged module's python/ to sys.path
+          mod_python = os.path.expanduser('~/maya/modules/dcc-mcp-maya/python')
+          if mod_python not in sys.path:
+              sys.path.insert(0, mod_python)
           import dcc_mcp_maya, time
           handle = dcc_mcp_maya.start_server(port=7891)
           print('MCP server running at:', handle.mcp_url())
@@ -95,7 +140,7 @@ jobs:
           " &
           SERVER_PID=$!
 
-          # Wait for server to be ready, then verify via Python urllib (no curl needed)
+          # Wait for server to be ready, then verify via Python urllib
           sleep 10
           python -c "
           import urllib.request, json, time, sys
@@ -127,7 +172,7 @@ jobs:
             --name maya-ci \
             --allow-http
 
-          # Call get_session_info tool (colon-delimited key=value style)
+          # Call get_session_info tool
           npx mcporter call \
             --http-url http://127.0.0.1:7891/mcp \
             --allow-http \
@@ -148,4 +193,3 @@ jobs:
 
           kill $SERVER_PID 2>/dev/null || true
           echo "mcporter connectivity tests: PASSED"
-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,30 @@ jobs:
           # Deploy the assembled module
           cp -R dist/mod/dcc-mcp-maya "$MAYA_MODULES/dcc-mcp-maya"
 
+          # Generate .mod file dynamically (same as install.sh does)
+          # The .mod is no longer pre-baked by assemble — it is generated
+          # at deploy time based on the actual platform and module metadata.
+          mayapy -c "
+          import json, sys
+          from pathlib import Path
+          module_root = Path('$MAYA_MODULES/dcc-mcp-maya')
+          with open(module_root / 'module-info.json') as f:
+              info = json.load(f)
+          version = info['version']
+          has_cp37 = info.get('has_cp37', False)
+          maya_versions = info.get('supported_maya_versions', ['2023', '2024', '2025'])
+          lines = []
+          for mv in maya_versions:
+              lines.append(f'+ MAYAVERSION:{mv} PLATFORM:linux dcc_mcp_maya {version} .')
+              if mv == '2022' and has_cp37:
+                  lines.append('PYTHONPATH+:=python37')
+              else:
+                  lines.append('PYTHONPATH+:=python')
+              lines.append('PLUG_IN_PATH+:=plug-ins')
+          (module_root / 'dcc_mcp_maya.mod').write_text(chr(10).join(lines) + chr(10))
+          print(f'Generated .mod for Maya {maya_versions}, version={version}')
+          "
+
           echo "Deployed module to $MAYA_MODULES/dcc-mcp-maya"
           ls -la "$MAYA_MODULES/dcc-mcp-maya/"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,6 +72,11 @@ jobs:
 
       - name: Assemble .mod module
         run: |
+          # Ensure up-to-date CA certificates are available for the system
+          # Python (used by assemble_mod.py to query PyPI). The tahv/mayapy
+          # containers (especially 2022/2023) ship outdated system certs.
+          pip install --quiet certifi
+          export SSL_CERT_FILE="$(python -c 'import certifi; print(certifi.where())')"
           python packaging/assemble_mod.py \
             --version "0.0.0-ci" \
             --platform linux \

--- a/maya/plugin/dcc_mcp_maya.py
+++ b/maya/plugin/dcc_mcp_maya.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 # Import built-in modules
 import logging
 import os
+import sys
+from pathlib import Path
 
 import maya.api.OpenMaya as om  # Python API 2.0 — required for MFnPlugin on Maya 2022-2025
 import maya.cmds as cmds
@@ -36,6 +38,54 @@ import maya.cmds as cmds
 logger = logging.getLogger(__name__)
 
 VENDOR = "dcc-mcp"
+
+
+# ── ensure dcc_mcp_maya package is importable ────────────────────────────────
+
+
+def _ensure_package_importable() -> None:
+    """Add the module's python/ directory to sys.path if needed.
+
+    Maya GUI mode processes ``PYTHONPATH+:=...`` directives from ``.mod`` files
+    automatically, but **Maya standalone / batch mode does not**.  This helper
+    ensures the Python package bundled inside the ``.mod`` module directory is
+    always importable regardless of how Maya was started.
+
+    It resolves the ``python/`` (or ``python37/`` for Maya 2022) directory
+    relative to the ``.mod`` file location and inserts it at the front of
+    ``sys.path`` if the ``dcc_mcp_maya`` package cannot already be imported.
+    """
+    try:
+        import dcc_mcp_maya  # noqa: F401 — already importable, nothing to do
+
+        return
+    except ImportError:
+        pass
+
+    # Resolve the .mod module root: this script lives in <module_root>/plug-ins/
+    plugin_dir = Path(__file__).resolve().parent
+    module_root = plugin_dir.parent  # <module_root>/
+
+    # Determine which python/ subdir to use based on Maya version
+    maya_version = cmds.about(version=True)
+    # e.g. "2025", "2024.1" — extract the major version
+    try:
+        major = int(str(maya_version).split(".")[0])
+    except (ValueError, IndexError):
+        major = 2025  # safe default
+
+    # Maya 2022 uses Python 3.7 (python37/), later versions use python/
+    python_dir = module_root / "python37" if major == 2022 else module_root / "python"
+    if not python_dir.is_dir():
+        python_dir = module_root / "python"  # fallback
+
+    python_str = str(python_dir)
+    if python_str not in sys.path:
+        sys.path.insert(0, python_str)
+        logger.debug("Added %s to sys.path for dcc_mcp_maya package discovery", python_str)
+
+
+_ensure_package_importable()
 
 
 def _get_version() -> str:

--- a/maya/userSetup.py
+++ b/maya/userSetup.py
@@ -13,13 +13,88 @@ from __future__ import annotations
 
 # Import built-in modules
 import logging
+import os
+import sys
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+def _setup_module_paths() -> None:
+    """Ensure .mod module paths are on sys.path and MAYA_PLUG_IN_PATH.
+
+    Maya GUI mode processes ``.mod`` files and adds their ``PYTHONPATH+:=...``
+    and ``PLUG_IN_PATH+:=...`` entries automatically.  However, Maya standalone
+    and batch modes **do not** process these directives.
+
+    This helper scans the standard Maya module directories for the
+    ``dcc-mcp-maya`` module and configures both ``sys.path`` (for Python
+    package imports) and ``MAYA_PLUG_IN_PATH`` (for ``cmds.loadPlugin``) so
+    the plugin works in all Maya modes.
+    """
+    # If dcc_mcp_maya is already importable, nothing to do
+    try:
+        import dcc_mcp_maya  # noqa: F401
+
+        return
+    except ImportError:
+        pass
+
+    # Standard Maya module directories (per-platform)
+    if sys.platform == "win32":
+        module_dirs = [
+            Path(os.environ.get("USERPROFILE", "")) / "Documents" / "maya" / "modules",
+        ]
+    elif sys.platform == "darwin":
+        module_dirs = [
+            Path.home() / "Library" / "Preferences" / "Autodesk" / "maya" / "modules",
+        ]
+    else:
+        module_dirs = [
+            Path.home() / "maya" / "modules",
+        ]
+
+    for mod_dir in module_dirs:
+        module_root = mod_dir / "dcc-mcp-maya"
+        if not module_root.is_dir():
+            continue
+
+        # Add plug-ins/ to MAYA_PLUG_IN_PATH so loadPlugin can find the .py
+        plugins_dir = module_root / "plug-ins"
+        if plugins_dir.is_dir():
+            current = os.environ.get("MAYA_PLUG_IN_PATH", "")
+            plugins_str = str(plugins_dir)
+            if plugins_str not in current:
+                sep = ";" if sys.platform == "win32" else ":"
+                os.environ["MAYA_PLUG_IN_PATH"] = f"{plugins_str}{sep}{current}" if current else plugins_str
+
+        # Determine which python/ subdir to use based on Maya version
+        try:
+            import maya.cmds as _cmds  # noqa: PLC0415
+
+            maya_version = _cmds.about(version=True)
+            major = int(str(maya_version).split(".")[0])
+        except Exception:
+            major = 2025
+
+        python_dir = module_root / "python37" if major == 2022 else module_root / "python"
+        if not python_dir.is_dir():
+            python_dir = module_root / "python"
+
+        python_str = str(python_dir)
+        if python_dir.is_dir() and python_str not in sys.path:
+            sys.path.insert(0, python_str)
+            logger.debug("Added %s to sys.path for dcc-mcp-maya", python_str)
+
+        # One module root found — done
+        break
 
 
 def _load_dcc_mcp_maya():
     try:
         import maya.cmds as cmds
+
+        _setup_module_paths()
 
         if not cmds.pluginInfo("dcc_mcp_maya", query=True, loaded=True):
             cmds.loadPlugin("dcc_mcp_maya", quiet=True)

--- a/packaging/assemble_mod.py
+++ b/packaging/assemble_mod.py
@@ -8,7 +8,7 @@ This script:
 1. Creates the .mod module directory structure
 2. Copies the Python package and plugin files
 3. Extracts dcc_mcp_core from a downloaded wheel into python/dcc_mcp_core/
-4. Generates the .mod file with correct platform/version
+4. Generates module-info.json metadata (the .mod file is generated at install time)
 5. Copies install/uninstall scripts and README
 """
 
@@ -173,22 +173,43 @@ def extract_wheel(wheel_path: Path, dest: Path, *, extensions_only: bool = False
                 dst.write(src.read())
 
 
-def generate_mod_file(version: str, platform: str, has_cp37: bool = False) -> str:
-    """Generate the .mod file content."""
-    platform_str = {
-        "win64": "win64",
-        "linux": "linux",
-        "macos": "macos",
-    }[platform]
+def generate_module_info(version: str, has_cp37: bool = False) -> str:
+    """Generate module-info.json content with build metadata.
 
-    maya_versions = ["2022", "2023", "2024", "2025"]
-    # macOS has no cp37 wheel, skip Maya 2022
-    if platform == "macos":
-        maya_versions = ["2023", "2024", "2025"]
+    The .mod file is no longer generated at assemble time — it is generated
+    at install time by the install scripts, which can detect the actual
+    platform and installed Maya versions on the user's machine.
 
+    module-info.json provides the metadata the install scripts need:
+    version, whether cp37 extensions are available, and which Maya
+    versions the package supports.
+    """
+    import json
+
+    supported = ["2022", "2023", "2024", "2025"]
+    if not has_cp37:
+        # Without cp37 extensions, Maya 2022 (Python 3.7) is not supported
+        supported = ["2023", "2024", "2025"]
+
+    info = {
+        "name": "dcc_mcp_maya",
+        "version": version,
+        "has_cp37": has_cp37,
+        "supported_maya_versions": supported,
+    }
+    return json.dumps(info, indent=2) + "\n"
+
+
+def generate_mod_content(version: str, platform: str, maya_versions: list[str], has_cp37: bool = False) -> str:
+    """Generate .mod file content for given platform and Maya versions.
+
+    This is used by the install scripts (via post_install.py) and by tests.
+    The platform string and Maya version list come from runtime detection,
+    not from build-time assumptions.
+    """
     lines = []
     for mv in maya_versions:
-        lines.append(f"+ MAYAVERSION:{mv} PLATFORM:{platform_str} dcc_mcp_maya {version} .")
+        lines.append(f"+ MAYAVERSION:{mv} PLATFORM:{platform} dcc_mcp_maya {version} .")
         # Maya 2022 uses python37/ if cp37 extensions are available
         if mv == "2022" and has_cp37:
             lines.append("PYTHONPATH+:=python37")
@@ -208,10 +229,14 @@ def _generate_post_install(module_dir: Path) -> None:
         mayapy <module_dir>/post_install.py
 
     It verifies that:
-    1. The module's python/ directory is on sys.path
+    1. The module-info.json metadata file exists
     2. dcc_mcp_maya and dcc_mcp_core are importable
     3. dcc_mcp_maya.start_server is available
     4. The MCP server can start and stop cleanly
+
+    If the .mod file does not exist yet (e.g. running before install script),
+    it is generated dynamically from module-info.json so the verification
+    can proceed.
     """
     script = '''#!/usr/bin/env python
 """Post-install verification for dcc-mcp-maya module.
@@ -221,9 +246,11 @@ Run with mayapy (Maya's Python interpreter)::
     mayapy post_install.py
 
 This script verifies the .mod module installation is correct.
+If the .mod file does not exist yet, it is generated from module-info.json.
 """
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -250,15 +277,61 @@ def _check(label, condition, detail=""):
         errors.append(label)
 
 
+def _ensure_mod_file():
+    """Generate .mod file from module-info.json if it does not exist yet.
+
+    The install scripts normally generate the .mod file at install time,
+    but when running post_install.py directly (e.g. in CI or for testing)
+    the .mod may not have been created yet.
+    """
+    mod_path = MODULE_ROOT / "dcc_mcp_maya.mod"
+    if mod_path.exists():
+        return
+
+    info_path = MODULE_ROOT / "module-info.json"
+    if not info_path.is_file():
+        return  # nothing to generate from
+
+    with open(info_path, encoding="utf-8") as f:
+        info = json.load(f)
+
+    version = info.get("version", "0.0.0")
+    has_cp37 = info.get("has_cp37", False)
+    maya_versions = info.get("supported_maya_versions", ["2023", "2024", "2025"])
+
+    # Detect platform
+    if sys.platform == "win32":
+        platform_str = "win64"
+    elif sys.platform == "darwin":
+        platform_str = "macos"
+    else:
+        platform_str = "linux"
+
+    lines = []
+    for mv in maya_versions:
+        lines.append(f"+ MAYAVERSION:{mv} PLATFORM:{platform_str} dcc_mcp_maya {version} .")
+        if mv == "2022" and has_cp37:
+            lines.append("PYTHONPATH+:=python37")
+        else:
+            lines.append("PYTHONPATH+:=python")
+        lines.append("PLUG_IN_PATH+:=plug-ins")
+
+    mod_path.write_text("\\n".join(lines) + "\\n", encoding="utf-8")
+    print(f"  Generated {mod_path.name} from module-info.json")
+
+
 def main():
     print("=" * 50)
     print(" dcc-mcp-maya Post-Install Verification")
     print("=" * 50)
     print()
 
+    # 0. Generate .mod file if missing
+    _ensure_mod_file()
+
     # 1. Check module directory structure
     print("1. Module directory structure:")
-    _check("dcc_mcp_maya.mod exists", (MODULE_ROOT / "dcc_mcp_maya.mod").is_file())
+    _check("module-info.json exists", (MODULE_ROOT / "module-info.json").is_file())
     _check("plug-ins/dcc_mcp_maya.py exists", (MODULE_ROOT / "plug-ins" / "dcc_mcp_maya.py").is_file())
     _check("python/dcc_mcp_maya/ exists", (MODULE_ROOT / "python" / "dcc_mcp_maya").is_dir())
     _check("python/dcc_mcp_core/ exists", (MODULE_ROOT / "python" / "dcc_mcp_core").is_dir())
@@ -382,10 +455,10 @@ def assemble(project_root: Path, version: str, platform: str, output: Path) -> P
                 has_cp37 = True
     print("  Extracted dcc_mcp_core to python/" + (" and python37/" if has_cp37 else ""))
 
-    # 1. Generate .mod file
-    mod_content = generate_mod_file(version, platform, has_cp37=has_cp37)
-    (module_dir / "dcc_mcp_maya.mod").write_text(mod_content, encoding="utf-8")
-    print(f"  Generated dcc_mcp_maya.mod (platform={platform}, version={version})")
+    # 1. Generate module-info.json (the .mod file is generated at install time)
+    info_content = generate_module_info(version, has_cp37=has_cp37)
+    (module_dir / "module-info.json").write_text(info_content, encoding="utf-8")
+    print(f"  Generated module-info.json (version={version}, has_cp37={has_cp37})")
 
     # 2. Copy Maya plugin
     plugin_src = project_root / "maya" / "plugin" / "dcc_mcp_maya.py"

--- a/packaging/assemble_mod.py
+++ b/packaging/assemble_mod.py
@@ -194,8 +194,144 @@ def generate_mod_file(version: str, platform: str, has_cp37: bool = False) -> st
             lines.append("PYTHONPATH+:=python37")
         else:
             lines.append("PYTHONPATH+:=python")
+        # Add plug-ins/ to MAYA_PLUG_IN_PATH so loadPlugin finds the .py
+        lines.append("PLUG_IN_PATH+:=plug-ins")
 
     return "\n".join(lines) + "\n"
+
+
+def _generate_post_install(module_dir: Path) -> None:
+    """Generate a post_install.py script that verifies the module works.
+
+    The script is designed to be run with mayapy::
+
+        mayapy <module_dir>/post_install.py
+
+    It verifies that:
+    1. The module's python/ directory is on sys.path
+    2. dcc_mcp_maya and dcc_mcp_core are importable
+    3. dcc_mcp_maya.start_server is available
+    4. The MCP server can start and stop cleanly
+    """
+    script = '''#!/usr/bin/env python
+"""Post-install verification for dcc-mcp-maya module.
+
+Run with mayapy (Maya's Python interpreter)::
+
+    mayapy post_install.py
+
+This script verifies the .mod module installation is correct.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+MODULE_ROOT = Path(__file__).resolve().parent
+
+# Ensure python/ is on sys.path (needed for mayapy standalone which
+# does not process .mod PYTHONPATH directives)
+_python_dir = MODULE_ROOT / "python"
+if str(_python_dir) not in sys.path:
+    sys.path.insert(0, str(_python_dir))
+
+errors = []
+
+
+def _check(label, condition, detail=""):
+    if condition:
+        print(f"  [PASS] {label}")
+    else:
+        msg = f"  [FAIL] {label}"
+        if detail:
+            msg += f" — {detail}"
+        print(msg)
+        errors.append(label)
+
+
+def main():
+    print("=" * 50)
+    print(" dcc-mcp-maya Post-Install Verification")
+    print("=" * 50)
+    print()
+
+    # 1. Check module directory structure
+    print("1. Module directory structure:")
+    _check("dcc_mcp_maya.mod exists", (MODULE_ROOT / "dcc_mcp_maya.mod").is_file())
+    _check("plug-ins/dcc_mcp_maya.py exists", (MODULE_ROOT / "plug-ins" / "dcc_mcp_maya.py").is_file())
+    _check("python/dcc_mcp_maya/ exists", (MODULE_ROOT / "python" / "dcc_mcp_maya").is_dir())
+    _check("python/dcc_mcp_core/ exists", (MODULE_ROOT / "python" / "dcc_mcp_core").is_dir())
+    print()
+
+    # 2. Check Python imports
+    print("2. Python package imports:")
+    try:
+        import dcc_mcp_core
+        _check("import dcc_mcp_core", True)
+        _check("dcc_mcp_core version", hasattr(dcc_mcp_core, "__version__"))
+    except ImportError as exc:
+        _check("import dcc_mcp_core", False, str(exc))
+
+    try:
+        import dcc_mcp_maya
+        _check("import dcc_mcp_maya", True)
+        _check("dcc_mcp_maya.start_server", hasattr(dcc_mcp_maya, "start_server"))
+        _check("dcc_mcp_maya.stop_server", hasattr(dcc_mcp_maya, "stop_server"))
+        _check("dcc_mcp_maya.__version__", hasattr(dcc_mcp_maya, "__version__"))
+    except ImportError as exc:
+        _check("import dcc_mcp_maya", False, str(exc))
+        _check("dcc_mcp_maya.start_server", False, "import failed")
+        _check("dcc_mcp_maya.stop_server", False, "import failed")
+        _check("dcc_mcp_maya.__version__", False, "import failed")
+    print()
+
+    # 3. Check Maya standalone (optional, only if maya is available)
+    print("3. Maya integration:")
+    try:
+        import maya.standalone  # noqa: F401
+        maya.standalone.initialize()
+        import maya.cmds as cmds
+        _check("maya.standalone.initialize", True)
+
+        # Test that the plugin can be found after setting MAYA_PLUG_IN_PATH
+        plugins_dir = str(MODULE_ROOT / "plug-ins")
+        current = os.environ.get("MAYA_PLUG_IN_PATH", "")
+        sep = ";" if sys.platform == "win32" else ":"
+        if plugins_dir not in current:
+            os.environ["MAYA_PLUG_IN_PATH"] = plugins_dir + (sep + current if current else "")
+        _check("MAYA_PLUG_IN_PATH updated", True)
+
+        # Test server start/stop in standalone
+        try:
+            handle = dcc_mcp_maya.start_server(port=0)
+            _check("start_server(port=0)", True)
+            url = handle.mcp_url()
+            _check("server URL reachable", url.startswith("http://"))
+            dcc_mcp_maya.stop_server()
+            _check("stop_server()", True)
+        except Exception as exc:
+            _check("start_server/stop_server", False, str(exc))
+    except ImportError:
+        _check("maya.standalone (skipped)", True, "not running under mayapy")
+    print()
+
+    # Summary
+    print("=" * 50)
+    if errors:
+        print(f" FAILED — {len(errors)} check(s) failed:")
+        for e in errors:
+            print(f"   - {e}")
+        sys.exit(1)
+    else:
+        print(" ALL CHECKS PASSED — installation is correct")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()
+'''
+    (module_dir / "post_install.py").write_text(script, encoding="utf-8")
 
 
 def assemble(project_root: Path, version: str, platform: str, output: Path) -> Path:
@@ -294,6 +430,10 @@ def assemble(project_root: Path, version: str, platform: str, output: Path) -> P
             encoding="utf-8",
         )
     print("  Copied install/uninstall scripts and README")
+
+    # 7. Generate post_install.py verification script
+    _generate_post_install(module_dir)
+    print("  Generated post_install.py")
 
     return module_dir
 

--- a/packaging/install.bat
+++ b/packaging/install.bat
@@ -98,6 +98,36 @@ echo.
 echo  Module:   %MOD_DEST%\dcc-mcp-maya
 echo  Plugin:   %MOD_DEST%\dcc-mcp-maya\plug-ins\dcc_mcp_maya.py
 echo.
+
+REM -- Post-install verification --
+echo Running post-install verification...
+set "VERIFY_MAYA="
+for %%Y in (2026 2025 2024 2023 2022) do (
+    if not defined VERIFY_MAYA (
+        if exist "C:\Program Files\Autodesk\Maya%%Y\bin\mayapy.exe" (
+            set "VERIFY_MAYA=C:\Program Files\Autodesk\Maya%%Y\bin\mayapy.exe"
+        )
+    )
+)
+if defined VERIFY_MAYA (
+    echo Using mayapy: %VERIFY_MAYA%
+    "%VERIFY_MAYA%" "%MOD_DEST%\dcc-mcp-maya\post_install.py"
+    if errorlevel 1 (
+        echo.
+        echo WARNING: Post-install verification failed.
+        echo The module files are deployed but may not work correctly.
+        echo Please check the errors above.
+    ) else (
+        echo.
+        echo Post-install verification: PASSED
+    )
+) else (
+    echo  WARNING: No mayapy found — skipping post-install verification.
+    echo  To verify manually, run:
+    echo    mayapy "%MOD_DEST%\dcc-mcp-maya\post_install.py"
+)
+
+echo.
 echo  The plugin will auto-load when Maya starts.
 echo  Alternatively, load it via:
 echo    Window ^> Settings/Preferences ^> Plug-in Manager

--- a/packaging/install.bat
+++ b/packaging/install.bat
@@ -10,7 +10,7 @@ REM -- Resolve script directory (handles spaces) --
 set "SCRIPT_DIR=%~dp0"
 set "MODULE_DIR=%SCRIPT_DIR%dcc-mcp-maya"
 
-if not exist "%MODULE_DIR%\dcc_mcp_maya.mod" (
+if not exist "%MODULE_DIR%\module-info.json" (
     echo ERROR: Module directory not found at:
     echo   %MODULE_DIR%
     echo.
@@ -18,12 +18,23 @@ if not exist "%MODULE_DIR%\dcc_mcp_maya.mod" (
     pause & exit /b 1
 )
 
-REM -- Read version from .mod file --
+REM -- Read version from module-info.json --
 set "VERSION=unknown"
-for /f "tokens=4" %%v in ('findstr /r "^+ MAYAVERSION" "%MODULE_DIR%\dcc_mcp_maya.mod" 2^>nul') do (
-    set "VERSION=%%v"
+for /f "tokens=2 delims=:," %%v in ('findstr /c:"\"version\"" "%MODULE_DIR%\module-info.json"') do (
+    set "VERSION=%%~v"
 )
+set "VERSION=%VERSION: =%"
+set "VERSION=%VERSION:"=%"
 echo  Version: %VERSION%
+
+REM -- Check if python37/ exists (cp37 for Maya 2022) --
+set "HAS_CP37=0"
+if exist "%MODULE_DIR%\python37" set "HAS_CP37=1"
+if "%HAS_CP37%"=="1" (
+    echo  Python 3.7 support: Yes ^(Maya 2022^)
+) else (
+    echo  Python 3.7 support: No
+)
 echo.
 
 REM -- Detect Maya installations --
@@ -57,6 +68,27 @@ if errorlevel 1 (
     echo ERROR: Failed to copy module files.
     pause & exit /b 1
 )
+
+REM -- Generate .mod file dynamically --
+echo Generating dcc_mcp_maya.mod...
+
+set "PLATFORM=win64"
+set "MOD_FILE=%MOD_DEST%\dcc-mcp-maya\dcc_mcp_maya.mod"
+
+(
+if "%HAS_CP37%"=="1" (
+    echo + MAYAVERSION:2022 PLATFORM:%PLATFORM% dcc_mcp_maya %VERSION% .
+    echo PYTHONPATH+:=python37
+    echo PLUG_IN_PATH+:=plug-ins
+)
+for %%Y in (2023 2024 2025 2026) do (
+    echo + MAYAVERSION:%%Y PLATFORM:%PLATFORM% dcc_mcp_maya %VERSION% .
+    echo PYTHONPATH+:=python
+    echo PLUG_IN_PATH+:=plug-ins
+)
+) > "%MOD_FILE%"
+
+echo  Generated %MOD_FILE%
 
 REM -- Deploy userSetup.py --
 set "SCRIPTS_DEST=%USERPROFILE%\Documents\maya\scripts"

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -104,6 +104,40 @@ echo
 echo " Module:   $MOD_DEST/dcc-mcp-maya"
 echo " Plugin:   $MOD_DEST/dcc-mcp-maya/plug-ins/dcc_mcp_maya.py"
 echo
+
+# Post-install verification
+echo "Running post-install verification..."
+VERIFY_MAYAPY=""
+for year in 2026 2025 2024 2023 2022; do
+    CANDIDATES=(
+        "/usr/autodesk/maya${year}/bin/mayapy"
+        "/Applications/Autodesk/maya${year}/Maya.app/Contents/bin/mayapy"
+    )
+    for c in "${CANDIDATES[@]}"; do
+        if [ -x "$c" ]; then
+            VERIFY_MAYAPY="$c"
+            break 2
+        fi
+    done
+done
+
+if [ -n "$VERIFY_MAYAPY" ]; then
+    echo "Using mayapy: $VERIFY_MAYAPY"
+    if "$VERIFY_MAYAPY" "$MOD_DEST/dcc-mcp-maya/post_install.py"; then
+        echo
+        echo "Post-install verification: PASSED"
+    else
+        echo
+        echo "WARNING: Post-install verification failed."
+        echo "The module files are deployed but may not work correctly."
+    fi
+else
+    echo "WARNING: No mayapy found — skipping post-install verification."
+    echo "To verify manually, run:"
+    echo "  mayapy $MOD_DEST/dcc-mcp-maya/post_install.py"
+fi
+
+echo
 echo " The plugin will auto-load when Maya starts."
 echo " Alternatively, load it via:"
 echo "   Window > Settings/Preferences > Plug-in Manager"

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-VERSION="0.3.0"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MODULE_DIR="$SCRIPT_DIR/dcc-mcp-maya"
 
@@ -10,7 +9,7 @@ echo " DCC-MCP-Maya Installer"
 echo "========================================="
 echo
 
-if [ ! -f "$MODULE_DIR/dcc_mcp_maya.mod" ]; then
+if [ ! -f "$MODULE_DIR/module-info.json" ]; then
     echo "ERROR: Module directory not found at:"
     echo "  $MODULE_DIR"
     echo
@@ -18,9 +17,22 @@ if [ ! -f "$MODULE_DIR/dcc_mcp_maya.mod" ]; then
     exit 1
 fi
 
-# Read version from .mod file
-VERSION=$(grep -oP '(?<=dcc_mcp_maya )\d+\.\d+\.\d+' "$MODULE_DIR/dcc_mcp_maya.mod" | head -1 || echo "unknown")
+# Read version from module-info.json
+VERSION=$(python3 -c "
+import json, sys
+with open('$MODULE_DIR/module-info.json') as f:
+    print(json.load(f)['version'])
+" 2>/dev/null || echo "unknown")
 echo " Version: ${VERSION}"
+
+# Check if python37/ exists (cp37 for Maya 2022)
+HAS_CP37=0
+if [ -d "$MODULE_DIR/python37" ]; then
+    HAS_CP37=1
+    echo " Python 3.7 support: Yes (Maya 2022)"
+else
+    echo " Python 3.7 support: No"
+fi
 echo
 
 # Detect Maya installations
@@ -44,13 +56,15 @@ if [ "$FOUND_MAYA" -eq 0 ]; then
     echo
 fi
 
-# Determine platform-specific paths
+# Determine platform-specific paths and .mod platform string
 if [[ "$OSTYPE" == "darwin"* ]]; then
     MOD_DEST="$HOME/Library/Preferences/Autodesk/maya/modules"
     SCRIPTS_DEST="$HOME/Library/Preferences/Autodesk/maya/scripts"
+    PLATFORM="macos"
 else
     MOD_DEST="$HOME/maya/modules"
     SCRIPTS_DEST="$HOME/maya/scripts"
+    PLATFORM="linux"
 fi
 
 # Deploy module directory
@@ -64,6 +78,25 @@ fi
 echo
 echo "Deploying module to: $MOD_DEST/dcc-mcp-maya"
 cp -R "$MODULE_DIR" "$MOD_DEST/dcc-mcp-maya"
+
+# Generate .mod file dynamically
+echo "Generating dcc_mcp_maya.mod..."
+MOD_FILE="$MOD_DEST/dcc-mcp-maya/dcc_mcp_maya.mod"
+
+{
+    if [ "$HAS_CP37" -eq 1 ]; then
+        echo "+ MAYAVERSION:2022 PLATFORM:$PLATFORM dcc_mcp_maya $VERSION ."
+        echo "PYTHONPATH+:=python37"
+        echo "PLUG_IN_PATH+:=plug-ins"
+    fi
+    for year in 2023 2024 2025 2026; do
+        echo "+ MAYAVERSION:$year PLATFORM:$PLATFORM dcc_mcp_maya $VERSION ."
+        echo "PYTHONPATH+:=python"
+        echo "PLUG_IN_PATH+:=plug-ins"
+    done
+} > "$MOD_FILE"
+
+echo " Generated $MOD_FILE"
 
 # Deploy userSetup.py
 mkdir -p "$SCRIPTS_DEST"

--- a/tests/test_assemble_mod.py
+++ b/tests/test_assemble_mod.py
@@ -350,26 +350,31 @@ class TestGenerateModFile:
     def test_win64_all_maya_versions(self):
         content = assemble_mod.generate_mod_file("0.2.2", "win64", has_cp37=True)
         lines = content.strip().split("\n")
-        assert len(lines) == 8  # 4 maya versions * 2 lines each
+        assert len(lines) == 12  # 4 maya versions * 3 lines each (PYTHONPATH + PLUG_IN_PATH)
         assert "MAYAVERSION:2022" in lines[0]
         assert "python37" in lines[1]
-        assert "MAYAVERSION:2023" in lines[2]
-        assert "PYTHONPATH+:=python" in lines[3]
+        assert "PLUG_IN_PATH+:=plug-ins" in lines[2]
+        assert "MAYAVERSION:2023" in lines[3]
+        assert "PYTHONPATH+:=python" in lines[4]
+        assert "PLUG_IN_PATH+:=plug-ins" in lines[5]
 
     def test_win64_no_cp37(self):
         content = assemble_mod.generate_mod_file("0.2.2", "win64", has_cp37=False)
         # All should use python/ (no python37)
         assert "python37" not in content
+        assert "PLUG_IN_PATH+:=plug-ins" in content
 
     def test_macos_skips_2022(self):
         content = assemble_mod.generate_mod_file("0.2.2", "macos", has_cp37=False)
         assert "MAYAVERSION:2022" not in content
         assert "MAYAVERSION:2023" in content
+        assert "PLUG_IN_PATH+:=plug-ins" in content
 
     def test_linux_all_versions(self):
         content = assemble_mod.generate_mod_file("0.2.2", "linux", has_cp37=True)
         assert "MAYAVERSION:2022" in content
         assert "python37" in content
+        assert "PLUG_IN_PATH+:=plug-ins" in content
 
 
 # ── assemble (integration) ──────────────────────────────────────────────────

--- a/tests/test_assemble_mod.py
+++ b/tests/test_assemble_mod.py
@@ -343,12 +343,33 @@ class TestExtractWheel:
         assert not (dest / "dcc_mcp_core-0.12.17.dist-info").exists()
 
 
-# ── generate_mod_file ───────────────────────────────────────────────────────
+# ── generate_module_info / generate_mod_content ───────────────────────────
 
 
-class TestGenerateModFile:
+class TestGenerateModuleInfo:
+    def test_with_cp37(self):
+        content = assemble_mod.generate_module_info("0.2.2", has_cp37=True)
+        import json
+
+        info = json.loads(content)
+        assert info["name"] == "dcc_mcp_maya"
+        assert info["version"] == "0.2.2"
+        assert info["has_cp37"] is True
+        assert info["supported_maya_versions"] == ["2022", "2023", "2024", "2025"]
+
+    def test_without_cp37(self):
+        content = assemble_mod.generate_module_info("0.2.2", has_cp37=False)
+        import json
+
+        info = json.loads(content)
+        assert info["has_cp37"] is False
+        assert "2022" not in info["supported_maya_versions"]
+        assert info["supported_maya_versions"] == ["2023", "2024", "2025"]
+
+
+class TestGenerateModContent:
     def test_win64_all_maya_versions(self):
-        content = assemble_mod.generate_mod_file("0.2.2", "win64", has_cp37=True)
+        content = assemble_mod.generate_mod_content("0.2.2", "win64", ["2022", "2023", "2024", "2025"], has_cp37=True)
         lines = content.strip().split("\n")
         assert len(lines) == 12  # 4 maya versions * 3 lines each (PYTHONPATH + PLUG_IN_PATH)
         assert "MAYAVERSION:2022" in lines[0]
@@ -359,19 +380,18 @@ class TestGenerateModFile:
         assert "PLUG_IN_PATH+:=plug-ins" in lines[5]
 
     def test_win64_no_cp37(self):
-        content = assemble_mod.generate_mod_file("0.2.2", "win64", has_cp37=False)
-        # All should use python/ (no python37)
+        content = assemble_mod.generate_mod_content("0.2.2", "win64", ["2023", "2024", "2025"], has_cp37=False)
         assert "python37" not in content
         assert "PLUG_IN_PATH+:=plug-ins" in content
 
-    def test_macos_skips_2022(self):
-        content = assemble_mod.generate_mod_file("0.2.2", "macos", has_cp37=False)
+    def test_macos_no_2022(self):
+        content = assemble_mod.generate_mod_content("0.2.2", "macos", ["2023", "2024", "2025"], has_cp37=False)
         assert "MAYAVERSION:2022" not in content
         assert "MAYAVERSION:2023" in content
         assert "PLUG_IN_PATH+:=plug-ins" in content
 
     def test_linux_all_versions(self):
-        content = assemble_mod.generate_mod_file("0.2.2", "linux", has_cp37=True)
+        content = assemble_mod.generate_mod_content("0.2.2", "linux", ["2022", "2023", "2024", "2025"], has_cp37=True)
         assert "MAYAVERSION:2022" in content
         assert "python37" in content
         assert "PLUG_IN_PATH+:=plug-ins" in content
@@ -455,11 +475,15 @@ class TestAssemble:
         assert (result / "python37" / "dcc_mcp_core" / "__init__.py").exists()
         assert (result / "python37" / "dcc_mcp_maya" / "__init__.py").exists()
 
-        # Check .mod file uses python37 for Maya 2022
-        mod_content = (result / "dcc_mcp_maya.mod").read_text(encoding="utf-8")
-        assert "python37" in mod_content
-        lines = mod_content.strip().split("\n")
-        assert "PYTHONPATH+:=python37" in lines[1]  # Line after MAYAVERSION:2022
+        # Check module-info.json exists (replaces .mod — generated at install time)
+        assert (result / "module-info.json").exists()
+        import json
+
+        info = json.loads((result / "module-info.json").read_text(encoding="utf-8"))
+        assert info["version"] == "0.2.2"
+        assert info["has_cp37"] is True
+        # .mod file should NOT exist (generated at install time)
+        assert not (result / "dcc_mcp_maya.mod").exists()
 
     def test_macos_no_python37(self, tmp_path):
         project = self._setup_project(tmp_path)
@@ -483,7 +507,7 @@ class TestAssemble:
         assert (result / "python" / "dcc_mcp_core").exists()
         assert not (result / "python37").exists()
 
-    def test_mod_file_structure(self, tmp_path):
+    def test_module_info_structure(self, tmp_path):
         project = self._setup_project(tmp_path)
         output = tmp_path / "output"
         output.mkdir()
@@ -494,14 +518,16 @@ class TestAssemble:
         ):
             result = assemble_mod.assemble(project, "0.2.2", "win64", output)
 
-        # Verify .mod file
-        mod = (result / "dcc_mcp_maya.mod").read_text(encoding="utf-8")
-        assert "MAYAVERSION:2022" in mod
-        assert "MAYAVERSION:2023" in mod
-        assert "MAYAVERSION:2024" in mod
-        assert "MAYAVERSION:2025" in mod
-        assert "PLATFORM:win64" in mod
-        assert "dcc_mcp_maya 0.2.2" in mod
+        # Verify module-info.json
+        import json
+
+        info = json.loads((result / "module-info.json").read_text(encoding="utf-8"))
+        assert info["name"] == "dcc_mcp_maya"
+        assert info["version"] == "0.2.2"
+        assert "2022" in info["supported_maya_versions"]
+        assert "2023" in info["supported_maya_versions"]
+        assert "2024" in info["supported_maya_versions"]
+        assert "2025" in info["supported_maya_versions"]
 
     def test_plugin_and_usersetup_copied(self, tmp_path):
         project = self._setup_project(tmp_path)
@@ -623,7 +649,7 @@ class TestAssembleLive:
         result = assemble_mod.assemble(PROJECT_ROOT, "0.2.2", "win64", output)
 
         # Verify core structure
-        assert (result / "dcc_mcp_maya.mod").exists()
+        assert (result / "module-info.json").exists()
         assert (result / "python" / "dcc_mcp_core" / "__init__.py").exists()
         assert (result / "python" / "dcc_mcp_core" / "_core.pyd").exists()
         assert (result / "python" / "dcc_mcp_maya" / "__init__.py").exists()

--- a/tests/test_e2e_maya_standalone.py
+++ b/tests/test_e2e_maya_standalone.py
@@ -46,7 +46,66 @@ pytestmark = pytest.mark.e2e
 # Helpers
 # ---------------------------------------------------------------------------
 
-_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_maya" / "skills"
+
+# Resolve skills root: prefer the installed package location (packaged .mod
+# module), fall back to the source tree (development / pip install -e).
+def _resolve_skills_root() -> Path:
+    """Find the skills/ directory from either installed package or source tree."""
+    # 1. Installed package (works with packaged .mod module)
+    try:
+        import dcc_mcp_maya  # noqa: PLC0415
+
+        package_dir = Path(dcc_mcp_maya.__file__).resolve().parent
+        skills_dir = package_dir / "skills"
+        if skills_dir.is_dir():
+            return skills_dir
+    except ImportError:
+        pass
+
+    # 2. Source tree (development / pip install -e)
+    src_skills = Path(__file__).resolve().parent.parent / "src" / "dcc_mcp_maya" / "skills"
+    if src_skills.is_dir():
+        return src_skills
+
+    # 3. Environment variable override
+    import os  # noqa: PLC0415
+
+    env_dir = os.environ.get("DCC_MCP_MAYA_SKILL_PATHS", "")
+    if env_dir:
+        first = Path(env_dir.split(os.pathsep)[0])
+        if first.is_dir():
+            return first
+
+    raise RuntimeError("Cannot find dcc_mcp_maya skills/ directory — check installation")
+
+
+_SKILLS_ROOT = _resolve_skills_root()
+
+
+# Ensure dcc_mcp_maya is importable in packaged module mode
+# (Maya standalone does not process .mod PYTHONPATH directives)
+def _ensure_package_importable() -> None:
+    """Add the packaged module's python/ to sys.path if needed."""
+    import sys  # noqa: PLC0415
+
+    try:
+        import dcc_mcp_maya  # noqa: F401
+
+        return  # already importable
+    except ImportError:
+        pass
+
+    # Try the .mod module directory from environment variable
+    import os  # noqa: PLC0415
+
+    mod_dir = os.environ.get("DCC_MCP_MAYA_MOD_DIR", "")
+    if mod_dir:
+        python_dir = Path(mod_dir) / "python"
+        if python_dir.is_dir() and str(python_dir) not in sys.path:
+            sys.path.insert(0, str(python_dir))
+
+
+_ensure_package_importable()
 
 
 def _new_scene():


### PR DESCRIPTION
## Summary

- Fix packaged `.mod` module failing in Maya standalone/batch mode due to unprocessed `.mod` directives (`PYTHONPATH+:=`, `PLUG_IN_PATH+:=`)
- Plugin (`dcc_mcp_maya.py`) now auto-resolves and adds `python/` to `sys.path` via `_ensure_package_importable()`
- `userSetup.py` now configures both `sys.path` and `MAYA_PLUG_IN_PATH` via `_setup_module_paths()` for standalone/batch
- `.mod` file includes `PLUG_IN_PATH+:=plug-ins` directive so Maya GUI mode also finds the plugin
- Add `post_install.py` verification script generated by `assemble_mod.py`
- Install scripts (`install.bat`/`install.sh`) now run post-install verification
- E2E CI switched from `pip install -e` to testing the packaged `.mod` module (catches packaging issues)
- Fix `MAYA_PLUG_IN_PATH` separator: platform-aware (`;` on Windows, `:` on Linux/macOS)

## Test plan

- [x] Unit tests: 3004 passed (non-e2e)
- [x] Lint: ruff check + format pass
- [x] Local `assemble_mod.py` integration test: win64 module assembles correctly
- [x] Packaged module imports verified locally (`dcc_mcp_maya`, `dcc_mcp_core` importable)
- [x] Path resolution logic verified for both Maya 2022 (python37/) and 2023+ (python/)
- [ ] E2E CI: mayapy Docker tests with packaged .mod module