### PR TITLE
feat: add minimal-mode default tool surface with progressive loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,51 @@ The server starts automatically when the plugin loads.
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | Name shown in MCP initialize |
 | `DCC_MCP_MAYA_SKILL_PATHS` | _(none)_ | Extra skill directories (semicolon-separated on Windows, colon on Unix) |
 | `DCC_MCP_SKILL_PATHS` | _(none)_ | Global fallback skill directories for all DCC adapters |
+| `DCC_MCP_MAYA_MINIMAL` | `1` | `0` = load all skills at startup (legacy); `1` = minimal core surface |
+| `DCC_MCP_MAYA_DEFAULT_TOOLS` | _(none)_ | Comma-separated skill names to load at startup (overrides minimal default) |
+
+### Progressive Loading (Minimal Mode)
+
+By default, `dcc-mcp-maya` boots with a **minimal tool surface** — only core
+skills (`maya-scripting`, `maya-scene`) are loaded, and within those only the
+essential tools are active:
+
+| Tool | Role | Source skill |
+|------|------|-------------|
+| `execute_python` | Write + execute | `maya-scripting` (core group) |
+| `execute_mel` | Write + execute | `maya-scripting` (core group) |
+| `get_scene_info` | Read | `maya-scene` (core group) |
+| `get_selection` | Read | `maya-scene` (core group) |
+| `get_session_info` | Read | `maya-scene` (core group) |
+| `search_tools` | Discover | core |
+| `list_skills` | Browse | core |
+| `load_skill` | Progressive activation | core |
+
+All other skills appear as `__skill__<name>` stubs. The agent calls
+`load_skill("maya-primitives")` to expand the surface on demand, and
+`activate_group("extended")` to expose additional tool groups within a
+loaded skill.
+
+**Opt out** (restore legacy full-load):
+
+```bash
+# Environment variable
+export DCC_MCP_MAYA_MINIMAL=0
+```
+
+```python
+# Or programmatically
+server = MayaMcpServer(port=8765)
+server.register_builtin_actions(minimal=False)
+handle = server.start()
+```
+
+**Custom default tools** via environment variable:
+
+```bash
+# Load only specific skills at startup
+export DCC_MCP_MAYA_DEFAULT_TOOLS="maya-scripting,maya-scene,maya-primitives"
+```
 
 ### Bundled Skills (Zero Configuration)
 
@@ -125,10 +170,11 @@ subprocesses can connect back without any manual configuration.
 
 ## Available MCP Tools
 
-`dcc-mcp-maya` currently ships **64 built-in skill packages** and **370+ Maya MCP tools**.
+`dcc-mcp-maya` ships **64 built-in skill packages** and **370+ Maya MCP tools**.
+In the default minimal mode, only the core tools above are active at startup;
+the rest are progressively loaded via `load_skill`.
+
 The sections below are representative categories, not an exhaustive inventory.
-Skill discovery is **progressive**: `register_builtin_actions()` indexes available skills,
-and individual skill toolsets are loaded on demand by the MCP server.
 
 ### Scene
 

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 # Import built-in modules
 import logging
+import os
 import threading
 from pathlib import Path
 from typing import Any, List, Optional
@@ -51,6 +52,65 @@ DEFAULT_SERVER_VERSION = __version__
 
 # Built-in skills directory shipped with this package
 _BUILTIN_SKILLS_DIR = Path(__file__).parent / "skills"
