### PR TITLE
refactor(packaging): rewrite install scripts and add portable/pipeline ZIP variants

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,31 +93,8 @@ jobs:
           rm -rf "$MAYA_MODULES/dcc-mcp-maya"
 
           # Deploy the assembled module
-          cp -R dist/mod/dcc-mcp-maya "$MAYA_MODULES/dcc-mcp-maya"
-
-          # Generate .mod file dynamically (same as install.sh does)
-          # The .mod is no longer pre-baked by assemble — it is generated
-          # at deploy time based on the actual platform and module metadata.
-          mayapy -c "
-          import json, sys
-          from pathlib import Path
-          module_root = Path('$MAYA_MODULES/dcc-mcp-maya')
-          with open(module_root / 'module-info.json') as f:
-              info = json.load(f)
-          version = info['version']
-          has_cp37 = info.get('has_cp37', False)
-          maya_versions = info.get('supported_maya_versions', ['2023', '2024', '2025'])
-          lines = []
-          for mv in maya_versions:
-              lines.append(f'+ MAYAVERSION:{mv} PLATFORM:linux dcc_mcp_maya {version} .')
-              if mv == '2022' and has_cp37:
-                  lines.append('PYTHONPATH+:=python37')
-              else:
-                  lines.append('PYTHONPATH+:=python')
-              lines.append('PLUG_IN_PATH+:=plug-ins')
-          (module_root / 'dcc_mcp_maya.mod').write_text(chr(10).join(lines) + chr(10))
-          print(f'Generated .mod for Maya {maya_versions}, version={version}')
-          "
+          # Portable variant is in dist/mod/portable/dcc-mcp-maya
+          cp -R dist/mod/portable/dcc-mcp-maya "$MAYA_MODULES/dcc-mcp-maya"
 
           echo "Deployed module to $MAYA_MODULES/dcc-mcp-maya"
           ls -la "$MAYA_MODULES/dcc-mcp-maya/"
@@ -125,10 +102,6 @@ jobs:
       # ── Phase 2: Post-install verification ─────────────────────────────
       # Run the post_install.py script that verifies the packaged module
       # works correctly in mayapy standalone mode.
-
-      - name: Post-install verification
-        run: |
-          mayapy "$HOME/maya/modules/dcc-mcp-maya/post_install.py"
 
       # ── Phase 3: E2E tests using the packaged module ───────────────────
       # The E2E tests exercise the server, skills, and plugin lifecycle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: mod-${{ matrix.platform }}
-          path: dist/mod/*.zip
+          path: dist/mod/**/*.zip
 
   # ── Attach wheels to GitHub Release ─────────────────────────────────────────
   attach-release-assets:

--- a/packaging/README-pipeline.txt
+++ b/packaging/README-pipeline.txt
@@ -1,0 +1,45 @@
+DCC-MCP-Maya — Pipeline Deployment
+====================================
+
+This package is designed for network-share deployment in pipeline
+environments. No install scripts are included.
+
+Deployment Options
+------------------
+
+Option A: MAYA_MODULE_PATH (recommended)
+  Add the parent directory of this folder to MAYA_MODULE_PATH.
+  The included dcc_mcp_maya.mod uses relative paths (.) so it
+  works from any location.
+
+  Example:
+    set MAYA_MODULE_PATH=\\server\tools\dcc-mcp-maya-module;%MAYA_MODULE_PATH%
+
+Option B: Maya modules directory
+  Copy or symlink dcc_mcp_maya.mod to a Maya modules directory:
+    - Windows:  %USERPROFILE%\Documents\maya\modules\
+    - Linux:    ~/maya/modules/
+    - macOS:    ~/Library/Preferences/Autodesk/maya/modules/
+
+  IMPORTANT: The .mod file uses relative paths (.), so it must
+  be in the same directory as the module content (plug-ins/,
+  python/, scripts/), or you must edit the module path in the
+  .mod file to point to the actual location.
+
+userSetup.py
+------------
+To auto-load the plugin at Maya startup, copy scripts/userSetup.py
+to your Maya scripts directory, or source it from your existing
+userSetup.py.
+
+Configuration
+-------------
+Environment variables (optional):
+
+  DCC_MCP_MAYA_PORT        TCP port for the MCP server. Default: 0 (OS-assigned)
+  DCC_MCP_MAYA_SERVER_NAME Server name in MCP initialize. Default: maya-mcp
+  DCC_MCP_GATEWAY_PORT     Gateway port. Default: 9765
+  DCC_MCP_MAYA_SKILL_PATHS Additional skill search paths (; separated)
+  DCC_MCP_SKILL_PATHS      Global skill search paths (; separated)
+
+For more information: https://github.com/loonghao/dcc-mcp-maya

--- a/packaging/README.txt
+++ b/packaging/README.txt
@@ -6,34 +6,42 @@ server plugin and all Python dependencies (including dcc-mcp-core).
 
 Requirements
 ------------
-- Autodesk Maya 2022, 2023, 2024, or 2025 (matching platform ZIP)
+- Autodesk Maya 2022, 2023, 2024, 2025, or 2026 (matching platform ZIP)
 
 Installation
 ------------
-1. Unzip the archive.
-2. Double-click install.bat (Windows) or run install.sh (Linux/macOS).
-3. Start Maya — the plugin loads automatically via userSetup.py.
+1. Unzip the archive to any location.
+2. Open the extracted dcc-mcp-maya folder.
+3. Double-click install.bat (Windows) or run install.sh (Linux/macOS).
+4. Start Maya — the plugin loads automatically via userSetup.py.
 
-Alternatively, load manually via:
-  Window > Settings/Preferences > Plug-in Manager > dcc_mcp_maya
+The installer generates a .mod file pointing to the extracted location
+and deploys userSetup.py to your Maya scripts directory. The module
+files stay where you extracted them — only the .mod pointer is copied.
 
 Uninstallation
 --------------
 Double-click uninstall.bat (Windows) or run uninstall.sh (Linux/macOS).
+This removes the .mod file from your Maya modules directory. The
+extracted module folder is not deleted.
+
+Alternatively, load manually via:
+  Window > Settings/Preferences > Plug-in Manager > dcc_mcp_maya
 
 Configuration
 -------------
 Environment variables (optional):
 
-  DCC_MCP_MAYA_PORT        TCP port for the MCP server. Default: 8765
+  DCC_MCP_MAYA_PORT        TCP port for the MCP server. Default: 0 (OS-assigned)
   DCC_MCP_MAYA_SERVER_NAME Server name in MCP initialize. Default: maya-mcp
+  DCC_MCP_GATEWAY_PORT     Gateway port. Default: 9765
   DCC_MCP_MAYA_SKILL_PATHS Additional skill search paths (; separated)
   DCC_MCP_SKILL_PATHS      Global skill search paths (; separated)
 
 Troubleshooting
 ---------------
-- If the plugin does not appear in Plug-in Manager, verify the module
-  directory is at: <User Documents>/maya/modules/dcc-mcp-maya/
+- If the plugin does not appear in Plug-in Manager, verify the .mod
+  file exists at: <User Documents>/maya/modules/dcc_mcp_maya.mod
 - Check the Maya Script Editor output window for error messages.
 - Ensure the ZIP matches your platform (win64 / linux / macos).
 

--- a/packaging/assemble_mod.py
+++ b/packaging/assemble_mod.py
@@ -8,13 +8,16 @@ This script:
 1. Creates the .mod module directory structure
 2. Copies the Python package and plugin files
 3. Extracts dcc_mcp_core from a downloaded wheel into python/dcc_mcp_core/
-4. Generates module-info.json metadata (the .mod file is generated at install time)
-5. Copies install/uninstall scripts and README
+4. Generates dcc_mcp_maya.mod with relative paths
+5. Produces two ZIP variants:
+   - Portable (with install scripts)
+   - Pipeline (with module-info.json, no install scripts)
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import shutil
 import tempfile
 from pathlib import Path
@@ -41,7 +44,6 @@ def resolve_core_version(project_root: Path) -> str:
     # Try to get the latest version from PyPI so we download a version
     # that actually has compiled wheels for all platforms.
     try:
-        import json
         import urllib.request
 
         url = "https://pypi.org/pypi/dcc-mcp-core/json"
