### PR TITLE
ci(codecov): add informational coverage reporting with 80% baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,15 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run tests
-        run: pytest tests/ -v --tb=short
+        run: pytest tests/ -v --tb=short --cov=dcc_mcp_maya --cov-report=xml --cov-report=term
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Maya plugin for the [DCC Model Context Protocol](https://github.com/loonghao/dcc
 Embeds a standards-compliant **MCP Streamable HTTP server** (2025-03-26 spec) directly inside Maya — no external gateway or separate IPC process required.
 
 [![CI](https://github.com/loonghao/dcc-mcp-maya/actions/workflows/ci.yml/badge.svg)](https://github.com/loonghao/dcc-mcp-maya/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/loonghao/dcc-mcp-maya/graph/badge.svg)](https://codecov.io/gh/loonghao/dcc-mcp-maya)
 [![PyPI](https://img.shields.io/pypi/v/dcc-mcp-maya)](https://pypi.org/project/dcc-mcp-maya/)
 [![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-maya)](https://pypi.org/project/dcc-mcp-maya/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,39 @@
+# Codecov configuration
+# Docs: https://docs.codecov.com/docs/codecov-yaml
+#
+# Coverage is reported informationally only — it surfaces as a PR comment
+# and a GitHub check, but never blocks the merge.
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+        informational: true
+        only_pulls: false
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+        informational: true
+
+comment:
+  layout: "header, diff, flags, components, footer"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "tests/**"
+  - "examples/**"
+  - "docs/**"
+  - "maya/plugin/**"


### PR DESCRIPTION
## Summary

Ports the Codecov integration that was prepared during #57 but landed a few minutes after that PR was merged. Restores a single-commit, rebased version on top of current `main`.

## Changes

### `codecov.yml` (new)
- Project & patch coverage targets at **80%** with 1% threshold.
- `informational: true` on both — coverage **never blocks** the PR; failures surface only as an informational status + PR comment.
- PR comment layout includes diff, flags, and components.
- Ignores `tests/`, `examples/`, `docs/`, `maya/plugin/` from coverage metrics.

### `.github/workflows/ci.yml`
- Test step now emits `coverage.xml`: `pytest --cov=dcc_mcp_maya --cov-report=xml --cov-report=term`.
- New step on the `ubuntu-latest` / Python 3.12 matrix point uploads `coverage.xml` via `codecov/codecov-action@v5` with `fail_ci_if_error: false`.

### `README.md`
- Codecov badge added next to the CI badge.

## Rationale

Current measured baseline is ~99%, well above the 80% target. Setting the target deliberately low leaves headroom for routine additions without producing red coverage comments on every PR, while still reporting the real number in the PR comment and badge.

## Verification

- Local: `pytest --cov=dcc_mcp_maya --cov-report=xml` completes and writes `coverage.xml`.
- `codecov.yml` is a clean copy of the file previously reviewed on PR #57.

No runtime code changes.