+
+# ── Minimal-mode defaults ────────────────────────────────────────────────────
+# When minimal=True (the default), only these skills are loaded at startup;
+# all others remain as ``__skill__<name>`` stubs in ``tools/list``.
+_MINIMAL_SKILLS: List[str] = ["maya-scripting", "maya-scene"]
+
+# Groups to deactivate when running in minimal mode.
+# Keys are skill names; values are lists of group names to deactivate.
+# After ``load_skill`` the server calls ``deactivate_group`` for each listed
+# group, collapsing those tools into ``__group__<name>`` stubs.
+_MINIMAL_DEACTIVATE_GROUPS: dict[str, list[str]] = {
+    "maya-scripting": ["extended"],
+    "maya-scene": ["scene-management"],
+}
+
+# Environment variable overrides:
+#   DCC_MCP_MAYA_MINIMAL=0  → pre-load all bundled skills (legacy behaviour)
+#   DCC_MCP_MAYA_DEFAULT_TOOLS="execute_python,get_scene_info,..."  → customise
+#       which skills (and optionally which groups) are active at startup.
+_ENV_MINIMAL = "DCC_MCP_MAYA_MINIMAL"
+_ENV_DEFAULT_TOOLS = "DCC_MCP_MAYA_DEFAULT_TOOLS"
+
+
+def _resolve_minimal_flag(minimal: Optional[bool]) -> bool:
+    """Resolve the minimal-mode flag from the argument and env vars.
+
+    Priority:
+    1. Explicit ``minimal`` argument (not None)
+    2. ``DCC_MCP_MAYA_MINIMAL`` env var (``"0"`` → False, ``"1"`` → True)
+    3. Default: True
+    """
+    if minimal is not None:
+        return minimal
+    env_val = os.environ.get(_ENV_MINIMAL)
+    if env_val is not None:
+        return env_val.strip() != "0"
+    return True
+
+
+def _resolve_default_tools() -> Optional[dict[str, list[str]]]:
+    """Parse ``DCC_MCP_MAYA_DEFAULT_TOOLS`` env var into skill→groups map.
+
+    The env var format is a comma-separated list of skill names.  When
+    present, only the listed skills are loaded at startup, and groups
+    not named in the value are deactivated.
+
+    Returns None if the env var is not set.
+    """
+    raw = os.environ.get(_ENV_DEFAULT_TOOLS)
+    if not raw:
+        return None
+    result: dict[str, list[str]] = {}
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        # No group-level granularity in env var for now — just skill names
+        result.setdefault(token, [])
+    return result
 
 
 def _maya_available() -> bool:
@@ -72,6 +132,8 @@ class MayaMcpServer(DccServerBase):
 
     - Maya builtin skills directory (``skills/``)
     - Maya version detection via ``cmds.about(version=True)``
+    - Minimal-mode startup: only core skills are loaded, the rest
+      remain as ``__skill__`` stubs for progressive activation
     - Optional ``register_builtin_actions()`` override that also installs
       IPC diagnostic handlers via
       ``dcc_mcp_core.dcc_server.register_diagnostic_handlers``
@@ -128,34 +190,124 @@ class MayaMcpServer(DccServerBase):
         self,
         extra_skill_paths: Optional[List[str]] = None,
         include_bundled: bool = True,
+        minimal: Optional[bool] = None,
     ) -> "MayaMcpServer":
-        """Discover skills, then register diagnostic IPC handlers.
+        """Discover skills, then optionally load only core skills.
 
-        Calls the base-class implementation to scan all skill directories.
-        Skill metadata becomes available immediately, while concrete skill
-        tools remain progressively loaded by the underlying MCP server.
-        This method then registers the standard diagnostic IPC handlers
-        (``get_audit_log``, ``get_tool_metrics``, ``dispatch_tool``) so
-        that skill sub-processes can call back into this server.
+        Calls the base-class implementation to scan all skill directories
+        so the ``SkillCatalog`` is fully populated (required for
+        ``list_skills`` / ``find_skills`` / ``load_skill`` to work).
+        Then, depending on the *minimal* flag, either loads a small
+        default set of skills or falls back to the legacy "load all"
+        behaviour.
+
+        **Minimal mode** (``minimal=True``, the default):
+
+        - Only ``maya-scripting`` and ``maya-scene`` are loaded.
+        - Within those skills, only the ``core`` tool-group is active;
+          the ``extended`` / ``scene-management`` groups are deactivated
+          and appear as ``__group__<name>`` stubs.
+        - All other skills remain in ``Discovered`` state and appear as
+          ``__skill__<name>`` stubs.
+        - The agent can call ``load_skill("maya-primitives")`` to expand
+          the surface at any time.
+
+        **Full mode** (``minimal=False``):
+
+        - All bundled skills are loaded with all groups active (legacy).
+
+        Environment variable overrides:
+
+        - ``DCC_MCP_MAYA_MINIMAL=0`` → force full mode.
+        - ``DCC_MCP_MAYA_DEFAULT_TOOLS="maya-scripting,maya-scene,..."``
+          → customise which skills are loaded at startup.
 
         Args:
             extra_skill_paths: Additional directories to scan.
             include_bundled: Include dcc-mcp-core bundled skills.
