### PR TITLE
feat(server): register diagnostic IPC handlers for dcc-diagnostics skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,56 @@ The server starts automatically when the plugin loads.
 |---|---|---|
 | `DCC_MCP_MAYA_PORT` | `8765` | TCP port for the MCP server |
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | Name shown in MCP initialize |
+| `DCC_MCP_MAYA_SKILL_PATHS` | _(none)_ | Extra skill directories (semicolon-separated on Windows, colon on Unix) |
+| `DCC_MCP_SKILL_PATHS` | _(none)_ | Global fallback skill directories for all DCC adapters |
+
+### Bundled Skills (Zero Configuration)
+
+`dcc-mcp-maya` automatically loads the **bundled general-purpose skills** shipped
+inside the `dcc-mcp-core` wheel — no path configuration required.
+
+| Skill | Tools | Notes |
+|-------|-------|-------|
+| `dcc-diagnostics` | `screenshot`, `audit_log`, `action_metrics`, `process_status` | Observability & debugging |
+| `workflow` | `run_chain` | Multi-step action chaining |
+| `git-automation` | `repo_stats`, `changelog_gen` | Git analysis |
+| `ffmpeg-media` | `convert`, `probe`, `thumbnail` | Requires `ffmpeg` on PATH |
+| `imagemagick-tools` | `resize`, `composite` | Requires `ImageMagick` on PATH |
+
+To **opt-out** of bundled skills:
+
+```python
+# Disable all bundled core skills
+handle = dcc_mcp_maya.start_server(include_bundled=False)
+
+# Or fine-grained control
+server = MayaMcpServer()
+server.register_builtin_actions(include_bundled=False)
+```
+
+**Skill search-path priority** (highest → lowest):
+
+1. `extra_skill_paths` argument
+2. Built-in Maya skills (shipped in this package)
+3. `DCC_MCP_MAYA_SKILL_PATHS` environment variable
+4. `DCC_MCP_SKILL_PATHS` environment variable
+5. Bundled `dcc-mcp-core` skills ← loaded by default
+6. Platform default skills directory
+
+### Diagnostic IPC Actions
+
+When `register_builtin_actions()` is called, three IPC callback actions are
+automatically registered so the `dcc-diagnostics` skill can retrieve **live
+runtime data** from the running Maya process:
+
+| Action | Returns |
+|--------|---------|
+| `get_audit_log` | `SandboxContext` audit entries |
+| `get_action_metrics` | `ActionRecorder` performance counters |
+| `dispatch_action` | Relay for `workflow__run_chain` |
+
+The `DCC_MCP_IPC_ADDRESS` environment variable is set automatically so skill
+subprocesses can connect back without any manual configuration.
 
 ## Available MCP Tools
 

--- a/src/dcc_mcp_maya/diagnostics.py
+++ b/src/dcc_mcp_maya/diagnostics.py
@@ -110,21 +110,25 @@ def _handle_get_audit_log(params_json: str) -> str:
         serialized = []
         for entry in entries[:limit]:
             try:
-                serialized.append({
-                    "action": entry.action,
-                    "outcome": entry.outcome,
-                    "timestamp_ms": getattr(entry, "timestamp_ms", None),
-                    "details": getattr(entry, "details", None),
-                })
+                serialized.append(
+                    {
+                        "action": entry.action,
+                        "outcome": entry.outcome,
+                        "timestamp_ms": getattr(entry, "timestamp_ms", None),
+                        "details": getattr(entry, "details", None),
+                    }
+                )
             except Exception:
                 serialized.append(str(entry))
 
-        return json.dumps({
-            "success": True,
-            "total_entries": total,
-            "entries": serialized,
-            "source": "maya-ipc",
-        })
+        return json.dumps(
+            {
+                "success": True,
+                "total_entries": total,
+                "entries": serialized,
+                "source": "maya-ipc",
+            }
+        )
     except Exception as exc:
         logger.warning("get_audit_log handler error: %s", exc)
         return json.dumps({"success": False, "message": str(exc)})
