### PR TITLE
fix: update justfile to use create_skill_server (renamed in core 0.13+)

### DIFF
--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ default:
 @verify-deps:
     echo "🔍 Verifying dependency installation..."
     python -c "from dcc_mcp_maya import start_server; print('✓ dcc_mcp_maya')"
-    python -c "from dcc_mcp_core import create_skill_manager; print('✓ dcc_mcp_core')"
+    python -c "from dcc_mcp_core import create_skill_server; print('✓ dcc_mcp_core')"
     python -c "import pytest; print('✓ pytest')"
     python -c "import requests; print('✓ requests')"
     echo "✅ All core dependencies verified"
@@ -196,7 +196,7 @@ lint-all: lint lint-skills
     echo ""
     echo "Trying imports:"
     python -c "from dcc_mcp_maya import start_server; print('✓ dcc_mcp_maya imports OK')" 2>&1 || echo "✗ dcc_mcp_maya import failed"
-    python -c "from dcc_mcp_core import create_skill_manager; print('✓ dcc_mcp_core imports OK')" 2>&1 || echo "✗ dcc_mcp_core import failed"
+    python -c "from dcc_mcp_core import create_skill_server; print('✓ dcc_mcp_core imports OK')" 2>&1 || echo "✗ dcc_mcp_core import failed"
     echo ""
     echo "✅ Diagnostic complete"
 


### PR DESCRIPTION
## Summary

`just setup` fails because `verify-deps` and `doctor` recipes import `create_skill_manager` which was renamed to `create_skill_server` in dcc-mcp-core 0.13+.

One-line fix: `s/create_skill_manager/create_skill_server/g` in justfile (2 occurrences).

## Test plan

- [ ] `just setup` completes without error
- [ ] `just doctor` passes