@@ -76,7 +78,6 @@ def download_core_wheels(version: str, platform: str, dest: Path) -> list[Path]:
     Downloads both abi3 (cp38+, covers Maya 2023+) and cp37 (Maya 2022)
     wheels where available.
     """
-    import json
     import urllib.request
 
     # Wheel filename patterns per platform.
@@ -173,23 +174,42 @@ def extract_wheel(wheel_path: Path, dest: Path, *, extensions_only: bool = False
                 dst.write(src.read())
 
 
+def generate_mod_file(version: str, platform: str, has_cp37: bool = False, path: str = ".") -> str:
+    """Generate .mod file content for given platform and Maya versions.
+
+    Args:
+        version: Package version string.
+        platform: Platform string (win64, linux, macos).
+        has_cp37: Whether cp37 (Maya 2022) extensions are available.
+        path: Module root path. Use ``"."`` for relative paths (pipeline),
+              or an absolute path for deployed installations.
+    """
+    lines = []
+    maya_versions = []
+    if has_cp37:
+        maya_versions.append("2022")
+    maya_versions.extend(["2023", "2024", "2025", "2026"])
+
+    for mv in maya_versions:
+        lines.append(f"+ MAYAVERSION:{mv} PLATFORM:{platform} dcc_mcp_maya {version} {path}")
+        # Maya 2022 uses python37/ if cp37 extensions are available
+        if mv == "2022" and has_cp37:
+            lines.append("PYTHONPATH+:=python37")
+        else:
+            lines.append("PYTHONPATH+:=python")
+        lines.append("PLUG_IN_PATH+:=plug-ins")
+
+    return "\n".join(lines) + "\n"
+
+
 def generate_module_info(version: str, has_cp37: bool = False) -> str:
     """Generate module-info.json content with build metadata.
 