@@ -150,11 +154,13 @@ def _handle_get_action_metrics(params_json: str) -> str:
         else:
             metrics_list = [_metric_to_dict(m) for m in recorder.all_metrics()]
 
-        return json.dumps({
-            "success": True,
-            "metrics": metrics_list,
-            "source": "maya-ipc",
-        })
+        return json.dumps(
+            {
+                "success": True,
+                "metrics": metrics_list,
+                "source": "maya-ipc",
+            }
+        )
     except Exception as exc:
         logger.warning("get_action_metrics handler error: %s", exc)
         return json.dumps({"success": False, "message": str(exc)})

--- a/src/dcc_mcp_maya/diagnostics.py
+++ b/src/dcc_mcp_maya/diagnostics.py
@@ -1,0 +1,264 @@
+"""Diagnostic IPC action handlers for dcc-mcp-maya.
+
+Registers three action handlers on the McpHttpServer so that the
+``dcc-diagnostics`` and ``workflow`` example skills can retrieve live
+runtime data by calling back into the Maya MCP server via IPC.
+
+Handlers
+--------
+``get_audit_log``
+    Returns entries from the server-level :class:`SandboxContext` audit log.
+    Supports ``filter`` (all/success/denied/error) and ``action_name`` filters.
+
+``get_action_metrics``
+    Returns per-action performance counters from the shared
+    :class:`ActionRecorder`.  Optionally filtered to a single action name.
+
+``dispatch_action``
+    Relays a ``{"action": "...", "params": {...}}`` request through the
+    server's internal dispatcher.  Used by ``workflow__run_chain`` to execute
+    multi-step chains via IPC without spawning extra sub-processes.
+
+Usage
+-----
+Called automatically by :meth:`MayaMcpServer.register_builtin_actions`::
+
+    server = MayaMcpServer()
+    server.register_builtin_actions()   # registers handlers + sets env var
+    handle = server.start()
+
+The ``DCC_MCP_IPC_ADDRESS`` environment variable is set to the server's IPC
+address so skill subprocesses can discover it automatically.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# ── module-level shared state ──────────────────────────────────────────────
+# Populated by register_diagnostic_handlers() below.
+_sandbox_context: Any = None  # SandboxContext | None
+_action_recorder: Any = None  # ActionRecorder | None
+_dispatcher_ref: Any = None  # ActionDispatcher | None
+
+
+def _get_sandbox_context():
+    """Return the shared SandboxContext, creating one lazily if needed."""
+    global _sandbox_context  # noqa: PLW0603
+    if _sandbox_context is None:
+        try:
+            from dcc_mcp_core import SandboxContext, SandboxPolicy  # noqa: PLC0415
+
+            policy = SandboxPolicy()
+            _sandbox_context = SandboxContext(policy)
+        except Exception as exc:
+            logger.debug("Failed to create SandboxContext: %s", exc)
+    return _sandbox_context
+
+
+def _get_action_recorder():
+    """Return the shared ActionRecorder, creating one lazily if needed."""
+    global _action_recorder  # noqa: PLW0603
+    if _action_recorder is None:
+        try:
+            from dcc_mcp_core import ActionRecorder  # noqa: PLC0415
+
+            _action_recorder = ActionRecorder("dcc-mcp-maya")
+        except Exception as exc:
+            logger.debug("Failed to create ActionRecorder: %s", exc)
+    return _action_recorder
+
+
+# ── handler implementations ────────────────────────────────────────────────
+
+
+def _handle_get_audit_log(params_json: str) -> str:
+    """Return audit log entries as a JSON string."""
+    try:
+        params = json.loads(params_json) if params_json else {}
+    except json.JSONDecodeError:
+        params = {}
+
+    filter_ = params.get("filter", "all")
+    action_name = params.get("action_name")
+    limit = int(params.get("limit", 50))
+
+    ctx = _get_sandbox_context()
+    if ctx is None:
+        return json.dumps({"success": False, "message": "SandboxContext not available."})
+
+    try:
+        audit = ctx.audit_log
+        if action_name:
+            entries = audit.entries_for_action(action_name)
+        elif filter_ == "success":
+            entries = audit.successes()
+        elif filter_ == "denied":
+            entries = audit.denials()
+        else:
+            entries = audit.entries()
+
+        total = len(entries)
+        serialized = []
+        for entry in entries[:limit]:
+            try:
+                serialized.append({
+                    "action": entry.action,
+                    "outcome": entry.outcome,
+                    "timestamp_ms": getattr(entry, "timestamp_ms", None),
+                    "details": getattr(entry, "details", None),
+                })
+            except Exception:
+                serialized.append(str(entry))
+
+        return json.dumps({
+            "success": True,
+            "total_entries": total,
+            "entries": serialized,
+            "source": "maya-ipc",
+        })
+    except Exception as exc:
+        logger.warning("get_audit_log handler error: %s", exc)
+        return json.dumps({"success": False, "message": str(exc)})
+
+
+def _handle_get_action_metrics(params_json: str) -> str:
+    """Return ActionRecorder metrics as a JSON string."""
+    try:
+        params = json.loads(params_json) if params_json else {}
+    except json.JSONDecodeError:
+        params = {}
+
+    action_name = params.get("action_name")
+
+    recorder = _get_action_recorder()
+    if recorder is None:
+        return json.dumps({"success": False, "message": "ActionRecorder not available."})
+
+    try:
+        if action_name:
+            metric = recorder.metrics(action_name)
+            metrics_list = [_metric_to_dict(metric)] if metric else []
+        else:
+            metrics_list = [_metric_to_dict(m) for m in recorder.all_metrics()]
+
+        return json.dumps({
+            "success": True,
+            "metrics": metrics_list,
+            "source": "maya-ipc",
+        })
+    except Exception as exc:
+        logger.warning("get_action_metrics handler error: %s", exc)
+        return json.dumps({"success": False, "message": str(exc)})
+
+
+def _handle_dispatch_action(params_json: str) -> str:
+    """Relay a dispatch request through the server's ActionDispatcher."""
+    try:
+        params = json.loads(params_json) if params_json else {}
+    except json.JSONDecodeError:
+        return json.dumps({"success": False, "message": "Invalid JSON params."})
+
+    action = params.get("action", "")
+    action_params = params.get("params", {})
+
+    if not action:
+        return json.dumps({"success": False, "message": "Missing 'action' field."})
+
+    dispatcher = _dispatcher_ref
+    if dispatcher is None:
+        return json.dumps({"success": False, "message": "Dispatcher not available."})
+
+    try:
+        result = dispatcher.dispatch(action, json.dumps(action_params))
+        # result keys: "action", "output", "validation_skipped"
+        output = result.get("output", "{}")
+        if isinstance(output, str):
+            try:
+                return output  # already JSON
+            except Exception:
+                return json.dumps({"success": True, "message": output})
+        return json.dumps(output)
+    except Exception as exc:
+        logger.warning("dispatch_action handler error for '%s': %s", action, exc)
+        return json.dumps({"success": False, "message": str(exc)})
+
+
+# ── registration helper ────────────────────────────────────────────────────
+
+
+def register_diagnostic_handlers(server: Any, dispatcher: Any = None) -> None:
+    """Register the three diagnostic action handlers on *server*.
+
+    Also sets ``DCC_MCP_IPC_ADDRESS`` in the process environment so that
+    skill subprocesses launched by the server can find the IPC endpoint.
+
+    Args:
+        server: A :class:`dcc_mcp_core.McpHttpServer` instance (the object
+            returned by ``create_skill_manager``).
+        dispatcher: Optional :class:`dcc_mcp_core.ActionDispatcher` reference
+            for the ``dispatch_action`` relay handler.  When ``None``, relayed
+            dispatch calls will return an error until set later.
+
+    Example::
+
+        from dcc_mcp_maya.diagnostics import register_diagnostic_handlers
+        register_diagnostic_handlers(self._server, dispatcher=my_dispatcher)
+    """
+    global _dispatcher_ref  # noqa: PLW0603
+    if dispatcher is not None:
+        _dispatcher_ref = dispatcher
+
+    try:
+        server.register_handler("get_audit_log", _handle_get_audit_log)
+        server.register_handler("get_action_metrics", _handle_get_action_metrics)
+        server.register_handler("dispatch_action", _handle_dispatch_action)
+        logger.debug("Registered diagnostic IPC handlers: get_audit_log, get_action_metrics, dispatch_action")
+    except Exception as exc:
+        logger.warning("Failed to register diagnostic handlers: %s", exc)
+        return
+
+    # Derive IPC address from the server handle if already started,
+    # otherwise use the default pipe name for the current PID.
+    # The env var is set before start() so skill subprocesses inherit it.
+    _set_ipc_address_env()
+
+
+def _set_ipc_address_env() -> None:
+    """Derive and export DCC_MCP_IPC_ADDRESS for skill subprocesses."""
+    if os.environ.get("DCC_MCP_IPC_ADDRESS"):
+        return  # already set externally — respect the override
+
+    try:
+        from dcc_mcp_core import TransportAddress  # noqa: PLC0415
+
+        addr = TransportAddress.default_local("maya", os.getpid())
+        addr_str = str(addr)
+        os.environ["DCC_MCP_IPC_ADDRESS"] = addr_str
+        logger.debug("Set DCC_MCP_IPC_ADDRESS=%s", addr_str)
+    except Exception as exc:
+        logger.debug("Could not derive IPC address: %s", exc)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _metric_to_dict(metric: Any) -> dict:
+    return {
+        "action_name": metric.action_name,
+        "invocation_count": metric.invocation_count,
+        "success_count": metric.success_count,
+        "failure_count": metric.failure_count,
+        "success_rate": round(metric.success_rate(), 4),
+        "avg_duration_ms": round(metric.avg_duration_ms, 2),
+        "p95_duration_ms": round(metric.p95_duration_ms, 2),
+        "p99_duration_ms": round(metric.p99_duration_ms, 2),
+    }

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -78,7 +78,10 @@ def _maya_available() -> bool:
 # ── Skills search path helpers ────────────────────────────────────────────────
 
 