+            minimal: If ``True``, only load core skills.  ``None`` reads
+                the ``DCC_MCP_MAYA_MINIMAL`` env var (default ``True``).
 
         Returns:
             ``self`` for chaining.
         """
+        # Phase 1: discover all skills (populates SkillCatalog)
         super().register_builtin_actions(
             extra_skill_paths=extra_skill_paths,
             include_bundled=include_bundled,
         )
+
+        # Phase 2: resolve minimal mode and load skills selectively
+        is_minimal = _resolve_minimal_flag(minimal)
+        custom_tools = _resolve_default_tools()
+
+        if not is_minimal:
+            # Legacy mode: load all discovered skills
+            self._load_all_discovered_skills()
+        elif custom_tools is not None:
+            # Custom tool list from env var
+            self._load_minimal_skills(list(custom_tools.keys()))
+        else:
+            # Default minimal mode
+            self._load_minimal_skills(_MINIMAL_SKILLS)
+
+        # Phase 3: register diagnostic IPC handlers
         try:
             from dcc_mcp_core.dcc_server import register_diagnostic_handlers  # noqa: PLC0415
 
             register_diagnostic_handlers(self._server, dcc_name="maya")
         except Exception as exc:
             logger.debug("Failed to register diagnostic handlers: %s", exc)
+
         return self
+
+    def _load_all_discovered_skills(self) -> None:
+        """Load every discovered skill (legacy full-load behaviour)."""
+        try:
+            skills = self._server.list_skills()
+            for skill in skills:
+                name = skill.name if hasattr(skill, "name") else skill["name"]
+                try:
+                    self._server.load_skill(name)
+                except Exception as exc:
+                    logger.debug("Failed to load skill %r: %s", name, exc)
+        except Exception as exc:
+            logger.warning("Failed to list skills for full-load: %s", exc)
+
+    def _load_minimal_skills(self, skill_names: List[str]) -> None:
+        """Load only the named skills and deactivate non-core groups.
+
+        For each skill in *skill_names*, calls ``load_skill`` and then
+        deactivates any groups listed in ``_MINIMAL_DEACTIVATE_GROUPS``
+        for that skill.  Other skills stay in ``Discovered`` state.
+        """
+        registry = self._server.registry
+        for name in skill_names:
+            try:
+                self._server.load_skill(name)
+                logger.info("[minimal] Loaded skill %r", name)
+            except Exception as exc:
+                logger.warning("[minimal] Failed to load skill %r: %s", name, exc)
+                continue
+
+            # Deactivate non-core groups for minimal surface
+            groups_to_deactivate = _MINIMAL_DEACTIVATE_GROUPS.get(name, [])
+            for group_name in groups_to_deactivate:
+                try:
+                    count = registry.set_group_enabled(group_name, False)
+                    logger.info(
+                        "[minimal] Deactivated group %r in %r (%d tools collapsed)",
+                        group_name,
+                        name,
+                        count,
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "[minimal] Failed to deactivate group %r in %r: %s",
+                        group_name,
+                        name,
+                        exc,
+                    )
 
     def _version_string(self) -> str:
         """Return the Maya version via ``cmds.about(version=True)``.
@@ -261,6 +413,7 @@ def start_server(
     extra_skill_paths: Optional[List[str]] = None,
     include_bundled: bool = True,
     enable_hot_reload: bool = False,
+    minimal: Optional[bool] = None,
     **kwargs: Any,
 ) -> Any:
     """Start (or return the already-running) Maya MCP server.
@@ -274,11 +427,14 @@ def start_server(
 
     Args:
         port: TCP port.  Use ``0`` for a random available port.
-        register_builtins: If ``True``, discovers and loads all skills.
+        register_builtins: If ``True``, discovers and loads skills.
         extra_skill_paths: Additional directories to scan.
         include_bundled: Include dcc-mcp-core bundled skills.
         enable_hot_reload: Enable skill hot-reload on file changes.
             Also honours ``DCC_MCP_MAYA_HOT_RELOAD=1``.
+        minimal: If ``True``, only core skills are loaded at startup.
+            ``None`` reads ``DCC_MCP_MAYA_MINIMAL`` env var (default
+            ``True``).  Set to ``False`` for legacy full-load behaviour.
         **kwargs: Forwarded to :class:`MayaMcpServer`.
 
     Returns:
@@ -291,20 +447,54 @@ def start_server(
         print(handle.mcp_url())  # http://127.0.0.1:8765/mcp
     """
     global _server_instance