-    The .mod file is no longer generated at assemble time — it is generated
-    at install time by the install scripts, which can detect the actual
-    platform and installed Maya versions on the user's machine.
-
-    module-info.json provides the metadata the install scripts need:
-    version, whether cp37 extensions are available, and which Maya
-    versions the package supports.
+    Included only in the pipeline ZIP for programmatic version queries.
     """
-    import json
-
-    supported = ["2022", "2023", "2024", "2025"]
-    if not has_cp37:
-        # Without cp37 extensions, Maya 2022 (Python 3.7) is not supported
-        supported = ["2023", "2024", "2025"]
+    supported = ["2023", "2024", "2025", "2026"]
+    if has_cp37:
+        supported.insert(0, "2022")
 
     info = {
         "name": "dcc_mcp_maya",
@@ -200,215 +220,13 @@ def generate_module_info(version: str, has_cp37: bool = False) -> str:
     return json.dumps(info, indent=2) + "\n"
 
 
-def generate_mod_content(version: str, platform: str, maya_versions: list[str], has_cp37: bool = False) -> str:
-    """Generate .mod file content for given platform and Maya versions.
-
-    This is used by the install scripts (via post_install.py) and by tests.
-    The platform string and Maya version list come from runtime detection,
-    not from build-time assumptions.
-    """
-    lines = []
-    for mv in maya_versions:
-        lines.append(f"+ MAYAVERSION:{mv} PLATFORM:{platform} dcc_mcp_maya {version} .")
-        # Maya 2022 uses python37/ if cp37 extensions are available
-        if mv == "2022" and has_cp37:
-            lines.append("PYTHONPATH+:=python37")
-        else:
-            lines.append("PYTHONPATH+:=python")
-        # Add plug-ins/ to MAYA_PLUG_IN_PATH so loadPlugin finds the .py
-        lines.append("PLUG_IN_PATH+:=plug-ins")
-
-    return "\n".join(lines) + "\n"
-
-
-def _generate_post_install(module_dir: Path) -> None:
-    """Generate a post_install.py script that verifies the module works.
-
-    The script is designed to be run with mayapy::
-
-        mayapy <module_dir>/post_install.py
-
-    It verifies that:
-    1. The module-info.json metadata file exists
-    2. dcc_mcp_maya and dcc_mcp_core are importable
-    3. dcc_mcp_maya.start_server is available
-    4. The MCP server can start and stop cleanly
-
-    If the .mod file does not exist yet (e.g. running before install script),
-    it is generated dynamically from module-info.json so the verification
-    can proceed.
-    """
-    script = '''#!/usr/bin/env python
-"""Post-install verification for dcc-mcp-maya module.
-
-Run with mayapy (Maya's Python interpreter)::
-
-    mayapy post_install.py
-
-This script verifies the .mod module installation is correct.
-If the .mod file does not exist yet, it is generated from module-info.json.
-"""
-from __future__ import annotations
-
-import json
-import os
-import sys
-from pathlib import Path
-
-MODULE_ROOT = Path(__file__).resolve().parent
-
-# Ensure python/ is on sys.path (needed for mayapy standalone which
-# does not process .mod PYTHONPATH directives)
-_python_dir = MODULE_ROOT / "python"
-if str(_python_dir) not in sys.path:
-    sys.path.insert(0, str(_python_dir))
-
-errors = []
-
-
-def _check(label, condition, detail=""):
-    if condition:
-        print(f"  [PASS] {label}")
-    else:
-        msg = f"  [FAIL] {label}"
-        if detail:
-            msg += f" — {detail}"
-        print(msg)
-        errors.append(label)
-
-
-def _ensure_mod_file():
-    """Generate .mod file from module-info.json if it does not exist yet.
-
-    The install scripts normally generate the .mod file at install time,
-    but when running post_install.py directly (e.g. in CI or for testing)
-    the .mod may not have been created yet.
-    """
-    mod_path = MODULE_ROOT / "dcc_mcp_maya.mod"
-    if mod_path.exists():
-        return
-
-    info_path = MODULE_ROOT / "module-info.json"
-    if not info_path.is_file():
-        return  # nothing to generate from
-
-    with open(info_path, encoding="utf-8") as f:
-        info = json.load(f)
-
-    version = info.get("version", "0.0.0")
-    has_cp37 = info.get("has_cp37", False)
-    maya_versions = info.get("supported_maya_versions", ["2023", "2024", "2025"])
-
-    # Detect platform
-    if sys.platform == "win32":
-        platform_str = "win64"
-    elif sys.platform == "darwin":
-        platform_str = "macos"
-    else:
-        platform_str = "linux"
-
-    lines = []
-    for mv in maya_versions:
-        lines.append(f"+ MAYAVERSION:{mv} PLATFORM:{platform_str} dcc_mcp_maya {version} .")
-        if mv == "2022" and has_cp37:
-            lines.append("PYTHONPATH+:=python37")
-        else:
-            lines.append("PYTHONPATH+:=python")
-        lines.append("PLUG_IN_PATH+:=plug-ins")
-
-    mod_path.write_text("\\n".join(lines) + "\\n", encoding="utf-8")
-    print(f"  Generated {mod_path.name} from module-info.json")
-
-
-def main():
-    print("=" * 50)
-    print(" dcc-mcp-maya Post-Install Verification")
-    print("=" * 50)
-    print()
-
-    # 0. Generate .mod file if missing
-    _ensure_mod_file()
-
-    # 1. Check module directory structure
-    print("1. Module directory structure:")
-    _check("module-info.json exists", (MODULE_ROOT / "module-info.json").is_file())
-    _check("plug-ins/dcc_mcp_maya_plugin.py exists", (MODULE_ROOT / "plug-ins" / "dcc_mcp_maya_plugin.py").is_file())
-    _check("python/dcc_mcp_maya/ exists", (MODULE_ROOT / "python" / "dcc_mcp_maya").is_dir())
-    _check("python/dcc_mcp_core/ exists", (MODULE_ROOT / "python" / "dcc_mcp_core").is_dir())
-    print()
-
-    # 2. Check Python imports
-    print("2. Python package imports:")
-    try:
-        import dcc_mcp_core
-        _check("import dcc_mcp_core", True)
-        _check("dcc_mcp_core version", hasattr(dcc_mcp_core, "__version__"))
-    except ImportError as exc:
-        _check("import dcc_mcp_core", False, str(exc))
-
-    try:
-        import dcc_mcp_maya
-        _check("import dcc_mcp_maya", True)
-        _check("dcc_mcp_maya.start_server", hasattr(dcc_mcp_maya, "start_server"))
-        _check("dcc_mcp_maya.stop_server", hasattr(dcc_mcp_maya, "stop_server"))
-        _check("dcc_mcp_maya.__version__", hasattr(dcc_mcp_maya, "__version__"))
-    except ImportError as exc:
-        _check("import dcc_mcp_maya", False, str(exc))
-        _check("dcc_mcp_maya.start_server", False, "import failed")
-        _check("dcc_mcp_maya.stop_server", False, "import failed")
-        _check("dcc_mcp_maya.__version__", False, "import failed")
-    print()
-
-    # 3. Check Maya standalone (optional, only if maya is available)
-    print("3. Maya integration:")
-    try:
-        import maya.standalone  # noqa: F401
-        maya.standalone.initialize()
-        import maya.cmds as cmds
-        _check("maya.standalone.initialize", True)
-
-        # Test that the plugin can be found after setting MAYA_PLUG_IN_PATH
-        plugins_dir = str(MODULE_ROOT / "plug-ins")
-        current = os.environ.get("MAYA_PLUG_IN_PATH", "")
-        sep = ";" if sys.platform == "win32" else ":"
-        if plugins_dir not in current:
-            os.environ["MAYA_PLUG_IN_PATH"] = plugins_dir + (sep + current if current else "")
-        _check("MAYA_PLUG_IN_PATH updated", True)
-
-        # Test server start/stop in standalone
-        try:
-            handle = dcc_mcp_maya.start_server(port=0)
-            _check("start_server(port=0)", True)
-            url = handle.mcp_url()
-            _check("server URL reachable", url.startswith("http://"))
-            dcc_mcp_maya.stop_server()
-            _check("stop_server()", True)
-        except Exception as exc:
-            _check("start_server/stop_server", False, str(exc))
-    except ImportError:
-        _check("maya.standalone (skipped)", True, "not running under mayapy")
-    print()
-
-    # Summary
-    print("=" * 50)
-    if errors:
-        print(f" FAILED — {len(errors)} check(s) failed:")
-        for e in errors:
-            print(f"   - {e}")
-        sys.exit(1)
-    else:
-        print(" ALL CHECKS PASSED — installation is correct")
-        sys.exit(0)
-
-
-if __name__ == "__main__":
-    main()
-'''
-    (module_dir / "post_install.py").write_text(script, encoding="utf-8")
-
-
 def assemble(project_root: Path, version: str, platform: str, output: Path) -> Path:
-    """Assemble the .mod module directory."""
+    """Assemble the shared .mod module directory structure.
+
+    Creates the common directory layout with python packages, plugin,
+    scripts, and a pre-generated .mod file with relative paths.
+    Returns the module directory path.
+    """
     module_name = "dcc-mcp-maya"
     module_dir = output / module_name
 
@@ -421,7 +239,7 @@ def assemble(project_root: Path, version: str, platform: str, output: Path) -> P
     (module_dir / "scripts").mkdir(parents=True)
     (module_dir / "python").mkdir(parents=True)
 
-    # 5. Download and extract dcc_mcp_core (early, so we know if cp37 is available)
+    # 1. Download and extract dcc_mcp_core
     core_version = resolve_core_version(project_root)
     print(f"  Resolved dcc-mcp-core version: >={core_version}")
 
@@ -435,12 +253,8 @@ def assemble(project_root: Path, version: str, platform: str, output: Path) -> P
             print(f"  Extracting {wheel.name} (full)...")
             extract_wheel(wheel, module_dir / "python")
         if cp37_wheels:
-            # Create python37/ directory with symlinks/copies of pure Python
-            # and cp37 native extensions for Maya 2022 compatibility
             python37_dir = module_dir / "python37"
             python37_dir.mkdir(parents=True)
-            # Copy the entire python/ contents first, then overlay cp37 extensions
-            # (This ensures python37 has all the pure-Python code too)
             python_dir = module_dir / "python"
             for item in python_dir.iterdir():
                 dest_item = python37_dir / item.name
@@ -448,17 +262,11 @@ def assemble(project_root: Path, version: str, platform: str, output: Path) -> P
                     shutil.copytree(item, dest_item)
                 else:
                     shutil.copy2(item, dest_item)
-            # Now overlay cp37 extensions
             for wheel in cp37_wheels:
                 print(f"  Extracting {wheel.name} (cp37 overlay to python37/)...")
                 extract_wheel(wheel, python37_dir, extensions_only=True)
                 has_cp37 = True
     print("  Extracted dcc_mcp_core to python/" + (" and python37/" if has_cp37 else ""))
-
-    # 1. Generate module-info.json (the .mod file is generated at install time)
-    info_content = generate_module_info(version, has_cp37=has_cp37)
-    (module_dir / "module-info.json").write_text(info_content, encoding="utf-8")
-    print(f"  Generated module-info.json (version={version}, has_cp37={has_cp37})")
 
     # 2. Copy Maya plugin
     plugin_src = project_root / "maya" / "plugin" / "dcc_mcp_maya_plugin.py"
@@ -484,7 +292,18 @@ def assemble(project_root: Path, version: str, platform: str, output: Path) -> P
         shutil.copytree(pkg_src, pkg_dest_37)
         print("  Copied dcc_mcp_maya package to python37/")
 
-    # 6. Copy install/uninstall scripts and README
+    # 5. Generate .mod file with relative paths
+    mod_content = generate_mod_file(version, platform, has_cp37=has_cp37, path=".")
+    (module_dir / "dcc_mcp_maya.mod").write_text(mod_content, encoding="utf-8")
+    print(f"  Generated dcc_mcp_maya.mod (version={version}, platform={platform}, has_cp37={has_cp37})")
+
+    return module_dir
+
+
+def assemble_portable(project_root: Path, version: str, platform: str, output: Path) -> Path:
+    """Assemble the portable ZIP with install scripts."""
+    module_dir = assemble(project_root, version, platform, output)
+
     packaging_dir = project_root / "packaging"
     if platform == "win64":
         shutil.copy2(packaging_dir / "install.bat", module_dir / "install.bat")
@@ -492,22 +311,33 @@ def assemble(project_root: Path, version: str, platform: str, output: Path) -> P
     else:
         shutil.copy2(packaging_dir / "install.sh", module_dir / "install.sh")
         shutil.copy2(packaging_dir / "uninstall.sh", module_dir / "uninstall.sh")
+
     readme_src = packaging_dir / "README.txt"
     if readme_src.exists():
         shutil.copy2(readme_src, module_dir / "README.txt")
-    else:
-        # Fallback: generate a minimal README if the file is not tracked in git
-        (module_dir / "README.txt").write_text(
-            "DCC-MCP-Maya — Maya Module Distribution\n"
-            "See https://github.com/loonghao/dcc-mcp-maya for full documentation.\n",
-            encoding="utf-8",
-        )
-    print("  Copied install/uninstall scripts and README")
 
-    # 7. Generate post_install.py verification script
-    _generate_post_install(module_dir)
-    print("  Generated post_install.py")
+    print("  Added install scripts and README (portable)")
+    return module_dir
 
+
+def assemble_pipeline(project_root: Path, version: str, platform: str, output: Path) -> Path:
+    """Assemble the pipeline ZIP with module-info.json, no install scripts."""
+    module_dir = assemble(project_root, version, platform, output)
+
+    # Determine has_cp37 from python37/ existence
+    has_cp37 = (module_dir / "python37").is_dir()
+
+    # Add module-info.json
+    info_content = generate_module_info(version, has_cp37=has_cp37)
+    (module_dir / "module-info.json").write_text(info_content, encoding="utf-8")
+    print(f"  Generated module-info.json (version={version}, has_cp37={has_cp37})")
+
+    # Add README-pipeline.txt
+    readme_src = project_root / "packaging" / "README-pipeline.txt"
+    if readme_src.exists():
+        shutil.copy2(readme_src, module_dir / "README-pipeline.txt")
+
+    print("  Added module-info.json and README-pipeline.txt (pipeline)")
     return module_dir
 
 
@@ -523,13 +353,23 @@ def main() -> None:
     output_dir = Path(args.output).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    print(f"Assembling .mod module for platform={args.platform}, version={args.version}")
-    assemble(project_root, args.version, args.platform, output_dir)
+    # --- Portable ZIP ---
+    print(f"\nAssembling portable .mod module for platform={args.platform}, version={args.version}")
+    portable_output = output_dir / "portable"
+    portable_output.mkdir(parents=True, exist_ok=True)
+    assemble_portable(project_root, args.version, args.platform, portable_output)
+    zip_path = portable_output / f"dcc-mcp-maya-{args.version}-{args.platform}"
+    shutil.make_archive(str(zip_path), "zip", root_dir=portable_output, base_dir="dcc-mcp-maya")
+    print(f"Created: {zip_path}.zip")
 
-    # Create ZIP
-    zip_path = output_dir / f"dcc-mcp-maya-{args.version}-{args.platform}"
-    shutil.make_archive(str(zip_path), "zip", root_dir=output_dir, base_dir="dcc-mcp-maya")
-    print(f"\nCreated: {zip_path}.zip")
+    # --- Pipeline ZIP ---
+    print(f"\nAssembling pipeline .mod module for platform={args.platform}, version={args.version}")
+    pipeline_output = output_dir / "pipeline"
+    pipeline_output.mkdir(parents=True, exist_ok=True)
+    assemble_pipeline(project_root, args.version, args.platform, pipeline_output)
+    zip_path = pipeline_output / f"dcc-mcp-maya-{args.version}-{args.platform}-pipeline"
+    shutil.make_archive(str(zip_path), "zip", root_dir=pipeline_output, base_dir="dcc-mcp-maya")
+    print(f"Created: {zip_path}.zip")
 
 
 if __name__ == "__main__":

--- a/packaging/install.bat
+++ b/packaging/install.bat
@@ -1,125 +1,61 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal
 
 echo =========================================
 echo  DCC-MCP-Maya Installer
 echo =========================================
 echo.
 
-REM -- Resolve script directory (handles spaces) --
-set "SCRIPT_DIR=%~dp0"
-set "MODULE_DIR=%SCRIPT_DIR%dcc-mcp-maya"
+REM -- Resolve module directory (this script lives inside it) --
+set "MODULE_DIR=%~dp0"
+if "%MODULE_DIR:~-1%"=="\" set "MODULE_DIR=%MODULE_DIR:~0,-1%"
 
-if not exist "%MODULE_DIR%\module-info.json" (
-    echo ERROR: Module directory not found at:
-    echo   %MODULE_DIR%
-    echo.
-    echo Please ensure this script is in the same directory as the dcc-mcp-maya folder.
-    pause & exit /b 1
-)
-
-REM -- Read version from module-info.json --
+REM -- Read version from pre-generated .mod file --
 set "VERSION=unknown"
-for /f "tokens=2 delims=:," %%v in ('findstr /c:"\"version\"" "%MODULE_DIR%\module-info.json"') do (
-    set "VERSION=%%~v"
+for /f "tokens=4" %%v in ('findstr /r "^+ MAYAVERSION" "%MODULE_DIR%\dcc_mcp_maya.mod"') do (
+    set "VERSION=%%v"
 )
-set "VERSION=%VERSION: =%"
-set "VERSION=%VERSION:"=%"
 echo  Version: %VERSION%
-
-REM -- Check if python37/ exists (cp37 for Maya 2022) --
-set "HAS_CP37=0"
-if exist "%MODULE_DIR%\python37" set "HAS_CP37=1"
-if "%HAS_CP37%"=="1" (
-    echo  Python 3.7 support: Yes ^(Maya 2022^)
-) else (
-    echo  Python 3.7 support: No
-)
+echo  Module:  %MODULE_DIR%
 echo.
 
-REM -- Detect Maya installations --
-set "FOUND_MAYA=0"
-for %%Y in (2026 2025 2024 2023 2022) do (
-    if exist "C:\Program Files\Autodesk\Maya%%Y\bin\mayapy.exe" (
-        echo  Found Maya %%Y
-        set "FOUND_MAYA=1"
-    )
-)
-if "%FOUND_MAYA%"=="0" (
-    echo  WARNING: No Maya installation detected.
-    echo  The module will still be installed but Maya may not find it automatically.
-    echo.
-)
-
-REM -- Deploy module directory --
+REM -- Generate .mod with absolute path to Maya modules dir --
 set "MOD_DEST=%USERPROFILE%\Documents\maya\modules"
 if not exist "%MOD_DEST%" mkdir "%MOD_DEST%"
 
-REM -- Remove previous installation --
-if exist "%MOD_DEST%\dcc-mcp-maya" (
-    echo Removing previous installation...
-    rmdir /s /q "%MOD_DEST%\dcc-mcp-maya"
-)
-
-echo.
-echo Deploying module to: %MOD_DEST%\dcc-mcp-maya
-xcopy /e /i /q /y "%MODULE_DIR%" "%MOD_DEST%\dcc-mcp-maya" >nul
-if errorlevel 1 (
-    echo ERROR: Failed to copy module files.
-    pause & exit /b 1
-)
-
-REM -- Generate .mod file dynamically --
-echo Generating dcc_mcp_maya.mod...
-
-set "PLATFORM=win64"
-set "MOD_FILE=%MOD_DEST%\dcc-mcp-maya\dcc_mcp_maya.mod"
+set "HAS_CP37=0"
+if exist "%MODULE_DIR%\python37" set "HAS_CP37=1"
 
 (
 if "%HAS_CP37%"=="1" (
-    echo + MAYAVERSION:2022 PLATFORM:%PLATFORM% dcc_mcp_maya %VERSION% .
+    echo + MAYAVERSION:2022 PLATFORM:win64 dcc_mcp_maya %VERSION% %MODULE_DIR%
     echo PYTHONPATH+:=python37
     echo PLUG_IN_PATH+:=plug-ins
 )
 for %%Y in (2023 2024 2025 2026) do (
-    echo + MAYAVERSION:%%Y PLATFORM:%PLATFORM% dcc_mcp_maya %VERSION% .
+    echo + MAYAVERSION:%%Y PLATFORM:win64 dcc_mcp_maya %VERSION% %MODULE_DIR%
     echo PYTHONPATH+:=python
     echo PLUG_IN_PATH+:=plug-ins
 )
-) > "%MOD_FILE%"
+) > "%MOD_DEST%\dcc_mcp_maya.mod"
 
-echo  Generated %MOD_FILE%
+echo  Generated %MOD_DEST%\dcc_mcp_maya.mod
 
 REM -- Deploy userSetup.py --
 set "SCRIPTS_DEST=%USERPROFILE%\Documents\maya\scripts"
 if not exist "%SCRIPTS_DEST%" mkdir "%SCRIPTS_DEST%"
 
-set "USERSETUP_DEST=%SCRIPTS_DEST%\userSetup.py"
-if not exist "%USERSETUP_DEST%" (
-    copy /y "%MOD_DEST%\dcc-mcp-maya\scripts\userSetup.py" "%USERSETUP_DEST%" >nul
-    echo Deployed userSetup.py to %SCRIPTS_DEST%
+if not exist "%SCRIPTS_DEST%\userSetup.py" (
+    copy /y "%MODULE_DIR%\scripts\userSetup.py" "%SCRIPTS_DEST%\userSetup.py" >nul
+    echo  Deployed userSetup.py
 ) else (
-    REM Check if our snippet is already present
-    findstr /c:"dcc_mcp_maya" "%USERSETUP_DEST%" >nul 2>&1
+    findstr /c:"dcc_mcp_maya" "%SCRIPTS_DEST%\userSetup.py" >nul 2>&1
     if errorlevel 1 (
-        echo.
-        echo Appending dcc-mcp-maya loader to existing userSetup.py...
-        echo. >> "%USERSETUP_DEST%"
-        echo # dcc-mcp-maya auto-load >> "%USERSETUP_DEST%"
-        echo try: >> "%USERSETUP_DEST%"
-        echo     import maya.utils >> "%USERSETUP_DEST%"
-        echo     def _load_dcc_mcp_maya^^^(^^^): >> "%USERSETUP_DEST%"
-        echo         try: >> "%USERSETUP_DEST%"
-        echo             import maya.cmds as cmds >> "%USERSETUP_DEST%"
-        echo             if not cmds.pluginInfo^^^("dcc_mcp_maya_plugin", query=True, loaded=True^^^): >> "%USERSETUP_DEST%"
-        echo                 cmds.loadPlugin^^^("dcc_mcp_maya_plugin", quiet=True^^^) >> "%USERSETUP_DEST%"
-        echo         except Exception: >> "%USERSETUP_DEST%"
-        echo             pass >> "%USERSETUP_DEST%"
-        echo     maya.utils.executeDeferred^^^(_load_dcc_mcp_maya^^^) >> "%USERSETUP_DEST%"
-        echo except ImportError: >> "%USERSETUP_DEST%"
-        echo     pass >> "%USERSETUP_DEST%"
+        echo. >> "%SCRIPTS_DEST%\userSetup.py"
+        type "%MODULE_DIR%\scripts\userSetup.py" >> "%SCRIPTS_DEST%\userSetup.py"
+        echo  Appended to existing userSetup.py
     ) else (
-        echo userSetup.py already contains dcc-mcp-maya loader, skipping.
+        echo  userSetup.py already configured, skipping.
     )
 )
 
@@ -127,42 +63,11 @@ echo.
 echo =========================================
 echo  Installation complete!
 echo.
-echo  Module:   %MOD_DEST%\dcc-mcp-maya
-echo  Plugin:   %MOD_DEST%\dcc-mcp-maya\plug-ins\dcc_mcp_maya_plugin.py
-echo.
-
-REM -- Post-install verification --
-echo Running post-install verification...
-set "VERIFY_MAYA="
-for %%Y in (2026 2025 2024 2023 2022) do (
-    if not defined VERIFY_MAYA (
-        if exist "C:\Program Files\Autodesk\Maya%%Y\bin\mayapy.exe" (
-            set "VERIFY_MAYA=C:\Program Files\Autodesk\Maya%%Y\bin\mayapy.exe"
-        )
-    )
-)
-if defined VERIFY_MAYA (
-    echo Using mayapy: %VERIFY_MAYA%
-    "%VERIFY_MAYA%" "%MOD_DEST%\dcc-mcp-maya\post_install.py"
-    if errorlevel 1 (
-        echo.
-        echo WARNING: Post-install verification failed.
-        echo The module files are deployed but may not work correctly.
-        echo Please check the errors above.
-    ) else (
-        echo.
-        echo Post-install verification: PASSED
-    )
-) else (
-    echo  WARNING: No mayapy found — skipping post-install verification.
-    echo  To verify manually, run:
-    echo    mayapy "%MOD_DEST%\dcc-mcp-maya\post_install.py"
-)
-
+echo  .mod file:  %MOD_DEST%\dcc_mcp_maya.mod
+echo  Module:     %MODULE_DIR%
+echo  Plugin:     %MODULE_DIR%\plug-ins\dcc_mcp_maya_plugin.py
 echo.
 echo  The plugin will auto-load when Maya starts.
-echo  Alternatively, load it via:
-echo    Window ^> Settings/Preferences ^> Plug-in Manager
 echo =========================================
 pause
 endlocal

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1,62 +1,22 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-MODULE_DIR="$SCRIPT_DIR/dcc-mcp-maya"
+# -- Resolve module directory (this script lives inside it) --
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo "========================================="
 echo " DCC-MCP-Maya Installer"
 echo "========================================="
 echo
 
-if [ ! -f "$MODULE_DIR/module-info.json" ]; then
-    echo "ERROR: Module directory not found at:"
-    echo "  $MODULE_DIR"
-    echo
-    echo "Please ensure this script is in the same directory as the dcc-mcp-maya folder."
-    exit 1
-fi
-
-# Read version from module-info.json
-VERSION=$(python3 -c "
-import json, sys
-with open('$MODULE_DIR/module-info.json') as f:
-    print(json.load(f)['version'])
-" 2>/dev/null || echo "unknown")
+# -- Read version from pre-generated .mod file --
+VERSION=$(grep -m1 '^+ MAYAVERSION' "$MODULE_DIR/dcc_mcp_maya.mod" | awk '{print $4}')
+VERSION="${VERSION:-unknown}"
 echo " Version: ${VERSION}"
-
-# Check if python37/ exists (cp37 for Maya 2022)
-HAS_CP37=0
-if [ -d "$MODULE_DIR/python37" ]; then
-    HAS_CP37=1
-    echo " Python 3.7 support: Yes (Maya 2022)"
-else
-    echo " Python 3.7 support: No"
-fi
+echo " Module:  ${MODULE_DIR}"
 echo
 
-# Detect Maya installations
-FOUND_MAYA=0
-for year in 2026 2025 2024 2023 2022; do
-    CANDIDATES=(
-        "/usr/autodesk/maya${year}/bin/mayapy"
-        "/Applications/Autodesk/maya${year}/Maya.app/Contents/bin/mayapy"
-    )
-    for c in "${CANDIDATES[@]}"; do
-        if [ -x "$c" ]; then
-            echo " Found Maya ${year} at $c"
-            FOUND_MAYA=1
-            break
-        fi
-    done
-done
-if [ "$FOUND_MAYA" -eq 0 ]; then
-    echo " WARNING: No Maya installation detected."
-    echo " The module will still be installed but Maya may not find it automatically."
-    echo
-fi
-
-# Determine platform-specific paths and .mod platform string
+# -- Determine platform-specific paths --
 if [[ "$OSTYPE" == "darwin"* ]]; then
     MOD_DEST="$HOME/Library/Preferences/Autodesk/maya/modules"
     SCRIPTS_DEST="$HOME/Library/Preferences/Autodesk/maya/scripts"
@@ -67,66 +27,43 @@ else
     PLATFORM="linux"
 fi
 
-# Deploy module directory
+# -- Generate .mod with absolute path to Maya modules dir --
 mkdir -p "$MOD_DEST"
 
-if [ -d "$MOD_DEST/dcc-mcp-maya" ]; then
-    echo "Removing previous installation..."
-    rm -rf "$MOD_DEST/dcc-mcp-maya"
+HAS_CP37=0
+if [ -d "$MODULE_DIR/python37" ]; then
+    HAS_CP37=1
 fi
-
-echo
-echo "Deploying module to: $MOD_DEST/dcc-mcp-maya"
-cp -R "$MODULE_DIR" "$MOD_DEST/dcc-mcp-maya"
-
-# Generate .mod file dynamically
-echo "Generating dcc_mcp_maya.mod..."
-MOD_FILE="$MOD_DEST/dcc-mcp-maya/dcc_mcp_maya.mod"
 
 {
     if [ "$HAS_CP37" -eq 1 ]; then
-        echo "+ MAYAVERSION:2022 PLATFORM:$PLATFORM dcc_mcp_maya $VERSION ."
+        echo "+ MAYAVERSION:2022 PLATFORM:$PLATFORM dcc_mcp_maya $VERSION $MODULE_DIR"
         echo "PYTHONPATH+:=python37"
         echo "PLUG_IN_PATH+:=plug-ins"
     fi
     for year in 2023 2024 2025 2026; do
-        echo "+ MAYAVERSION:$year PLATFORM:$PLATFORM dcc_mcp_maya $VERSION ."
+        echo "+ MAYAVERSION:$year PLATFORM:$PLATFORM dcc_mcp_maya $VERSION $MODULE_DIR"
         echo "PYTHONPATH+:=python"
         echo "PLUG_IN_PATH+:=plug-ins"
     done
-} > "$MOD_FILE"
+} > "$MOD_DEST/dcc_mcp_maya.mod"
 
-echo " Generated $MOD_FILE"
+echo " Generated $MOD_DEST/dcc_mcp_maya.mod"
 
-# Deploy userSetup.py
+# -- Deploy userSetup.py --
 mkdir -p "$SCRIPTS_DEST"
 
 USERSETUP_DEST="$SCRIPTS_DEST/userSetup.py"
 if [ ! -f "$USERSETUP_DEST" ]; then
-    cp "$MOD_DEST/dcc-mcp-maya/scripts/userSetup.py" "$USERSETUP_DEST"
-    echo "Deployed userSetup.py to $SCRIPTS_DEST"
+    cp "$MODULE_DIR/scripts/userSetup.py" "$USERSETUP_DEST"
+    echo " Deployed userSetup.py"
 else
     if ! grep -q "dcc_mcp_maya" "$USERSETUP_DEST" 2>/dev/null; then
-        echo
-        echo "Appending dcc-mcp-maya loader to existing userSetup.py..."
-        cat >> "$USERSETUP_DEST" << 'USERSETUP_EOF'
-
-# dcc-mcp-maya auto-load
-try:
-    import maya.utils
-    def _load_dcc_mcp_maya():
-        try:
-            import maya.cmds as cmds
-            if not cmds.pluginInfo("dcc_mcp_maya_plugin", query=True, loaded=True):
-                cmds.loadPlugin("dcc_mcp_maya_plugin", quiet=True)
-        except Exception:
-            pass
-    maya.utils.executeDeferred(_load_dcc_mcp_maya)
-except ImportError:
-    pass
-USERSETUP_EOF
+        echo "" >> "$USERSETUP_DEST"
+        cat "$MODULE_DIR/scripts/userSetup.py" >> "$USERSETUP_DEST"
+        echo " Appended to existing userSetup.py"
     else
-        echo "userSetup.py already contains dcc-mcp-maya loader, skipping."
+        echo " userSetup.py already configured, skipping."
     fi
 fi
 
@@ -134,44 +71,9 @@ echo
 echo "========================================="
 echo " Installation complete!"
 echo
-echo " Module:   $MOD_DEST/dcc-mcp-maya"
-echo " Plugin:   $MOD_DEST/dcc-mcp-maya/plug-ins/dcc_mcp_maya_plugin.py"
-echo
-
-# Post-install verification
-echo "Running post-install verification..."
-VERIFY_MAYAPY=""
-for year in 2026 2025 2024 2023 2022; do
-    CANDIDATES=(
-        "/usr/autodesk/maya${year}/bin/mayapy"
-        "/Applications/Autodesk/maya${year}/Maya.app/Contents/bin/mayapy"
-    )
-    for c in "${CANDIDATES[@]}"; do
-        if [ -x "$c" ]; then
-            VERIFY_MAYAPY="$c"
-            break 2
-        fi
-    done
-done
-
-if [ -n "$VERIFY_MAYAPY" ]; then
-    echo "Using mayapy: $VERIFY_MAYAPY"
-    if "$VERIFY_MAYAPY" "$MOD_DEST/dcc-mcp-maya/post_install.py"; then
-        echo
-        echo "Post-install verification: PASSED"
-    else
-        echo
-        echo "WARNING: Post-install verification failed."
-        echo "The module files are deployed but may not work correctly."
-    fi
-else
-    echo "WARNING: No mayapy found — skipping post-install verification."
-    echo "To verify manually, run:"
-    echo "  mayapy $MOD_DEST/dcc-mcp-maya/post_install.py"
-fi
-
+echo " .mod file:  $MOD_DEST/dcc_mcp_maya.mod"
+echo " Module:     $MODULE_DIR"
+echo " Plugin:     $MODULE_DIR/plug-ins/dcc_mcp_maya_plugin.py"
 echo
 echo " The plugin will auto-load when Maya starts."
-echo " Alternatively, load it via:"
-echo "   Window > Settings/Preferences > Plug-in Manager"
 echo "========================================="

--- a/packaging/uninstall.bat
+++ b/packaging/uninstall.bat
@@ -6,25 +6,26 @@ echo  DCC-MCP-Maya Uninstaller
 echo =========================================
 echo.
 
-set "MOD_DEST=%USERPROFILE%\Documents\maya\modules\dcc-mcp-maya"
+set "MOD_FILE=%USERPROFILE%\Documents\maya\modules\dcc_mcp_maya.mod"
 
-if not exist "%MOD_DEST%" (
-    echo Module directory not found at: %MOD_DEST%
+if not exist "%MOD_FILE%" (
+    echo .mod file not found at: %MOD_FILE%
     echo Nothing to uninstall.
     pause & exit /b 0
 )
 
-echo Removing module directory: %MOD_DEST%
-rmdir /s /q "%MOD_DEST%"
+echo Removing .mod file: %MOD_FILE%
+del /f "%MOD_FILE%"
 if errorlevel 1 (
-    echo ERROR: Failed to remove module directory.
+    echo ERROR: Failed to remove .mod file.
     echo Please close Maya and try again.
     pause & exit /b 1
 )
 
 echo.
-echo Module removed successfully.
+echo .mod file removed successfully. The plugin will no longer load at Maya startup.
 echo.
+echo NOTE: The module directory was not deleted (it remains where you extracted it).
 echo NOTE: userSetup.py was not modified. If you want to remove the
 echo auto-load snippet, edit this file manually:
 echo   %USERPROFILE%\Documents\maya\scripts\userSetup.py

--- a/packaging/uninstall.sh
+++ b/packaging/uninstall.sh
@@ -8,27 +8,26 @@ echo
 
 # Determine platform-specific paths
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    MOD_DEST="$HOME/Library/Preferences/Autodesk/maya/modules/dcc-mcp-maya"
+    MOD_FILE="$HOME/Library/Preferences/Autodesk/maya/modules/dcc_mcp_maya.mod"
+    SCRIPTS_DIR="$HOME/Library/Preferences/Autodesk/maya/scripts"
 else
-    MOD_DEST="$HOME/maya/modules/dcc-mcp-maya"
+    MOD_FILE="$HOME/maya/modules/dcc_mcp_maya.mod"
+    SCRIPTS_DIR="$HOME/maya/scripts"
 fi
 
-if [ ! -d "$MOD_DEST" ]; then
-    echo "Module directory not found at: $MOD_DEST"
+if [ ! -f "$MOD_FILE" ]; then
+    echo ".mod file not found at: $MOD_FILE"
     echo "Nothing to uninstall."
     exit 0
 fi
 
-echo "Removing module directory: $MOD_DEST"
-rm -rf "$MOD_DEST"
+echo "Removing .mod file: $MOD_FILE"
+rm -f "$MOD_FILE"
 
 echo
-echo "Module removed successfully."
+echo ".mod file removed successfully. The plugin will no longer load at Maya startup."
 echo
+echo "NOTE: The module directory was not deleted (it remains where you extracted it)."
 echo "NOTE: userSetup.py was not modified. If you want to remove the"
 echo "auto-load snippet, edit this file manually:"
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "  ~/Library/Preferences/Autodesk/maya/scripts/userSetup.py"
-else
-    echo "  ~/maya/scripts/userSetup.py"
-fi
+echo "  $SCRIPTS_DIR/userSetup.py"

--- a/tests/test_assemble_mod.py
+++ b/tests/test_assemble_mod.py
@@ -4,8 +4,9 @@ These tests verify:
 - resolve_core_version: reads minimum version from pyproject.toml and resolves latest from PyPI
 - download_core_wheels: finds and downloads correct wheel files via PyPI JSON API
 - extract_wheel: correctly extracts wheel contents using zipfile
-- generate_mod_file: generates proper .mod content with python37 support
-- assemble: end-to-end assembly produces correct directory structure
+- generate_mod_file: generates proper .mod content with python37 support and custom path
+- generate_module_info: generates module-info.json metadata
+- assemble_portable/assemble_pipeline: end-to-end assembly produces correct directory structure
 """
 
 from __future__ import annotations
@@ -188,7 +189,6 @@ class TestDownloadCoreWheels:
         mock_resp.__exit__ = MagicMock(return_value=False)
 
         def fake_urlretrieve(url, dest):
-            # Create a minimal wheel file at dest
             fname = Path(dest).name
             if "abi3" in fname:
                 files = {"dcc_mcp_core/__init__.py": b"# abi3", "dcc_mcp_core/_core.pyd": b"\x00abi3"}
@@ -343,123 +343,134 @@ class TestExtractWheel:
         assert not (dest / "dcc_mcp_core-0.12.17.dist-info").exists()
 
 
-# ── generate_module_info / generate_mod_content ───────────────────────────
+# ── generate_mod_file ───────────────────────────────────────────────────────
 
 
-class TestGenerateModuleInfo:
-    def test_with_cp37(self):
-        content = assemble_mod.generate_module_info("0.2.2", has_cp37=True)
-        import json
-
-        info = json.loads(content)
-        assert info["name"] == "dcc_mcp_maya"
-        assert info["version"] == "0.2.2"
-        assert info["has_cp37"] is True
-        assert info["supported_maya_versions"] == ["2022", "2023", "2024", "2025"]
-
-    def test_without_cp37(self):
-        content = assemble_mod.generate_module_info("0.2.2", has_cp37=False)
-        import json
-
-        info = json.loads(content)
-        assert info["has_cp37"] is False
-        assert "2022" not in info["supported_maya_versions"]
-        assert info["supported_maya_versions"] == ["2023", "2024", "2025"]
-
-
-class TestGenerateModContent:
-    def test_win64_all_maya_versions(self):
-        content = assemble_mod.generate_mod_content("0.2.2", "win64", ["2022", "2023", "2024", "2025"], has_cp37=True)
+class TestGenerateModFile:
+    def test_win64_with_cp37_relative_path(self):
+        content = assemble_mod.generate_mod_file("0.2.2", "win64", has_cp37=True, path=".")
         lines = content.strip().split("\n")
-        assert len(lines) == 12  # 4 maya versions * 3 lines each (PYTHONPATH + PLUG_IN_PATH)
+        # 5 maya versions (2022-2026), each with 3 lines
+        assert len(lines) == 15
         assert "MAYAVERSION:2022" in lines[0]
         assert "python37" in lines[1]
         assert "PLUG_IN_PATH+:=plug-ins" in lines[2]
         assert "MAYAVERSION:2023" in lines[3]
         assert "PYTHONPATH+:=python" in lines[4]
-        assert "PLUG_IN_PATH+:=plug-ins" in lines[5]
+        # All lines use "." as the module path
+        assert all("." in line.split("dcc_mcp_maya")[1].strip().split()[0] for line in lines if line.startswith("+"))
 
     def test_win64_no_cp37(self):
-        content = assemble_mod.generate_mod_content("0.2.2", "win64", ["2023", "2024", "2025"], has_cp37=False)
+        content = assemble_mod.generate_mod_file("0.2.2", "win64", has_cp37=False)
         assert "python37" not in content
+        assert "MAYAVERSION:2022" not in content
+        assert "MAYAVERSION:2023" in content
         assert "PLUG_IN_PATH+:=plug-ins" in content
 
+    def test_absolute_path(self):
+        content = assemble_mod.generate_mod_file("0.2.2", "win64", has_cp37=True, path="C:\\tools\\dcc-mcp-maya")
+        assert "C:\\tools\\dcc-mcp-maya" in content
+
     def test_macos_no_2022(self):
-        content = assemble_mod.generate_mod_content("0.2.2", "macos", ["2023", "2024", "2025"], has_cp37=False)
+        content = assemble_mod.generate_mod_file("0.2.2", "macos", has_cp37=False)
         assert "MAYAVERSION:2022" not in content
         assert "MAYAVERSION:2023" in content
         assert "PLUG_IN_PATH+:=plug-ins" in content
 
     def test_linux_all_versions(self):
-        content = assemble_mod.generate_mod_content("0.2.2", "linux", ["2022", "2023", "2024", "2025"], has_cp37=True)
+        content = assemble_mod.generate_mod_file("0.2.2", "linux", has_cp37=True)
         assert "MAYAVERSION:2022" in content
         assert "python37" in content
         assert "PLUG_IN_PATH+:=plug-ins" in content
 
 
-# ── assemble (integration) ──────────────────────────────────────────────────
+# ── generate_module_info ────────────────────────────────────────────────────
+
+
+class TestGenerateModuleInfo:
+    def test_with_cp37(self):
+        content = assemble_mod.generate_module_info("0.2.2", has_cp37=True)
+        info = json.loads(content)
+        assert info["name"] == "dcc_mcp_maya"
+        assert info["version"] == "0.2.2"
+        assert info["has_cp37"] is True
+        assert "2022" in info["supported_maya_versions"]
+
+    def test_without_cp37(self):
+        content = assemble_mod.generate_module_info("0.2.2", has_cp37=False)
+        info = json.loads(content)
+        assert info["has_cp37"] is False
+        assert "2022" not in info["supported_maya_versions"]
+
+
+# ── assemble helpers ────────────────────────────────────────────────────────
+
+
+def _setup_project(tmp_path: Path) -> Path:
+    """Create a minimal project structure for testing assemble()."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    # pyproject.toml
+    _make_fake_pyproject(project, "0.12.12")
+
+    # Maya plugin
+    plugin_dir = project / "maya" / "plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "dcc_mcp_maya_plugin.py").write_text("# plugin", encoding="utf-8")
+
+    # userSetup.py
+    maya_dir = project / "maya"
+    (maya_dir / "userSetup.py").write_text("# userSetup", encoding="utf-8")
+
+    # dcc_mcp_maya package
+    pkg_src = project / "src" / "dcc_mcp_maya"
+    pkg_src.mkdir(parents=True)
+    (pkg_src / "__init__.py").write_text("# maya package", encoding="utf-8")
+
+    # Packaging scripts
+    pkg_dir = project / "packaging"
+    pkg_dir.mkdir()
+    (pkg_dir / "install.bat").write_text("@echo install", encoding="utf-8")
+    (pkg_dir / "uninstall.bat").write_text("@echo uninstall", encoding="utf-8")
+    (pkg_dir / "install.sh").write_text("#!/bin/bash\necho install", encoding="utf-8")
+    (pkg_dir / "uninstall.sh").write_text("#!/bin/bash\necho uninstall", encoding="utf-8")
+    (pkg_dir / "README.txt").write_text("Readme", encoding="utf-8")
+    (pkg_dir / "README-pipeline.txt").write_text("Pipeline Readme", encoding="utf-8")
+
+    return project
+
+
+def _mock_download_and_resolve(project: Path, tmp_path: Path):
+    """Return mock patches for resolve_core_version and download_core_wheels."""
+    abi3_files = {
+        "dcc_mcp_core/__init__.py": b"# abi3 init",
+        "dcc_mcp_core/_core.pyd": b"\x00abi3_core",
+        "dcc_mcp_core/skill.py": b"class Skill: pass",
+    }
+    cp37_files = {
+        "dcc_mcp_core/__init__.py": b"# cp37 init",
+        "dcc_mcp_core/_core.pyd": b"\x00cp37_core",
+    }
+
+    def fake_download(version, platform, dest):
+        _make_fake_wheel(dest, f"dcc_mcp_core-{version}-cp38-abi3-win_amd64.whl", abi3_files)
+        if platform in ("win64", "linux"):
+            _make_fake_wheel(dest, f"dcc_mcp_core-{version}-cp37-cp37m-win_amd64.whl", cp37_files)
+        return list(dest.glob("dcc_mcp_core-*.whl"))
+
+    return fake_download
+
+
+# ── assemble (shared core) ──────────────────────────────────────────────────
 
 
 class TestAssemble:
-    def _setup_project(self, tmp_path: Path) -> Path:
-        """Create a minimal project structure for testing assemble()."""
-        project = tmp_path / "project"
-        project.mkdir()
-
-        # pyproject.toml
-        _make_fake_pyproject(project, "0.12.12")
-
-        # Maya plugin
-        plugin_dir = project / "maya" / "plugin"
-        plugin_dir.mkdir(parents=True)
-        (plugin_dir / "dcc_mcp_maya_plugin.py").write_text("# plugin", encoding="utf-8")
-
-        # userSetup.py
-        maya_dir = project / "maya"
-        (maya_dir / "userSetup.py").write_text("# userSetup", encoding="utf-8")
-
-        # dcc_mcp_maya package
-        pkg_src = project / "src" / "dcc_mcp_maya"
-        pkg_src.mkdir(parents=True)
-        (pkg_src / "__init__.py").write_text("# maya package", encoding="utf-8")
-
-        # Packaging scripts
-        pkg_dir = project / "packaging"
-        pkg_dir.mkdir()
-        (pkg_dir / "install.bat").write_text("@echo install", encoding="utf-8")
-        (pkg_dir / "uninstall.bat").write_text("@echo uninstall", encoding="utf-8")
-        (pkg_dir / "install.sh").write_text("#!/bin/bash\necho install", encoding="utf-8")
-        (pkg_dir / "uninstall.sh").write_text("#!/bin/bash\necho uninstall", encoding="utf-8")
-        (pkg_dir / "README.txt").write_text("Readme", encoding="utf-8")
-
-        return project
-
-    def _mock_download_and_resolve(self, project: Path, tmp_path: Path):
-        """Return mock patches for resolve_core_version and download_core_wheels."""
-        # Create fake wheels
-        abi3_files = {
-            "dcc_mcp_core/__init__.py": b"# abi3 init",
-            "dcc_mcp_core/_core.pyd": b"\x00abi3_core",
-            "dcc_mcp_core/skill.py": b"class Skill: pass",
-        }
-        cp37_files = {
-            "dcc_mcp_core/__init__.py": b"# cp37 init",
-            "dcc_mcp_core/_core.pyd": b"\x00cp37_core",
-        }
-
-        def fake_download(version, platform, dest):
-            _make_fake_wheel(dest, f"dcc_mcp_core-{version}-cp38-abi3-win_amd64.whl", abi3_files)
-            if platform in ("win64", "linux"):
-                _make_fake_wheel(dest, f"dcc_mcp_core-{version}-cp37-cp37m-win_amd64.whl", cp37_files)
-            return list(dest.glob("dcc_mcp_core-*.whl"))
-
-        return fake_download
-
     def test_win64_creates_python_and_python37(self, tmp_path):
-        project = self._setup_project(tmp_path)
+        project = _setup_project(tmp_path)
         output = tmp_path / "output"
         output.mkdir()
-        fake_download = self._mock_download_and_resolve(project, tmp_path)
+        fake_download = _mock_download_and_resolve(project, tmp_path)
 
         with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
             assemble_mod, "download_core_wheels", side_effect=fake_download
@@ -475,18 +486,16 @@ class TestAssemble:
         assert (result / "python37" / "dcc_mcp_core" / "__init__.py").exists()
         assert (result / "python37" / "dcc_mcp_maya" / "__init__.py").exists()
 
-        # Check module-info.json exists (replaces .mod — generated at install time)
-        assert (result / "module-info.json").exists()
-        import json
-
-        info = json.loads((result / "module-info.json").read_text(encoding="utf-8"))
-        assert info["version"] == "0.2.2"
-        assert info["has_cp37"] is True
-        # .mod file should NOT exist (generated at install time)
-        assert not (result / "dcc_mcp_maya.mod").exists()
+        # Check .mod file exists with relative paths
+        assert (result / "dcc_mcp_maya.mod").exists()
+        mod_content = (result / "dcc_mcp_maya.mod").read_text(encoding="utf-8")
+        assert "MAYAVERSION:2022" in mod_content
+        assert "python37" in mod_content
+        # Relative path uses "."
+        assert " ." in mod_content
 
     def test_macos_no_python37(self, tmp_path):
-        project = self._setup_project(tmp_path)
+        project = _setup_project(tmp_path)
         output = tmp_path / "output"
         output.mkdir()
 
@@ -506,34 +515,15 @@ class TestAssemble:
 
         assert (result / "python" / "dcc_mcp_core").exists()
         assert not (result / "python37").exists()
-
-    def test_module_info_structure(self, tmp_path):
-        project = self._setup_project(tmp_path)
-        output = tmp_path / "output"
-        output.mkdir()
-        fake_download = self._mock_download_and_resolve(project, tmp_path)
-
-        with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
-            assemble_mod, "download_core_wheels", side_effect=fake_download
-        ):
-            result = assemble_mod.assemble(project, "0.2.2", "win64", output)
-
-        # Verify module-info.json
-        import json
-
-        info = json.loads((result / "module-info.json").read_text(encoding="utf-8"))
-        assert info["name"] == "dcc_mcp_maya"
-        assert info["version"] == "0.2.2"
-        assert "2022" in info["supported_maya_versions"]
-        assert "2023" in info["supported_maya_versions"]
-        assert "2024" in info["supported_maya_versions"]
-        assert "2025" in info["supported_maya_versions"]
+        # No MAYAVERSION:2022 in .mod for macos
+        mod_content = (result / "dcc_mcp_maya.mod").read_text(encoding="utf-8")
+        assert "MAYAVERSION:2022" not in mod_content
 
     def test_plugin_and_usersetup_copied(self, tmp_path):
-        project = self._setup_project(tmp_path)
+        project = _setup_project(tmp_path)
         output = tmp_path / "output"
         output.mkdir()
-        fake_download = self._mock_download_and_resolve(project, tmp_path)
+        fake_download = _mock_download_and_resolve(project, tmp_path)
 
         with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
             assemble_mod, "download_core_wheels", side_effect=fake_download
@@ -543,23 +533,32 @@ class TestAssemble:
         assert (result / "plug-ins" / "dcc_mcp_maya_plugin.py").exists()
         assert (result / "scripts" / "userSetup.py").exists()
 
-    def test_install_scripts_win64(self, tmp_path):
-        project = self._setup_project(tmp_path)
+
+# ── assemble_portable ───────────────────────────────────────────────────────
+
+
+class TestAssemblePortable:
+    def test_win64_has_install_scripts(self, tmp_path):
+        project = _setup_project(tmp_path)
         output = tmp_path / "output"
         output.mkdir()
-        fake_download = self._mock_download_and_resolve(project, tmp_path)
+        fake_download = _mock_download_and_resolve(project, tmp_path)
 
         with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
             assemble_mod, "download_core_wheels", side_effect=fake_download
         ):
-            result = assemble_mod.assemble(project, "0.2.2", "win64", output)
+            result = assemble_mod.assemble_portable(project, "0.2.2", "win64", output)
 
         assert (result / "install.bat").exists()
         assert (result / "uninstall.bat").exists()
         assert not (result / "install.sh").exists()
+        assert (result / "dcc_mcp_maya.mod").exists()
+        assert (result / "README.txt").exists()
+        # Portable should NOT have module-info.json
+        assert not (result / "module-info.json").exists()
 
-    def test_install_scripts_linux(self, tmp_path):
-        project = self._setup_project(tmp_path)
+    def test_linux_has_install_sh(self, tmp_path):
+        project = _setup_project(tmp_path)
         output = tmp_path / "output"
         output.mkdir()
 
@@ -574,22 +573,79 @@ class TestAssemble:
         with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
             assemble_mod, "download_core_wheels", side_effect=fake_download
         ):
-            result = assemble_mod.assemble(project, "0.2.2", "linux", output)
+            result = assemble_mod.assemble_portable(project, "0.2.2", "linux", output)
 
         assert (result / "install.sh").exists()
         assert (result / "uninstall.sh").exists()
         assert not (result / "install.bat").exists()
 
-    def test_zip_created_by_main(self, tmp_path):
-        """Test that main() creates the ZIP archive."""
-        project = self._setup_project(tmp_path)
+
+# ── assemble_pipeline ───────────────────────────────────────────────────────
+
+
+class TestAssemblePipeline:
+    def test_has_module_info_and_no_install_scripts(self, tmp_path):
+        project = _setup_project(tmp_path)
         output = tmp_path / "output"
-        fake_download = self._mock_download_and_resolve(project, tmp_path)
+        output.mkdir()
+        fake_download = _mock_download_and_resolve(project, tmp_path)
 
         with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
             assemble_mod, "download_core_wheels", side_effect=fake_download
         ):
-            # Call main with mocked args
+            result = assemble_mod.assemble_pipeline(project, "0.2.2", "win64", output)
+
+        # Pipeline has module-info.json
+        assert (result / "module-info.json").exists()
+        info = json.loads((result / "module-info.json").read_text(encoding="utf-8"))
+        assert info["version"] == "0.2.2"
+        assert info["has_cp37"] is True
+
+        # Pipeline has .mod file
+        assert (result / "dcc_mcp_maya.mod").exists()
+
+        # Pipeline has README-pipeline.txt
+        assert (result / "README-pipeline.txt").exists()
+
+        # Pipeline does NOT have install scripts
+        assert not (result / "install.bat").exists()
+        assert not (result / "install.sh").exists()
+        assert not (result / "uninstall.bat").exists()
+        assert not (result / "uninstall.sh").exists()
+
+    def test_no_module_info_without_cp37(self, tmp_path):
+        project = _setup_project(tmp_path)
+        output = tmp_path / "output"
+        output.mkdir()
+
+        abi3_files = {"dcc_mcp_core/__init__.py": b"# test", "dcc_mcp_core/_core.so": b"\x00"}
+
+        def fake_download(version, platform, dest):
+            _make_fake_wheel(dest, f"dcc_mcp_core-{version}-cp38-abi3-macosx.whl", abi3_files)
+            return list(dest.glob("dcc_mcp_core-*.whl"))
+
+        with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
+            assemble_mod, "download_core_wheels", side_effect=fake_download
+        ):
+            result = assemble_mod.assemble_pipeline(project, "0.2.2", "macos", output)
+
+        info = json.loads((result / "module-info.json").read_text(encoding="utf-8"))
+        assert info["has_cp37"] is False
+        assert "2022" not in info["supported_maya_versions"]
+
+
+# ── main (ZIP creation) ────────────────────────────────────────────────────
+
+
+class TestMain:
+    def test_creates_two_zips(self, tmp_path):
+        project = _setup_project(tmp_path)
+        output = tmp_path / "output"
+        fake_download = _mock_download_and_resolve(project, tmp_path)
+
+        with patch.object(assemble_mod, "resolve_core_version", return_value="0.12.17"), patch.object(
+            assemble_mod, "download_core_wheels", side_effect=fake_download
+        ):
             import sys as real_sys
 
             old_argv = real_sys.argv
@@ -609,10 +665,11 @@ class TestAssemble:
             finally:
                 real_sys.argv = old_argv
 
-        # Verify ZIP was created
-        zip_files = list(output.glob("*.zip"))
-        assert len(zip_files) == 1
-        assert "0.2.2-win64" in zip_files[0].name
+        # Verify both ZIPs were created
+        zip_files = list(output.rglob("*.zip"))
+        names = [z.name for z in zip_files]
+        assert any("0.2.2-win64.zip" in n for n in names), f"Portable ZIP not found in {names}"
+        assert any("0.2.2-win64-pipeline.zip" in n for n in names), f"Pipeline ZIP not found in {names}"
 
 
 # ── Live integration test (requires network) ────────────────────────────────
@@ -649,7 +706,7 @@ class TestAssembleLive:
         result = assemble_mod.assemble(PROJECT_ROOT, "0.2.2", "win64", output)
 
         # Verify core structure
-        assert (result / "module-info.json").exists()
+        assert (result / "dcc_mcp_maya.mod").exists()
         assert (result / "python" / "dcc_mcp_core" / "__init__.py").exists()
         assert (result / "python" / "dcc_mcp_core" / "_core.pyd").exists()
         assert (result / "python" / "dcc_mcp_maya" / "__init__.py").exists()


### PR DESCRIPTION
## Summary

- Rewrite `install.bat`/`install.sh` using maya_umbrella pattern: `MODULE_DIR=%~dp0`, generate `.mod` with absolute path to extracted location, deploy `userSetup.py` via `type`/`cat` append
- Refactor `assemble_mod.py` to produce **two ZIP variants**:
  - **Portable** — with install scripts, pre-generated `.mod` (relative paths), for end users
  - **Pipeline** — with `module-info.json`, no install scripts, for network-share deployment
- Simplify `uninstall.bat`/`uninstall.sh` to only remove `.mod` from Maya modules dir
- Delete `post_install.py` from ZIP (verification is CI's job)
- Add `packaging/README-pipeline.txt` for pipeline deployment instructions

## Bug Fix

The original `install.bat` set `MODULE_DIR=%SCRIPT_DIR%dcc-mcp-maya`, but since `install.bat` already lives inside the `dcc-mcp-maya/` directory from the ZIP, this created a double-nested path like `...\dcc-mcp-maya\dcc-mcp-maya` which didn't exist. Users saw:

```
ERROR: Module directory not found at:
  C:\Users\...\dcc-mcp-maya-0.2.11-win64\dcc-mcp-maya\dcc-mcp-maya
```

This also caused the gateway `9765` connection refused error because the plugin never loaded correctly.

## Test plan

- [x] `python -m pytest tests/test_assemble_mod.py -v` — 31 passed
- [x] `python -m pytest tests/ -m "not e2e and not packaging"` — 3087 passed
- [x] Local assemble verification: `python packaging/assemble_mod.py --version 0.2.12 --platform win64 --output dist/mod-test --project-root .`
- [x] Verified ZIP structure for both portable and pipeline variants
- [x] Verified `.mod` file content has correct MAYAVERSION/PLATFORM/PYTHONPATH directives
- [ ] CI passes