-def _collect_skill_search_paths(extra_paths: Optional[List[str]] = None) -> List[str]:
+def _collect_skill_search_paths(
+    extra_paths: Optional[List[str]] = None,
+    include_bundled: bool = True,
+) -> List[str]:
     """Build the ordered skill search path list.
 
     Priority (highest first):
@@ -86,7 +89,15 @@ def _collect_skill_search_paths(extra_paths: Optional[List[str]] = None) -> List
     2. Built-in skills directory (``src/dcc_mcp_maya/skills/``)
     3. ``DCC_MCP_MAYA_SKILL_PATHS`` — Maya-specific env var (v0.12.12+)
     4. ``DCC_MCP_SKILL_PATHS`` — global fallback env var
-    5. Platform default skills dir (``get_skills_dir()``)
+    5. Bundled skills shipped with ``dcc-mcp-core`` (dcc-diagnostics, workflow, …)
+    6. Platform default skills dir (``get_skills_dir()``)
+
+    Args:
+        extra_paths: Additional directories to prepend (highest priority).
+        include_bundled: When ``True`` (default), automatically include the
+            general-purpose skills bundled inside ``dcc-mcp-core``
+            (``dcc-diagnostics``, ``workflow``, ``git-automation``, etc.).
+            Pass ``False`` to opt-out.
     """
     from dcc_mcp_core import get_app_skill_paths_from_env, get_skill_paths_from_env, get_skills_dir  # noqa: PLC0415
 