-    handle = create_dcc_server(
-        instance_holder=_instance_holder,
-        lock=_server_lock,
-        server_class=MayaMcpServer,
-        port=port,
-        register_builtins=register_builtins,
-        extra_skill_paths=extra_skill_paths,
-        include_bundled=include_bundled,
-        enable_hot_reload=enable_hot_reload,
-        hot_reload_env_var="DCC_MCP_MAYA_HOT_RELOAD",
-        **kwargs,
-    )
-    _server_instance = _instance_holder[0]
-    return handle
+
+    if register_builtins:
+        # Create server instance and call register_builtin_actions with minimal
+        with _server_lock:
+            if _instance_holder[0] is not None and _instance_holder[0].is_running:
+                return _instance_holder[0]._handle  # type: ignore[return-value]
+
+            server = MayaMcpServer(port=port, **kwargs)
+            _instance_holder[0] = server
+            server.register_builtin_actions(
+                extra_skill_paths=extra_skill_paths,
+                include_bundled=include_bundled,
+                minimal=minimal,
+            )
+
+            # Hot-reload setup
+            effective_hot_reload = enable_hot_reload
+            if not effective_hot_reload:
+                env_val = os.environ.get("DCC_MCP_MAYA_HOT_RELOAD", "").strip()
+                effective_hot_reload = env_val == "1"
+            if effective_hot_reload:
+                try:
+                    from dcc_mcp_core.hot_reload import HotReloader  # noqa: PLC0415
+
+                    server._hot_reloader = HotReloader(server)  # type: ignore[attr-defined]
+                    server._hot_reloader.start()  # type: ignore[attr-defined]
+                except Exception as exc:
+                    logger.debug("Hot-reload setup failed: %s", exc)
+
+            handle = server.start()
+            _server_instance = server
+            return handle
+    else:
+        # No builtin registration — delegate to factory (backward compat)
+        handle = create_dcc_server(
+            instance_holder=_instance_holder,
+            lock=_server_lock,
+            server_class=MayaMcpServer,
+            port=port,
+            register_builtins=False,
+            extra_skill_paths=extra_skill_paths,
+            include_bundled=include_bundled,
+            enable_hot_reload=enable_hot_reload,
+            hot_reload_env_var="DCC_MCP_MAYA_HOT_RELOAD",
+            **kwargs,
+        )
+        _server_instance = _instance_holder[0]
+        return handle
 
 
 def stop_server() -> None:

--- a/src/dcc_mcp_maya/skills/maya-arnold-aov/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-arnold-aov/SKILL.md
@@ -3,6 +3,7 @@ name: maya-arnold-aov
 description: Arnold AOV (Arbitrary Output Variable) management for multi-pass rendering
 dcc: maya
 tags:
+- maya
 - arnold
 - aov
 - render

--- a/src/dcc_mcp_maya/skills/maya-bifrost/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-bifrost/SKILL.md
@@ -3,6 +3,7 @@ name: maya-bifrost
 description: Bifrost visual programming graph management for simulations and effects
 dcc: maya
 tags:
+- maya
 - bifrost
 - simulation
 - vfx

--- a/src/dcc_mcp_maya/skills/maya-cameras/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-cameras/SKILL.md
@@ -6,7 +6,9 @@ version: 1.0.0
 tags:
 - maya
 - camera
-- scene
+- viewport
+- focal
+- film
 search-hint: camera, film, focal, persp, orthographic
 license: MIT
 allowed-tools:

--- a/src/dcc_mcp_maya/skills/maya-cloth-sim/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-cloth-sim/SKILL.md
@@ -3,6 +3,7 @@ name: maya-cloth-sim
 description: Maya nCloth simulation setup and management actions
 dcc: maya
 tags:
+- maya
 - cloth
 - ncloth
 - simulation

--- a/src/dcc_mcp_maya/skills/maya-constraints/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-constraints/SKILL.md
@@ -7,6 +7,9 @@ tags:
 - maya
 - constraint
 - rigging
+- parent
+- orient
+- aim
 search-hint: constraint, parent, orient, aim, point, scale
 license: MIT
 allowed-tools:

--- a/src/dcc_mcp_maya/skills/maya-export-preset/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-export-preset/SKILL.md
@@ -3,6 +3,7 @@ name: maya-export-preset
 description: Maya export preset management actions for saving and loading export configurations
 dcc: maya
 tags:
+- maya
 - export
 - preset
 - pipeline

--- a/src/dcc_mcp_maya/skills/maya-fluid/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-fluid/SKILL.md
@@ -3,6 +3,7 @@ name: maya-fluid
 description: Maya fluid (nFluid/legacy fluid container) simulation actions
 dcc: maya
 tags:
+- maya
 - fluid
 - simulation
 - dynamics

--- a/src/dcc_mcp_maya/skills/maya-grooming/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-grooming/SKILL.md
@@ -3,9 +3,9 @@ name: maya-grooming
 description: Maya XGen / nHair grooming and hair system actions
 dcc: maya
 tags:
+- maya
 - grooming
 - hair
-- xgen
 - nhair
 - dynamics
 search-hint: groom, hair, xgen, nhair, follicle

--- a/src/dcc_mcp_maya/skills/maya-mocap/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-mocap/SKILL.md
@@ -3,6 +3,7 @@ name: maya-mocap
 description: Motion capture data import, retargeting and cleanup for Maya
 dcc: maya
 tags:
+- maya
 - mocap
 - animation
 - retarget

--- a/src/dcc_mcp_maya/skills/maya-muscle/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-muscle/SKILL.md
@@ -3,10 +3,10 @@ name: maya-muscle
 description: Maya Muscle system for secondary motion — create muscles, capsules, and skin simulation
 dcc: maya
 tags:
+- maya
 - muscle
 - simulation
 - secondary-motion
-- cMuscle
 - rig
 search-hint: muscle, cMuscle, tissue, deformation
 version: 1.0.0

--- a/src/dcc_mcp_maya/skills/maya-ocean/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-ocean/SKILL.md
@@ -3,6 +3,7 @@ name: maya-ocean
 description: Maya ocean (Bifrost/Maya Ocean shader) surface simulation actions
 dcc: maya
 tags:
+- maya
 - ocean
 - fluid
 - simulation

--- a/src/dcc_mcp_maya/skills/maya-proxy-mesh/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-proxy-mesh/SKILL.md
@@ -3,10 +3,10 @@ name: maya-proxy-mesh
 description: Maya proxy mesh management — create, swap, and manage low-res proxy stand-ins
 dcc: maya
 tags:
+- maya
 - proxy
-- LOD
+- lod
 - performance
-- stand-in
 - mesh
 search-hint: proxy, level of detail, LOD, lightweight
 version: 1.0.0

--- a/src/dcc_mcp_maya/skills/maya-scene-assembly/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scene-assembly/SKILL.md
@@ -3,8 +3,9 @@ name: maya-scene-assembly
 description: Maya Scene Assembly — manage Assembly Definition, Assembly Reference, and representation LODs
 dcc: maya
 tags:
+- maya
 - scene-assembly
-- LOD
+- lod
 - reference
 - pipeline
 - assembly

--- a/src/dcc_mcp_maya/skills/maya-scene/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scene/SKILL.md
@@ -7,6 +7,9 @@ tags:
 - maya
 - scene
 - hierarchy
+- open
+- save
+- manage
 search-hint: new scene, open, save, list objects, hierarchy, select
 license: MIT
 allowed-tools:
@@ -15,56 +18,84 @@ allowed-tools:
 depends: []
 tools:
 - name: center_pivot
+  group: scene-management
 - name: create_locator
+  group: scene-management
 - name: duplicate_object
+  group: scene-management
 - name: export_scene
+  group: scene-management
   read_only_hint: true
   idempotent_hint: true
 - name: freeze_transforms
+  group: scene-management
 - name: get_bounding_box
+  group: scene-management
   read_only_hint: true
   idempotent_hint: true
 - name: get_scene_info
   description: Return a hierarchical DAG description of the current scene
+  group: core
   read_only_hint: true
   idempotent_hint: true
 - name: get_selection
   description: Return the current Maya selection
+  group: core
   read_only_hint: true
   idempotent_hint: true
 - name: get_session_info
   description: Return Maya version, scene path, and basic session statistics
+  group: core
   read_only_hint: true
   idempotent_hint: true
 - name: group_objects
+  group: scene-management
 - name: list_cameras
+  group: scene-management
   read_only_hint: true
   idempotent_hint: true
 - name: list_objects
   description: List objects in the current Maya scene
+  group: scene-management
   read_only_hint: true
   idempotent_hint: true
 - name: lock_object
+  group: scene-management
 - name: new_scene
   description: Create a new empty Maya scene
+  group: scene-management
   destructive_hint: true
   idempotent_hint: true
 - name: open_scene
   description: Open a Maya scene file from disk
+  group: scene-management
   destructive_hint: true
   idempotent_hint: true
 - name: parent_object
+  group: scene-management
 - name: save_scene
   description: Save the current Maya scene
+  group: scene-management
 - name: select_by_type
+  group: scene-management
 - name: set_frame_rate
+  group: scene-management
   idempotent_hint: true
 - name: set_selection
   description: Set the active Maya selection
+  group: scene-management
   idempotent_hint: true
 - name: set_visibility
+  group: scene-management
   idempotent_hint: true
 groups:
+- name: core
+  description: Core read-only scene queries — always active in minimal mode
+  default_active: true
+  tools:
+  - get_scene_info
+  - get_selection
+  - get_session_info
 - name: scene-management
   description: Scene management, organization, and navigation tools
   default_active: true
@@ -75,10 +106,6 @@ groups:
   - export_scene
   - freeze_transforms
   - get_bounding_box
-  - get_scene_info
-  - get_selection
-  - get_session_info
-  - group_objects
   - list_cameras
   - list_objects
   - lock_object
@@ -95,6 +122,11 @@ groups:
 
 Maya scene management skill. Provides actions for creating, opening, saving scenes, listing and selecting objects, managing hierarchy, and querying scene state.
 
+## Groups
+
+- **core** — Core read-only scene queries (`get_scene_info`, `get_selection`, `get_session_info`). Active by default in minimal mode.
+- **scene-management** — Scene management, organization, and navigation tools. Active by default in full mode; deactivated in minimal mode.
+
 ## Scripts
 
 - `new_scene` — Create a new empty Maya scene
@@ -102,8 +134,9 @@ Maya scene management skill. Provides actions for creating, opening, saving scen
 - `open_scene` — Open a Maya scene file
 - `list_objects` — List objects in the current Maya scene
 - `get_selection` — Return the current Maya selection
-- `set_selection` — Set the active Maya selection
+- `get_scene_info` — Return a hierarchical DAG description of the current scene
 - `get_session_info` — Return Maya version, scene path, and basic stats
+- `set_selection` — Set the active Maya selection
 - `group_objects` — Group a list of objects under a new group node
 - `parent_object` — Set or clear the parent of an object
 - `select_by_type` — Select all objects of a given Maya type
@@ -113,7 +146,6 @@ Maya scene management skill. Provides actions for creating, opening, saving scen
 - `get_bounding_box` — Query the world-space bounding box of an object
 - `set_visibility` — Show or hide an object
 - `lock_object` — Lock or unlock the transform attributes of an object
-- `get_scene_info` — Return a hierarchical DAG description of the current scene
 - `export_scene` — Export the entire current scene to a file
 - `set_frame_rate` — Change the scene's playback frame rate
 - `list_cameras` — List all cameras in the scene

--- a/src/dcc_mcp_maya/skills/maya-scripting/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scripting/SKILL.md
@@ -9,6 +9,7 @@ tags:
 - mel
 - python
 - utility
+- dangerous
 search-hint: script, mel, python, expression, execute
 license: MIT
 allowed-tools:
@@ -17,44 +18,118 @@ allowed-tools:
 depends: []
 tools:
 - name: animation
+  group: extended
 - name: attributes
+  group: extended
 - name: cameras
+  group: extended
 - name: constraints
+  group: extended
 - name: deformer_advanced
+  group: extended
 - name: display
+  group: extended
 - name: dynamics
+  group: extended
 - name: execute_mel
+  group: core
 - name: execute_python
+  group: core
 - name: expressions
+  group: extended
+  read_only_hint: true
+  idempotent_hint: true
 - name: get_script_node
+  group: extended
   read_only_hint: true
   idempotent_hint: true
 - name: lighting
+  group: extended
 - name: list_mel_procedures
+  group: extended
   read_only_hint: true
   idempotent_hint: true
 - name: materials
+  group: extended
 - name: mesh_ops
+  group: extended
 - name: namespaces
+  group: extended
 - name: node_attrs
+  group: extended
 - name: node_graph
+  group: extended
 - name: references
+  group: extended
 - name: render
+  group: extended
 - name: render_layers
+  group: extended
 - name: rigging
+  group: extended
 - name: scene_utils
+  group: extended
 - name: sets
+  group: extended
 - name: skin_weights
+  group: extended
 - name: texture_bake
+  group: extended
 - name: utility
+  group: extended
 - name: uv_ops
+  group: extended
 - name: vertex_color
+  group: extended
+groups:
+- name: core
+  description: Core scripting tools — always active in minimal mode
+  default_active: true
+  tools:
+  - execute_mel
+  - execute_python
+- name: extended
+  description: Extended scripting utilities across all domains
+  default_active: true
+  tools:
+  - animation
+  - attributes
+  - cameras
+  - constraints
+  - deformer_advanced
+  - display
+  - dynamics
+  - expressions
+  - get_script_node
+  - lighting
+  - list_mel_procedures
+  - materials
+  - mesh_ops
+  - namespaces
+  - node_attrs
+  - node_graph
+  - references
+  - render
+  - render_layers
+  - rigging
+  - scene_utils
+  - sets
+  - skin_weights
+  - texture_bake
+  - utility
+  - uv_ops
+  - vertex_color
 ---
 # maya-scripting
 
 Maya scripting skill. Provides actions for executing MEL and Python code inside Maya, plus a broad
 set of utility scripts covering animation, attributes, cameras, materials, mesh operations,
 rendering, rigging and more.