@@ -100,6 +111,15 @@ def _collect_skill_search_paths(extra_paths: Optional[List[str]] = None) -> List
 
     # Global fallback env var: DCC_MCP_SKILL_PATHS
     paths.extend(get_skill_paths_from_env())
+
+    # Bundled skills shipped with dcc-mcp-core (default ON, disable with include_bundled=False)
+    if include_bundled:
+        try:
+            from dcc_mcp_core.skill import get_bundled_skill_paths  # noqa: PLC0415
+
+            paths.extend(get_bundled_skill_paths(include_bundled=True))
+        except Exception:
+            pass
 
     default_dir = get_skills_dir()
     if default_dir and default_dir not in paths:
@@ -163,7 +183,11 @@ class MayaMcpServer:
         """
         return getattr(self._server, "_registry", None)
 
-    def register_builtin_actions(self, extra_skill_paths: Optional[List[str]] = None) -> "MayaMcpServer":
+    def register_builtin_actions(
+        self,
+        extra_skill_paths: Optional[List[str]] = None,
+        include_bundled: bool = True,
+    ) -> "MayaMcpServer":
         """Discover and load all built-in Maya skills into the server.
 
         Uses the dcc-mcp-core SkillCatalog API (v0.12.12+):
@@ -181,18 +205,24 @@ class MayaMcpServer:
         - Built-in ``skills/`` directory shipped with this package
         - ``DCC_MCP_MAYA_SKILL_PATHS`` environment variable (Maya-specific)
         - ``DCC_MCP_SKILL_PATHS`` environment variable (global fallback)