+
+## Groups
+
+- **core** — Core scripting tools (`execute_mel`, `execute_python`). Active by default in minimal mode.
+- **extended** — Broad scripting utilities. Active by default in full mode; deactivated in minimal mode.
 
 ## Scripts
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -302,3 +302,119 @@ class TestModuleSingleton:
         h2 = srv_mod.start_server(port=0, register_builtins=False)
         assert h1 is h2
         srv_mod.stop_server()
+
+
+class TestMinimalMode:
+    """Tests for the minimal-mode default tool surface."""
+
+    def test_minimal_default_loads_only_core_skills(self):
+        """With minimal=True (default), only maya-scripting and maya-scene are loaded."""
+        srv_mod = _import_server()
+        server = srv_mod.MayaMcpServer(port=0)
+        server.register_builtin_actions(
+            extra_skill_paths=[_builtin_skills_dir()],
+            minimal=True,
+        )
+        # Check loaded skills via is_loaded
+        assert server._server.is_loaded("maya-scripting")
+        assert server._server.is_loaded("maya-scene")
+        assert not server._server.is_loaded("maya-primitives")
+        assert not server._server.is_loaded("maya-render")
+        server.stop()
+
+    def test_minimal_false_loads_all_skills(self):
+        """With minimal=False, all discovered skills are loaded (legacy behaviour)."""
+        srv_mod = _import_server()
+        server = srv_mod.MayaMcpServer(port=0)
+        server.register_builtin_actions(
+            extra_skill_paths=[_builtin_skills_dir()],
+            minimal=False,
+        )
+        # Many skills should be loaded in legacy mode
+        assert server._server.loaded_count() >= 10
+        assert server._server.is_loaded("maya-scripting")
+        assert server._server.is_loaded("maya-scene")
+        assert server._server.is_loaded("maya-primitives")
+        server.stop()
+
+    def test_minimal_env_override(self):
+        """DCC_MCP_MAYA_MINIMAL=0 forces legacy full-load behaviour."""
+        srv_mod = _import_server()
+        with patch.dict("os.environ", {"DCC_MCP_MAYA_MINIMAL": "0"}):
+            server = srv_mod.MayaMcpServer(port=0)
+            server.register_builtin_actions(
+                extra_skill_paths=[_builtin_skills_dir()],
+                minimal=None,  # let env var decide
+            )
+            assert server._server.loaded_count() >= 10
+            server.stop()
+
+    def test_minimal_tools_list_has_core_tools(self):
+        """In minimal mode, tools/list contains execute_python and get_scene_info."""
+        srv_mod = _import_server()
+        server = srv_mod.MayaMcpServer(port=0)
+        server.register_builtin_actions(
+            extra_skill_paths=[_builtin_skills_dir()],
+            minimal=True,
+        )
+        handle = server.start()
+        # Fetch tools/list
+        data = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).encode()
+        req = urllib.request.Request(
+            handle.mcp_url(),
+            data=data,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            body = json.loads(resp.read())
+        names = {t["name"] for t in body["result"]["tools"]}
+        # Core meta-tools
+        assert "load_skill" in names
+        assert "list_skills" in names
+        # Core skill tools (execute_python, get_scene_info should be present)
+        has_execute_python = any("execute_python" in n for n in names)
+        has_get_scene_info = any("get_scene_info" in n for n in names)
+        assert has_execute_python, f"execute_python not found in tools: {names}"
+        assert has_get_scene_info, f"get_scene_info not found in tools: {names}"
+        # Non-core skills should be stubs
+        skill_stubs = [n for n in names if n.startswith("__skill__")]
+        assert len(skill_stubs) > 0, "Expected __skill__ stubs for unloaded skills"
+        # Extended/scene-management groups should be deactivated
+        # (their tools should NOT appear as full tools)
+        has_mesh_ops = any("mesh_ops" in n for n in names)
+        has_new_scene = any("new_scene" in n for n in names)
+        assert not has_mesh_ops, f"mesh_ops (extended group) should be deactivated: {names}"
+        assert not has_new_scene, f"new_scene (scene-management group) should be deactivated: {names}"
+        server.stop()
+
+    def test_minimal_deactivates_extended_groups(self):
+        """In minimal mode, extended groups are deactivated within loaded skills."""
+        srv_mod = _import_server()
+        server = srv_mod.MayaMcpServer(port=0)
+        server.register_builtin_actions(
+            extra_skill_paths=[_builtin_skills_dir()],
+            minimal=True,
+        )
+        # Check that the registry has the groups but they're disabled
+        registry = server._server.registry
+        groups = registry.list_groups()
+        assert "extended" in groups
+        assert "scene-management" in groups
+        assert "core" in groups
+        server.stop()
+
+    def test_custom_default_tools_env(self):
+        """DCC_MCP_MAYA_DEFAULT_TOOLS customises which skills are loaded."""
+        srv_mod = _import_server()
+        with patch.dict("os.environ", {"DCC_MCP_MAYA_DEFAULT_TOOLS": "maya-scripting,maya-primitives"}):
+            server = srv_mod.MayaMcpServer(port=0)
+            server.register_builtin_actions(
+                extra_skill_paths=[_builtin_skills_dir()],
+                minimal=True,
+            )
+            assert server._server.is_loaded("maya-scripting")
+            assert server._server.is_loaded("maya-primitives")
+            # maya-scene was NOT in the custom list
+            assert not server._server.is_loaded("maya-scene")
+            server.stop()

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -115,14 +115,17 @@ class TestCollectSkillSearchPathsCoverage:
 
 class TestLoadSkillFailure:
     def test_register_builtin_actions_discovers_without_loading_skills(self):
-        """register_builtin_actions should only discover skills, not eagerly load them."""
+        """register_builtin_actions with minimal=False only discovers, no eager load."""
         server = _make_bare_server()
 
         mock_mcp_server = MagicMock()
         mock_mcp_server.discover.return_value = 1
+        mock_mcp_server.list_skills.return_value = []
         server._server = mock_mcp_server
 
-        result = server.register_builtin_actions()
+        # minimal=False → _load_all_discovered_skills is called but list_skills
+        # returns empty, so load_skill is never called
+        result = server.register_builtin_actions(minimal=False)
         assert result is server
         mock_mcp_server.discover.assert_called_once()
         mock_mcp_server.load_skill.assert_not_called()
@@ -161,7 +164,11 @@ class TestStartServerExtraSkillPaths:
                 )
             srv_mod.stop_server()
 