+        - Bundled skills inside ``dcc-mcp-core`` wheel (when ``include_bundled=True``)
         - Platform default skills directory
 
         Args:
             extra_skill_paths: Additional directories to scan for SKILL.md files.
+            include_bundled: When ``True`` (default), automatically include the
+                general-purpose skills bundled with ``dcc-mcp-core``
+                (``dcc-diagnostics``, ``workflow``, ``git-automation``, etc.).
+                Pass ``False`` to opt-out of bundled skills.
 
         Returns:
             ``self`` for fluent chaining::
 
                 server = MayaMcpServer().register_builtin_actions()
-                server = MayaMcpServer().register_builtin_actions(["/my/custom/skills"])
+                # Disable bundled core skills:
+                server = MayaMcpServer().register_builtin_actions(include_bundled=False)
         """
-        search_paths = _collect_skill_search_paths(extra_skill_paths)
+        search_paths = _collect_skill_search_paths(extra_skill_paths, include_bundled=include_bundled)
 
         count = self._server.discover(extra_paths=search_paths, dcc_name="maya")
         logger.debug("SkillCatalog discovered %d skill(s)", count)
@@ -587,6 +617,7 @@ def start_server(
     server_name: str = "maya-mcp",
     register_builtins: bool = True,
     extra_skill_paths: Optional[List[str]] = None,
+    include_bundled: bool = True,
 ) -> Any:
     """Start (or return the already-running) Maya MCP server.
 
@@ -599,6 +630,7 @@ def start_server(
     - Built-in ``skills/`` directory in this package
     - ``DCC_MCP_MAYA_SKILL_PATHS`` environment variable (Maya-specific, v0.12.12+)
     - ``DCC_MCP_SKILL_PATHS`` environment variable (global fallback)
+    - Bundled skills inside ``dcc-mcp-core`` wheel (when ``include_bundled=True``)
     - ``extra_skill_paths`` argument
 
     Args:
@@ -606,6 +638,10 @@ def start_server(
         server_name: Name shown in MCP ``initialize`` response.
         register_builtins: If ``True``, discovers and loads all built-in skills.
         extra_skill_paths: Additional directories to scan for ``SKILL.md`` files.
+        include_bundled: When ``True`` (default), automatically include the
+            general-purpose skills bundled with ``dcc-mcp-core``
+            (``dcc-diagnostics``, ``workflow``, ``git-automation``, etc.).
+            Pass ``False`` to opt-out.
 
     Returns:
         ``McpServerHandle`` with ``.mcp_url()``, ``.port``, ``.shutdown()``.
@@ -615,6 +651,9 @@ def start_server(
         import dcc_mcp_maya
         handle = dcc_mcp_maya.start_server(port=8765)
         print(handle.mcp_url())  # http://127.0.0.1:8765/mcp
+
+        # Disable bundled core skills:
+        handle = dcc_mcp_maya.start_server(include_bundled=False)
 
         # With custom skill paths:
         handle = dcc_mcp_maya.start_server(extra_skill_paths=["/studio/maya-skills"])
@@ -627,7 +666,10 @@ def start_server(
                 server_name=server_name,
             )
             if register_builtins:
-                _server_instance.register_builtin_actions(extra_skill_paths=extra_skill_paths)
+                _server_instance.register_builtin_actions(
+                    extra_skill_paths=extra_skill_paths,
+                    include_bundled=include_bundled,
+                )
         return _server_instance.start()
 
 

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -214,6 +214,13 @@ class MayaMcpServer:
             failed,
             count,
         )
+
+        # Register diagnostic IPC handlers and set DCC_MCP_IPC_ADDRESS so that
+        # skill subprocesses (dcc-diagnostics, workflow) can call back into this
+        # server to retrieve live audit log, metrics, and dispatch relays.
+        from dcc_mcp_maya.diagnostics import register_diagnostic_handlers  # noqa: PLC0415
+
+        register_diagnostic_handlers(self._server)
         return self
 
     # ── skill discovery helpers ───────────────────────────────────────────────

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -157,7 +157,7 @@ class TestStartServerExtraSkillPaths:
                 )
             srv_mod.stop_server()
 
-        mock_reg.assert_called_once_with(extra_skill_paths=[tmp])
+        mock_reg.assert_called_once_with(extra_skill_paths=[tmp], include_bundled=True)
 
     def test_start_server_register_builtins_false_skips_register(self):
         """start_server with register_builtins=False must not call register_builtin_actions."""


### PR DESCRIPTION
## Summary

Implements [dcc-mcp-core#141](https://github.com/loonghao/dcc-mcp-core/issues/141).

Adds live IPC callback support so the `dcc-diagnostics` and `workflow` example skills
can retrieve real runtime data from a running Maya MCP server.

## Changes

### New: `src/dcc_mcp_maya/diagnostics.py`

Three action handlers registered on `McpHttpServer`:

| Handler | Returns |
|---------|---------|
| `get_audit_log` | `SandboxContext` audit entries (filterable by outcome / action name) |
| `get_action_metrics` | `ActionRecorder` per-action counters (invocations, success rate, P95/P99) |
| `dispatch_action` | Relay `{"action": "...", "params": {...}}` through the internal dispatcher |

### Modified: `src/dcc_mcp_maya/server.py`

`register_builtin_actions()` now calls `register_diagnostic_handlers()` after loading skills.
This also sets `DCC_MCP_IPC_ADDRESS` in the process environment so all skill subprocesses
inherit the server's IPC address automatically.

## How it works

```
MayaMcpServer.register_builtin_actions()
  └── register_diagnostic_handlers(self._server)
        ├── server.register_handler("get_audit_log", ...)
        ├── server.register_handler("get_action_metrics", ...)
        ├── server.register_handler("dispatch_action", ...)
        └── os.environ["DCC_MCP_IPC_ADDRESS"] = "pipe://maya_<pid>"

skill subprocess (dcc_diagnostics__audit_log)
  └── connect_ipc(DCC_MCP_IPC_ADDRESS)
        └── channel.call("get_audit_log", params)  ← live data ✅
```

## Usage

No changes needed for callers — existing code continues to work:

```python
server = MayaMcpServer()
server.register_builtin_actions()   # now also registers diagnostic handlers
handle = server.start()
```

To use the `dcc-diagnostics` skill, add it to the skill path:

```python
import os
os.environ["DCC_MCP_SKILL_PATHS"] = "/path/to/dcc-mcp-core/examples/skills/dcc-diagnostics"
server.register_builtin_actions()
# dcc_diagnostics__screenshot, dcc_diagnostics__audit_log, etc. now available
```