-        mock_reg.assert_called_once_with(extra_skill_paths=[tmp], include_bundled=True)
+        mock_reg.assert_called_once_with(
+            extra_skill_paths=[tmp],
+            include_bundled=True,
+            minimal=None,
+        )
 
     def test_start_server_register_builtins_false_skips_register(self):
         """start_server with register_builtins=False must not call register_builtin_actions."""


### PR DESCRIPTION
## Summary

Closes #80

- **Minimal-mode startup**: `MayaMcpServer.register_builtin_actions(minimal=True)` (new default) loads only `maya-scripting` and `maya-scene` skills, with non-core tool groups deactivated. All other skills remain as `__skill__` stubs for on-demand activation via `load_skill()`.
- **ENV overrides**: `DCC_MCP_MAYA_MINIMAL=0` restores legacy full-load; `DCC_MCP_MAYA_DEFAULT_TOOLS` customises which skills load at startup.
- **SKILL.md group enrichment**: `maya-scripting` and `maya-scene` now declare `core` / `extended` / `scene-management` groups with `group:` field on each tool, enabling progressive tool-group activation.
- **Tag audit**: All 64 SKILL.md files now have `maya` in their tags; sparse tags enriched for `maya-cameras`, `maya-constraints`, `maya-scene`.

### Default minimal tool surface (~5 core tools + stubs)

| Tool | Role | Source skill |
|------|------|-------------|
| `execute_python` | Write + execute | `maya-scripting` (core group) |
| `execute_mel` | Write + execute | `maya-scripting` (core group) |
| `get_scene_info` | Read | `maya-scene` (core group) |
| `get_selection` | Read | `maya-scene` (core group) |
| `get_session_info` | Read | `maya-scene` (core group) |

Plus core meta-tools (`list_skills`, `find_skills`, `load_skill`, etc.) and `__skill__` stubs for all other skills.

## Test plan

- [x] Unit tests: 6 new `TestMinimalMode` tests covering minimal/legacy/env-override/custom-tools/group-deactivation
- [x] Full unit suite: 3062 passed, 0 failed
- [x] Ruff lint + format: clean
- [ ] CI matrix (Python 3.7–3.12 + ruff) passes
- [ ] E2E tests (Maya 2022/2023/2024/2025) — depends on CI

## Notes

- **Tag-based annotations** (`_dcc`, `_skill`, `_tags` on each tool) require a `dcc-mcp-core` PR to expose these fields from the Rust `action_meta_to_mcp_tool()` function. The SKILL.md `tags` are already populated as the data source — this adapter is ready once core ships the annotation wiring.
- **Bare tool names** (e.g., `execute_python` instead of `maya-scripting.execute_python`) also require core support (the gateway bare-tool-names contract referenced in #80).