### PR TITLE
feat(skills): annotate bundled tools.yaml with execution/affinity (#84)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,6 @@ jobs:
 
       - name: Lint SKILL.md files
         run: python tools/lint_skills.py --error-only
+
+      - name: Lint tools.yaml affinity (issue #84)
+        run: python tools/lint_skill_affinity.py

--- a/README.md
+++ b/README.md
@@ -255,6 +255,54 @@ Add to `claude_desktop_config.json`:
 - Maya 2020+ (Python 3.7+)
 - [`dcc-mcp-core`](https://github.com/loonghao/dcc-mcp-core) ≥ 0.12.29
 
+## Authoring Skills: Execution & Affinity
+
+Every tool declared in a `tools.yaml` file must tell the MCP gateway **how** it
+should be dispatched.  This is what lets the gateway return an async `job_id`
+instead of blocking, and what prevents main-thread-affine tools from running
+on a worker thread and crashing Maya.
+
+Each entry in `tools.yaml` supports three dispatch fields:
+
+```yaml
+tools:
+  - name: render_frames
+    execution: async          # long-running — spawn as a Job
+    affinity: main            # cmds.render touches scene state
+    timeout_hint_secs: 600    # required when execution: async
+  - name: get_scene_info
+    execution: sync
+    affinity: main            # cmds.ls is main-thread-only
+  - name: list_render_presets
+    execution: sync
+    affinity: any             # pure filesystem read — worker-thread safe
+```
+
+Rules of thumb:
+
+| Property | Guidance |
+|---|---|
+| `execution: async` | Use for anything that typically runs > 2s (render, bake, simulation, large I/O). Must declare `timeout_hint_secs`. |
+| `execution: sync` | Use for fast queries, attribute edits, and small creations. |
+| `affinity: main` | **Default**. Anything that calls `maya.cmds` or `OpenMaya`. |
+| `affinity: any`  | Pure Python / filesystem only — never touches Maya state. |
+
+Two helpers keep the annotations consistent across the 64 bundled skills:
+
+```bash
+# Annotate every bundled tools.yaml from the SKILL_DEFAULTS table.
+python tools/annotate_skill_affinity.py
+
+# CI enforcement — fails if any tool is missing affinity/execution
+# or if an async tool is missing timeout_hint_secs.
+python tools/lint_skill_affinity.py
+```
+
+Third-party skill authors should run `tools/lint_skill_affinity.py` against
+their own skill packages before publishing.  See issue
+[#84](https://github.com/loonghao/dcc-mcp-maya/issues/84) for the full
+categorisation matrix.
+
 ## Development
 
 ### Clone and Install

--- a/src/dcc_mcp_maya/skills/maya-animation/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-animation/tools.yaml
@@ -1,65 +1,93 @@
 tools:
 - name: bake_constraints
+  execution: sync
+  affinity: main
   group: animation
 - name: bake_simulation
   description: Bake simulation / constraints to keyframes on objects
+  execution: sync
+  affinity: main
   group: animation
 - name: delete_keyframes
   description: Delete keyframes from an object within an optional frame range
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: animation
 - name: export_animation_curves
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: animation
 - name: get_current_time
   description: Get the current frame number
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: animation
 - name: get_frame_range
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: animation
 - name: get_keyframes
   description: Get all keyframe times for an object / attribute
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: animation
 - name: import_animation_curves
+  execution: sync
+  affinity: main
   group: animation
 - name: list_animation_curves
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: animation
 - name: query_scene_time_info
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: animation
 - name: set_animation_curve_tangent
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: animation
 - name: set_current_time
   description: Set the current frame number
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: animation
 - name: set_keyframe
   description: Set a keyframe on an object at the given time
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: animation
 - name: set_timeline
   description: Set the playback and animation timeline range
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: animation

--- a/src/dcc_mcp_maya/skills/maya-annotation/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-annotation/tools.yaml
@@ -1,13 +1,21 @@
 tools:
 - name: create_annotation
+  execution: sync
+  affinity: main
 - name: delete_annotation
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
 - name: list_annotations
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: update_annotation
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-arnold-aov/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-arnold-aov/tools.yaml
@@ -1,21 +1,31 @@
 tools:
 - name: add_aov
+  execution: sync
+  affinity: main
   group: rendering
 - name: delete_aov
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: rendering
 - name: enable_aov
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
 - name: list_aovs
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
 - name: set_aov_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rendering

--- a/src/dcc_mcp_maya/skills/maya-attributes/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-attributes/tools.yaml
@@ -1,17 +1,27 @@
 tools:
 - name: add_attribute
+  execution: sync
+  affinity: main
 - name: delete_attribute
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
 - name: get_attribute
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: list_attributes
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: set_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-audio/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-audio/tools.yaml
@@ -1,13 +1,21 @@
 tools:
 - name: import_audio
+  execution: sync
+  affinity: main
 - name: list_audio
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: remove_audio
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
 - name: set_timeline_audio
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-bifrost/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-bifrost/tools.yaml
@@ -1,16 +1,27 @@
 tools:
 - name: add_bifrost_node
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: connect_bifrost_ports
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: create_bifrost_graph
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
   group: simulation-fx
 - name: list_bifrost_graphs
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: set_bifrost_property
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx

--- a/src/dcc_mcp_maya/skills/maya-blend-shape-utils/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-blend-shape-utils/tools.yaml
@@ -1,17 +1,25 @@
 tools:
 - name: create_blend_shape
+  execution: sync
+  affinity: main
   group: rigging
 - name: get_blend_shape_weights
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rigging
 - name: list_blend_shapes
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rigging
 - name: set_blend_shape_weight
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rigging

--- a/src/dcc_mcp_maya/skills/maya-cache/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-cache/tools.yaml
@@ -1,11 +1,21 @@
 tools:
 - name: attach_geometry_cache
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
 - name: create_geometry_cache
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
 - name: delete_geometry_cache
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
 - name: list_geometry_caches
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-camera-sequence/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-camera-sequence/tools.yaml
@@ -1,17 +1,25 @@
 tools:
 - name: create_shot
+  execution: sync
+  affinity: main
   group: animation
 - name: delete_shot
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: animation
 - name: list_shots
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: animation
 - name: set_shot_range
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: animation

--- a/src/dcc_mcp_maya/skills/maya-cameras/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-cameras/tools.yaml
@@ -1,21 +1,31 @@
 tools:
 - name: create_camera
+  execution: sync
+  affinity: main
   group: rendering
 - name: get_camera_info
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
 - name: list_all_cameras
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
 - name: set_active_camera
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
 - name: set_camera_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rendering

--- a/src/dcc_mcp_maya/skills/maya-cloth-sim/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-cloth-sim/tools.yaml
@@ -1,14 +1,23 @@
 tools:
 - name: bake_cloth_cache
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
   group: simulation-fx
 - name: create_ncloth
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: list_ncloth_objects
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: set_ncloth_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx

--- a/src/dcc_mcp_maya/skills/maya-color-grading/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-color-grading/tools.yaml
@@ -1,18 +1,26 @@
 tools:
 - name: apply_gamma_correction
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
 - name: get_color_management_info
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: set_rendering_space
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
 - name: set_view_transform
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting

--- a/src/dcc_mcp_maya/skills/maya-constraints-advanced/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-constraints-advanced/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: add_pole_vector_constraint
+  execution: sync
+  affinity: main
   group: animation
 - name: bake_constraint
+  execution: sync
+  affinity: main
   group: animation
 - name: get_constraint_weights
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: animation
 - name: set_constraint_weight
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: animation

--- a/src/dcc_mcp_maya/skills/maya-constraints/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-constraints/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: add_constraint
+  execution: sync
+  affinity: main
   group: animation
 - name: create_constraint_weighted
+  execution: sync
+  affinity: main
   group: animation
 - name: list_constraints
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: animation
 - name: remove_constraint
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-deformers/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-deformers/tools.yaml
@@ -1,19 +1,33 @@
 tools:
 - name: apply_subdivision
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
 - name: cleanup_mesh
+  execution: sync
+  affinity: main
   group: rigging
 - name: create_cluster
+  execution: sync
+  affinity: main
   group: rigging
 - name: create_lattice
+  execution: sync
+  affinity: main
   group: rigging
 - name: sculpt_deformer
+  execution: sync
+  affinity: main
   group: rigging
 - name: set_cluster_weights
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
 - name: wire_deformer
+  execution: sync
+  affinity: main
   group: rigging

--- a/src/dcc_mcp_maya/skills/maya-display/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-display/tools.yaml
@@ -1,17 +1,25 @@
 tools:
 - name: create_display_layer
+  execution: sync
+  affinity: main
   group: scene-management
 - name: delete_display_layer
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
 - name: list_display_layers
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
 - name: set_display_layer
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management

--- a/src/dcc_mcp_maya/skills/maya-dynamics/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-dynamics/tools.yaml
@@ -1,33 +1,53 @@
 tools:
 - name: connect_field_to_objects
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: create_dynamic_field
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: create_ncloth
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: create_nrigid
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: create_nucleus
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: list_ncloth_nodes
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: list_nrigid_nodes
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: set_ncloth_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
 - name: set_nrigid_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
 - name: set_nucleus_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx

--- a/src/dcc_mcp_maya/skills/maya-export-preset/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-export-preset/tools.yaml
@@ -1,11 +1,19 @@
 tools:
 - name: delete_export_preset
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
 - name: list_export_presets
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: load_export_preset
+  execution: sync
+  affinity: main
 - name: save_export_preset
+  execution: sync
+  affinity: main

--- a/src/dcc_mcp_maya/skills/maya-expressions/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-expressions/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: create_expression
+  execution: sync
+  affinity: main
   group: animation
 - name: delete_expression
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: animation
 - name: edit_expression
+  execution: sync
+  affinity: main
   group: animation
 - name: list_expressions
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-fluid/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-fluid/tools.yaml
@@ -1,17 +1,26 @@
 tools:
 - name: create_fluid_container
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
   group: simulation-fx
 - name: delete_fluid_container
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: list_fluid_containers
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: set_fluid_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx

--- a/src/dcc_mcp_maya/skills/maya-gpu-cache/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-gpu-cache/tools.yaml
@@ -1,11 +1,19 @@
 tools:
 - name: export_gpu_cache
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: import_gpu_cache
+  execution: sync
+  affinity: main
 - name: list_gpu_caches
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: refresh_gpu_cache
+  execution: sync
+  affinity: main

--- a/src/dcc_mcp_maya/skills/maya-grooming/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-grooming/tools.yaml
@@ -1,14 +1,24 @@
 tools:
 - name: add_nhair_cache
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   group: simulation-fx
 - name: create_nhair_system
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   group: simulation-fx
 - name: list_hair_systems
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: set_nhair_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx

--- a/src/dcc_mcp_maya/skills/maya-hdri/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-hdri/tools.yaml
@@ -1,16 +1,24 @@
 tools:
 - name: list_hdri_nodes
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: load_hdri
+  execution: sync
+  affinity: main
   group: shading-lighting
 - name: set_hdri_exposure
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
 - name: set_hdri_rotation
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting

--- a/src/dcc_mcp_maya/skills/maya-instancer/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-instancer/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: add_instance_object
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: create_instancer
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: list_instancers
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: set_instancer_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx

--- a/src/dcc_mcp_maya/skills/maya-light-rig/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-light-rig/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: create_hdri_dome
+  execution: sync
+  affinity: main
   group: shading-lighting
 - name: create_three_point_rig
+  execution: sync
+  affinity: main
   group: shading-lighting
 - name: list_light_rigs
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: set_light_rig_intensity
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting

--- a/src/dcc_mcp_maya/skills/maya-lighting/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-lighting/tools.yaml
@@ -1,17 +1,25 @@
 tools:
 - name: create_light
+  execution: sync
+  affinity: main
   group: shading-lighting
 - name: delete_light
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: list_lights
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: set_light_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting

--- a/src/dcc_mcp_maya/skills/maya-mash/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-mash/tools.yaml
@@ -1,19 +1,29 @@
 tools:
 - name: add_node
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: create_network
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: delete_network
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: list_networks
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: set_mash_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx

--- a/src/dcc_mcp_maya/skills/maya-material-library/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-material-library/tools.yaml
@@ -1,15 +1,23 @@
 tools:
 - name: delete_material_preset
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: list_materials
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: load_material
+  execution: sync
+  affinity: main
   group: shading-lighting
 - name: save_material
+  execution: sync
+  affinity: main
   group: shading-lighting

--- a/src/dcc_mcp_maya/skills/maya-materials/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-materials/tools.yaml
@@ -1,35 +1,51 @@
 tools:
 - name: assign_material
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
 - name: create_material
+  execution: sync
+  affinity: main
   group: shading-lighting
 - name: get_material_connections
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: get_shader_assignment
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: list_materials
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: list_shading_groups
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: reset_to_default_material
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
 - name: set_material_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/tools.yaml
@@ -1,33 +1,57 @@
 tools:
 - name: apply_subdivision
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: modeling
 - name: cleanup_mesh
+  execution: sync
+  affinity: main
   group: modeling
 - name: combine_meshes
+  execution: sync
+  affinity: main
   group: modeling
 - name: create_proxy_mesh
+  execution: sync
+  affinity: main
   group: modeling
 - name: extract_faces
+  execution: sync
+  affinity: main
   group: modeling
 - name: get_mesh_edge_info
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
 - name: get_poly_count
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
 - name: merge_vertices
+  execution: sync
+  affinity: main
   group: modeling
 - name: mirror_mesh
+  execution: sync
+  affinity: main
   group: modeling
 - name: select_by_material
+  execution: sync
+  affinity: main
   group: modeling
 - name: separate_mesh
+  execution: sync
+  affinity: main
   group: modeling
 - name: triangulate
+  execution: sync
+  affinity: main
   group: modeling

--- a/src/dcc_mcp_maya/skills/maya-mocap/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-mocap/tools.yaml
@@ -1,9 +1,19 @@
 tools:
 - name: bake_mocap_to_rig
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   group: animation
 - name: clean_mocap_keys
+  execution: sync
+  affinity: main
   group: animation
 - name: create_hik_definition
+  execution: sync
+  affinity: main
   group: animation
 - name: import_mocap
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   group: animation

--- a/src/dcc_mcp_maya/skills/maya-muscle/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-muscle/tools.yaml
@@ -1,16 +1,25 @@
 tools:
 - name: apply_muscle_skin
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   annotations:
     idempotent_hint: true
   group: rigging
 - name: create_muscle_capsule
+  execution: sync
+  affinity: main
   group: rigging
 - name: list_muscles
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rigging
 - name: set_muscle_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rigging

--- a/src/dcc_mcp_maya/skills/maya-namespaces/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-namespaces/tools.yaml
@@ -1,26 +1,38 @@
 tools:
 - name: create_namespace
+  execution: sync
+  affinity: main
   group: scene-management
 - name: delete_namespace
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
 - name: list_namespaces
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
 - name: remove_namespace
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
 - name: rename_namespace
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
 - name: set_namespace
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management

--- a/src/dcc_mcp_maya/skills/maya-node-graph/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/tools.yaml
@@ -1,24 +1,42 @@
 tools:
 - name: apply_symmetry
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
 - name: connect_attr
+  execution: sync
+  affinity: main
 - name: delete_history
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
 - name: disconnect_attr
+  execution: sync
+  affinity: main
 - name: get_dag_path
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: list_connections
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: list_history
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: smooth_mesh
+  execution: sync
+  affinity: main
 - name: transfer_attributes
+  execution: sync
+  affinity: main

--- a/src/dcc_mcp_maya/skills/maya-nparticles/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-nparticles/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: add_field_to_nparticles
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: create_nparticle_emitter
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: list_nparticle_systems
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: set_nparticle_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx

--- a/src/dcc_mcp_maya/skills/maya-ocean/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-ocean/tools.yaml
@@ -1,14 +1,23 @@
 tools:
 - name: add_ocean_wake
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: create_ocean
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   group: simulation-fx
 - name: list_ocean_surfaces
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: set_ocean_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx

--- a/src/dcc_mcp_maya/skills/maya-paint-effects/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-paint-effects/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: attach_stroke_to_surface
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: create_stroke
+  execution: sync
+  affinity: main
   group: simulation-fx
 - name: delete_stroke
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: list_strokes
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-pipeline/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-pipeline/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: get_asset_metadata
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
 - name: publish_asset
+  execution: sync
+  affinity: main
   group: scene-management
 - name: set_project
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
 - name: tag_asset_metadata
+  execution: sync
+  affinity: main
   group: scene-management

--- a/src/dcc_mcp_maya/skills/maya-pose-library/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-pose-library/tools.yaml
@@ -1,12 +1,20 @@
 tools:
 - name: list_poses
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: animation
 - name: load_pose
+  execution: sync
+  affinity: main
   group: animation
 - name: mirror_pose
+  execution: sync
+  affinity: main
   group: animation
 - name: save_pose
+  execution: sync
+  affinity: main
   group: animation

--- a/src/dcc_mcp_maya/skills/maya-primitives/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-primitives/tools.yaml
@@ -1,35 +1,51 @@
 tools:
 - name: create_cube
   description: Create a polygon cube
+  execution: sync
+  affinity: main
   group: modeling
 - name: create_cylinder
   description: Create a polygon cylinder
+  execution: sync
+  affinity: main
   group: modeling
 - name: create_plane
   description: Create a polygon plane
+  execution: sync
+  affinity: main
   group: modeling
 - name: create_sphere
   description: Create a polygon sphere
+  execution: sync
+  affinity: main
   group: modeling
 - name: delete_objects
   description: Delete objects from the Maya scene
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: modeling
 - name: get_transform
   description: Get translate/rotate/scale of an object
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
 - name: rename_object
   description: Rename an object in the scene
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: modeling
 - name: set_transform
   description: Set translate/rotate/scale on an object
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: modeling

--- a/src/dcc_mcp_maya/skills/maya-proxy-mesh/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-proxy-mesh/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: create_proxy
+  execution: sync
+  affinity: main
   group: modeling
 - name: list_proxies
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
 - name: set_proxy_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: modeling
 - name: swap_proxy
+  execution: sync
+  affinity: main
   group: modeling

--- a/src/dcc_mcp_maya/skills/maya-references/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-references/tools.yaml
@@ -1,22 +1,34 @@
 tools:
 - name: create_reference
+  execution: sync
+  affinity: main
   group: scene-management
 - name: list_namespaces
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
 - name: list_references
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
 - name: reload_reference
+  execution: sync
+  affinity: main
   group: scene-management
 - name: remove_reference
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
 - name: unload_reference
+  execution: sync
+  affinity: main
   group: scene-management

--- a/src/dcc_mcp_maya/skills/maya-render-farm/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render-farm/tools.yaml
@@ -1,12 +1,23 @@
 tools:
 - name: get_render_job_status
+  execution: sync
+  affinity: any
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
 - name: submit_to_deadline
+  execution: async
+  affinity: main
+  timeout_hint_secs: 900
   group: rendering
 - name: validate_scene_for_farm
+  execution: async
+  affinity: main
+  timeout_hint_secs: 900
   group: rendering
 - name: write_render_job
+  execution: async
+  affinity: main
+  timeout_hint_secs: 900
   group: rendering

--- a/src/dcc_mcp_maya/skills/maya-render-layers/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render-layers/tools.yaml
@@ -1,21 +1,31 @@
 tools:
 - name: create_render_layer
+  execution: sync
+  affinity: main
   group: rendering
 - name: delete_render_layer
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: rendering
 - name: list_render_layers
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
 - name: set_render_layer
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
 - name: set_render_layer_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rendering

--- a/src/dcc_mcp_maya/skills/maya-render-passes/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render-passes/tools.yaml
@@ -1,16 +1,24 @@
 tools:
 - name: create_render_pass
+  execution: sync
+  affinity: main
   group: rendering
 - name: enable_render_pass
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
 - name: list_render_passes
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
 - name: set_render_pass_output
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rendering

--- a/src/dcc_mcp_maya/skills/maya-render/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render/tools.yaml
@@ -1,33 +1,53 @@
 tools:
 - name: capture_viewport
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
   group: rendering
 - name: export_selection
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
 - name: get_render_settings
   description: Query current render settings
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
 - name: get_scene_render_stats
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
 - name: import_file
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   group: rendering
 - name: playblast
   description: Capture a viewport screenshot as a base64-encoded PNG
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
   group: rendering
 - name: set_render_quality
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
 - name: set_render_settings
   description: Set render parameters (resolution, frame range, renderer, image format)
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rendering

--- a/src/dcc_mcp_maya/skills/maya-rig-utils/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-rig-utils/tools.yaml
@@ -1,9 +1,17 @@
 tools:
 - name: add_space_switch
+  execution: sync
+  affinity: main
   group: rigging
 - name: connect_attributes
+  execution: sync
+  affinity: main
   group: rigging
 - name: create_control_curve
+  execution: sync
+  affinity: main
   group: rigging
 - name: lock_hide_attributes
+  execution: sync
+  affinity: main
   group: rigging

--- a/src/dcc_mcp_maya/skills/maya-rigging/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-rigging/tools.yaml
@@ -1,35 +1,59 @@
 tools:
 - name: assign_deformer
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
 - name: blend_shape_add_target
+  execution: sync
+  affinity: main
   group: rigging
 - name: create_blend_shape
+  execution: sync
+  affinity: main
   group: rigging
 - name: create_curve
+  execution: sync
+  affinity: main
   group: rigging
 - name: create_ik_handle
+  execution: sync
+  affinity: main
   group: rigging
 - name: create_joint
+  execution: sync
+  affinity: main
   group: rigging
 - name: mirror_joints
+  execution: sync
+  affinity: main
   group: rigging
 - name: set_driven_key
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
 - name: set_ik_fk_blend
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
 - name: set_joint_limit
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
 - name: set_joint_orient
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
 - name: skin_cluster_bind
+  execution: sync
+  affinity: main
   group: rigging

--- a/src/dcc_mcp_maya/skills/maya-scene-assembly/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene-assembly/tools.yaml
@@ -1,11 +1,21 @@
 tools:
 - name: add_assembly_representation
+  execution: sync
+  affinity: main
   group: scene-management
 - name: create_assembly_definition
+  execution: async
+  affinity: main
+  timeout_hint_secs: 120
   group: scene-management
 - name: create_assembly_reference
+  execution: async
+  affinity: main
+  timeout_hint_secs: 120
   group: scene-management
 - name: list_assemblies
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-scene-utils/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene-utils/tools.yaml
@@ -1,23 +1,37 @@
 tools:
 - name: align_objects
+  execution: sync
+  affinity: main
   group: scene-management
 - name: create_annotation
+  execution: sync
+  affinity: main
   group: scene-management
 - name: create_polygon_text
+  execution: sync
+  affinity: main
   group: scene-management
 - name: set_object_color
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
 - name: set_pivot
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
 - name: set_shading_mode
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
 - name: toggle_gpu_override
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management

--- a/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
@@ -1,83 +1,129 @@
 tools:
 - name: center_pivot
+  execution: sync
+  affinity: main
   group: scene-management
 - name: create_locator
+  execution: sync
+  affinity: main
   group: scene-management
 - name: duplicate_object
+  execution: sync
+  affinity: main
   group: scene-management
 - name: export_scene
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
 - name: freeze_transforms
+  execution: sync
+  affinity: main
   group: scene-management
 - name: get_bounding_box
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
 - name: get_scene_info
   description: Return a hierarchical DAG description of the current scene
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: core
 - name: get_selection
   description: Return the current Maya selection
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: core
 - name: get_session_info
   description: Return Maya version, scene path, and basic session statistics
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: core
 - name: group_objects
+  execution: sync
+  affinity: main
 - name: list_cameras
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
 - name: list_objects
   description: List objects in the current Maya scene
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
 - name: lock_object
+  execution: sync
+  affinity: main
   group: scene-management
 - name: new_scene
   description: Create a new empty Maya scene
+  execution: async
+  affinity: main
+  timeout_hint_secs: 60
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
 - name: open_scene
   description: Open a Maya scene file from disk
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
 - name: parent_object
+  execution: sync
+  affinity: main
   group: scene-management
 - name: save_scene
   description: Save the current Maya scene
+  execution: async
+  affinity: main
+  timeout_hint_secs: 120
   group: scene-management
 - name: select_by_type
+  execution: sync
+  affinity: main
   group: scene-management
 - name: set_frame_rate
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
 - name: set_selection
   description: Set the active Maya selection
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
 - name: set_visibility
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management

--- a/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
@@ -1,68 +1,126 @@
 tools:
 - name: animation
+  execution: sync
+  affinity: main
   group: extended
 - name: attributes
+  execution: sync
+  affinity: main
   group: extended
 - name: cameras
+  execution: sync
+  affinity: main
   group: extended
 - name: constraints
+  execution: sync
+  affinity: main
   group: extended
 - name: deformer_advanced
+  execution: sync
+  affinity: main
   group: extended
 - name: display
+  execution: sync
+  affinity: main
   group: extended
 - name: dynamics
+  execution: sync
+  affinity: main
   group: extended
 - name: execute_mel
+  execution: sync
+  affinity: main
   group: core
 - name: execute_python
+  execution: sync
+  affinity: main
   group: core
 - name: expressions
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: extended
 - name: get_script_node
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: extended
 - name: lighting
+  execution: sync
+  affinity: main
   group: extended
 - name: list_mel_procedures
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: extended
 - name: materials
+  execution: sync
+  affinity: main
   group: extended
 - name: mesh_ops
+  execution: sync
+  affinity: main
   group: extended
 - name: namespaces
+  execution: sync
+  affinity: main
   group: extended
 - name: node_attrs
+  execution: sync
+  affinity: main
   group: extended
 - name: node_graph
+  execution: sync
+  affinity: main
   group: extended
 - name: references
+  execution: sync
+  affinity: main
   group: extended
 - name: render
+  execution: sync
+  affinity: main
   group: extended
 - name: render_layers
+  execution: sync
+  affinity: main
   group: extended
 - name: rigging
+  execution: sync
+  affinity: main
   group: extended
 - name: scene_utils
+  execution: sync
+  affinity: main
   group: extended
 - name: sets
+  execution: sync
+  affinity: main
   group: extended
 - name: skin_weights
+  execution: sync
+  affinity: main
   group: extended
 - name: texture_bake
+  execution: sync
+  affinity: main
   group: extended
 - name: utility
+  execution: sync
+  affinity: main
   group: extended
 - name: uv_ops
+  execution: sync
+  affinity: main
   group: extended
 - name: vertex_color
+  execution: sync
+  affinity: main
   group: extended

--- a/src/dcc_mcp_maya/skills/maya-selection/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-selection/tools.yaml
@@ -1,11 +1,21 @@
 tools:
 - name: convert_selection
+  execution: sync
+  affinity: main
   group: scene-management
 - name: grow_selection
+  execution: sync
+  affinity: main
   group: scene-management
 - name: invert_selection
+  execution: sync
+  affinity: main
   group: scene-management
 - name: select_similar
+  execution: sync
+  affinity: main
   group: scene-management
 - name: shrink_selection
+  execution: sync
+  affinity: main
   group: scene-management

--- a/src/dcc_mcp_maya/skills/maya-sets/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-sets/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: add_to_set
+  execution: sync
+  affinity: main
   group: scene-management
 - name: create_set
+  execution: sync
+  affinity: main
   group: scene-management
 - name: list_sets
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
 - name: remove_from_set
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-shot-export/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-shot-export/tools.yaml
@@ -1,17 +1,28 @@
 tools:
 - name: export_camera
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: export_shot_alembic
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: export_shot_fbx
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: get_shot_info
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-skinning-utils/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-skinning-utils/tools.yaml
@@ -1,9 +1,17 @@
 tools:
 - name: copy_skin_weights
+  execution: sync
+  affinity: main
   group: rigging
 - name: mirror_skin_weights
+  execution: sync
+  affinity: main
   group: rigging
 - name: normalize_skin_weights
+  execution: sync
+  affinity: main
   group: rigging
 - name: prune_skin_weights
+  execution: sync
+  affinity: main
   group: rigging

--- a/src/dcc_mcp_maya/skills/maya-spline-ik/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-spline-ik/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: add_stretch_to_spline_ik
+  execution: sync
+  affinity: main
   group: rigging
 - name: create_spline_ik
+  execution: sync
+  affinity: main
   group: rigging
 - name: list_spline_ik_handles
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rigging
 - name: set_spline_ik_twist
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: rigging

--- a/src/dcc_mcp_maya/skills/maya-texture-bake/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-texture-bake/tools.yaml
@@ -1,23 +1,41 @@
 tools:
 - name: bake_ambient_occlusion
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
   group: shading-lighting
 - name: bake_lighting
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
   group: shading-lighting
 - name: bake_textures
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
   group: shading-lighting
 - name: list_bake_sets
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: list_color_spaces
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: set_color_management
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
 - name: transfer_maps
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
   group: shading-lighting

--- a/src/dcc_mcp_maya/skills/maya-toon/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-toon/tools.yaml
@@ -1,14 +1,22 @@
 tools:
 - name: add_toon_outline
+  execution: sync
+  affinity: main
   group: shading-lighting
 - name: create_toon_shader
+  execution: sync
+  affinity: main
   group: shading-lighting
 - name: list_toon_outlines
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
 - name: set_outline_width
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting

--- a/src/dcc_mcp_maya/skills/maya-utility/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-utility/tools.yaml
@@ -1,11 +1,19 @@
 tools:
 - name: clean_scene
+  execution: sync
+  affinity: main
 - name: create_utility_node
+  execution: sync
+  affinity: main
 - name: get_scene_statistics
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
 - name: list_node_connections
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/tools.yaml
@@ -1,26 +1,42 @@
 tools:
 - name: copy_uvs
+  execution: sync
+  affinity: main
   group: modeling
 - name: create_uv_set
+  execution: sync
+  affinity: main
   group: modeling
 - name: delete_uv_set
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: modeling
 - name: get_uv_info
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
 - name: get_uv_shell_info
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
 - name: normalize_uvs
+  execution: sync
+  affinity: main
   group: modeling
 - name: project_uvs
+  execution: sync
+  affinity: main
   group: modeling
 - name: unfold_uvs
+  execution: sync
+  affinity: main
   group: modeling

--- a/src/dcc_mcp_maya/skills/maya-vertex-color/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-vertex-color/tools.yaml
@@ -1,17 +1,25 @@
 tools:
 - name: create_color_set
+  execution: sync
+  affinity: main
   group: modeling
 - name: get_vertex_color
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
 - name: remove_vertex_colors
+  execution: sync
+  affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: modeling
 - name: set_vertex_color
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: modeling

--- a/src/dcc_mcp_maya/skills/maya-xform-utils/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-xform-utils/tools.yaml
@@ -1,7 +1,15 @@
 tools:
 - name: bake_transforms
+  execution: sync
+  affinity: main
 - name: freeze_transforms
+  execution: sync
+  affinity: main
 - name: match_transforms
+  execution: sync
+  affinity: main
 - name: reset_pivot
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-xgen/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-xgen/tools.yaml
@@ -1,22 +1,34 @@
 tools:
 - name: create_description
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   group: simulation-fx
 - name: delete_description
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
   annotations:
     destructive_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: get_xgen_attribute
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: list_descriptions
+  execution: sync
+  affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
 - name: set_xgen_attribute
+  execution: sync
+  affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx

--- a/tests/test_skill_affinity.py
+++ b/tests/test_skill_affinity.py
@@ -1,0 +1,130 @@
+"""Tests for ``tools/lint_skill_affinity.py`` and the bundled skill affinity.
+
+Covers issue #84 acceptance criteria:
+
+- Every bundled ``tools.yaml`` declares ``affinity`` and ``execution``.
+- Every ``execution: async`` entry has a positive ``timeout_hint_secs``.
+- The lint script exits 0 on the repository and non-zero on bad input.
+- ``tools/annotate_skill_affinity.py`` is idempotent (running it again
+  produces no changes on a freshly annotated tree).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_ROOT = REPO_ROOT / "src" / "dcc_mcp_maya" / "skills"
+LINT_SCRIPT = REPO_ROOT / "tools" / "lint_skill_affinity.py"
+ANNOTATE_SCRIPT = REPO_ROOT / "tools" / "annotate_skill_affinity.py"
+
+
+def _tools_yaml_paths() -> list[Path]:
+    return sorted(SKILLS_ROOT.glob("*/tools.yaml"))
+
+
+def test_every_tool_declares_affinity_and_execution():
+    """Every bundled tool must declare execution + affinity (issue #84)."""
+    missing: list[str] = []
+    for path in _tools_yaml_paths():
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for tool in data.get("tools", []) or []:
+            name = tool.get("name", "<unnamed>")
+            if "affinity" not in tool:
+                missing.append(f"{path.parent.name}:{name} (no affinity)")
+            if "execution" not in tool:
+                missing.append(f"{path.parent.name}:{name} (no execution)")
+    assert not missing, "Tools missing affinity/execution:\n  " + "\n  ".join(missing)
+
+
+def test_async_tools_have_timeout_hint():
+    """Every async tool must declare a positive ``timeout_hint_secs``."""
+    bad: list[str] = []
+    for path in _tools_yaml_paths():
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for tool in data.get("tools", []) or []:
+            if tool.get("execution") == "async":
+                hint = tool.get("timeout_hint_secs")
+                if not isinstance(hint, int) or hint <= 0:
+                    bad.append(f"{path.parent.name}:{tool.get('name')} timeout_hint_secs={hint!r}")
+    assert not bad, "Async tools with bad timeout_hint_secs:\n  " + "\n  ".join(bad)
+
+
+def test_long_running_families_are_async():
+    """Long-running skill families must have at least one async tool (#84)."""
+    long_running_skills = {
+        "maya-render",
+        "maya-render-farm",
+        "maya-texture-bake",
+        "maya-cache",
+        "maya-shot-export",
+    }
+    for skill in long_running_skills:
+        path = SKILLS_ROOT / skill / "tools.yaml"
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        executions = {tool.get("execution") for tool in data.get("tools", []) or []}
+        assert "async" in executions, f"{skill} declares no async tool but belongs to long-running family"
+
+
+def test_lint_script_passes_on_repo():
+    """The CI lint script must succeed on the current tree."""
+    result = subprocess.run(
+        [sys.executable, str(LINT_SCRIPT), "--skills-root", str(SKILLS_ROOT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Affinity lint failed:\n{result.stdout}\n{result.stderr}"
+
+
+def test_lint_script_rejects_missing_affinity(tmp_path: Path):
+    """The lint script must exit non-zero when ``affinity`` is absent."""
+    bad_skill = tmp_path / "bad-skill"
+    bad_skill.mkdir()
+    (bad_skill / "tools.yaml").write_text(
+        "tools:\n- name: do_something\n  execution: sync\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(LINT_SCRIPT), "--skills-root", str(tmp_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "MISSING_AFFINITY" in result.stdout
+
+
+def test_lint_script_rejects_async_without_timeout(tmp_path: Path):
+    """Async tools missing ``timeout_hint_secs`` must fail the linter."""
+    bad_skill = tmp_path / "bad-skill"
+    bad_skill.mkdir()
+    (bad_skill / "tools.yaml").write_text(
+        "tools:\n- name: render_frames\n  execution: async\n  affinity: main\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(LINT_SCRIPT), "--skills-root", str(tmp_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "MISSING_TIMEOUT_HINT" in result.stdout
+
+
+@pytest.mark.skipif(not ANNOTATE_SCRIPT.exists(), reason="annotator script not present")
+def test_annotator_is_idempotent():
+    """Running the annotator on already-annotated files must be a no-op."""
+    result = subprocess.run(
+        [sys.executable, str(ANNOTATE_SCRIPT), "--skills-root", str(SKILLS_ROOT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    # "Annotated 0 of N" means no changes; the script always prints a summary line.
+    assert "Annotated 0 of " in result.stdout, result.stdout

--- a/tools/annotate_skill_affinity.py
+++ b/tools/annotate_skill_affinity.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Annotate all bundled ``tools.yaml`` files with ``execution``/``affinity``.
+
+Addresses issue #84 (core #317 / #332): every tool declared by a bundled
+skill must tell the gateway how it should be dispatched so the async
+path (core #318), chunked-execution path (core #332) and ``deferredHint``
+in ``tools/list`` can make correct decisions.
+
+Classification strategy
+-----------------------
+1. A per-skill default ``(execution, affinity, timeout_hint_secs)`` tuple
+   is chosen from :data:`SKILL_DEFAULTS` below.  The table follows the
+   categorisation given in the issue description.
+2. Tool-name heuristics (:data:`TOOL_OVERRIDES`) override the default for
+   specific verbs.  Read-only verbs (``get_*``, ``list_*``, ``query_*``)
+   collapse to ``execution: sync`` regardless of the skill default.
+3. Maya cmds-touching tools always get ``affinity: main`` — it is never
+   safe to assume ``any`` unless we know the script is pure filesystem.
+
+The script is idempotent: running it twice produces the same output.
+It is intentionally kept as a one-shot maintenance helper, not a runtime
+dependency, so it lives under ``tools/`` rather than ``src/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("ERROR: PyYAML is required (pip install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+
+ExecAffinity = Tuple[str, str, Optional[int]]  # (execution, affinity, timeout_hint_secs)
+
+
+# Per-skill defaults (execution, affinity, timeout_hint_secs).
+# The ``timeout_hint_secs`` field is only meaningful when execution == "async".
+SKILL_DEFAULTS: Dict[str, ExecAffinity] = {
+    # Long-running / main-thread-affine families
+    "maya-render": ("async", "main", 600),
+    "maya-render-farm": ("async", "main", 900),
+    "maya-render-layers": ("sync", "main", None),
+    "maya-render-passes": ("sync", "main", None),
+    "maya-texture-bake": ("async", "main", 600),
+    "maya-cache": ("async", "main", 300),
+    "maya-cloth-sim": ("async", "main", 600),
+    "maya-fluid": ("async", "main", 600),
+    "maya-dynamics": ("async", "main", 600),
+    "maya-muscle": ("async", "main", 300),
+    "maya-grooming": ("async", "main", 300),
+    "maya-xgen": ("async", "main", 300),
+    "maya-bifrost": ("async", "main", 600),
+    "maya-ocean": ("async", "main", 300),
+    "maya-mocap": ("async", "main", 300),
+    "maya-nparticles": ("async", "main", 600),
+    # Scene I/O: export/save are async, meta reads are sync (overrides handle them)
+    "maya-scene": ("sync", "main", None),
+    "maya-scene-assembly": ("sync", "main", None),
+    "maya-scene-utils": ("sync", "main", None),
+    "maya-export-preset": ("sync", "main", None),
+    "maya-shot-export": ("async", "main", 300),
+    # Scripting: arbitrary user code — sync + main by default; caller chooses
+    # async if they know the script is long-running.
+    "maya-scripting": ("sync", "main", None),
+    # Pure filesystem readers: worker-thread safe
+    "maya-pipeline": ("sync", "main", None),
+    "maya-material-library": ("sync", "main", None),
+    # Everything else: sync + main (touches maya.cmds)
+    "maya-animation": ("sync", "main", None),
+    "maya-annotation": ("sync", "main", None),
+    "maya-arnold-aov": ("sync", "main", None),
+    "maya-attributes": ("sync", "main", None),
+    "maya-audio": ("sync", "main", None),
+    "maya-blend-shape-utils": ("sync", "main", None),
+    "maya-camera-sequence": ("sync", "main", None),
+    "maya-cameras": ("sync", "main", None),
+    "maya-color-grading": ("sync", "main", None),
+    "maya-constraints": ("sync", "main", None),
+    "maya-constraints-advanced": ("sync", "main", None),
+    "maya-deformers": ("sync", "main", None),
+    "maya-display": ("sync", "main", None),
+    "maya-expressions": ("sync", "main", None),
+    "maya-gpu-cache": ("sync", "main", None),
+    "maya-hdri": ("sync", "main", None),
+    "maya-instancer": ("sync", "main", None),
+    "maya-light-rig": ("sync", "main", None),
+    "maya-lighting": ("sync", "main", None),
+    "maya-mash": ("sync", "main", None),
+    "maya-materials": ("sync", "main", None),
+    "maya-mesh-ops": ("sync", "main", None),
+    "maya-namespaces": ("sync", "main", None),
+    "maya-node-graph": ("sync", "main", None),
+    "maya-paint-effects": ("sync", "main", None),
+    "maya-pose-library": ("sync", "main", None),
+    "maya-primitives": ("sync", "main", None),
+    "maya-proxy-mesh": ("sync", "main", None),
+    "maya-references": ("sync", "main", None),
+    "maya-rig-utils": ("sync", "main", None),
+    "maya-rigging": ("sync", "main", None),
+    "maya-selection": ("sync", "main", None),
+    "maya-sets": ("sync", "main", None),
+    "maya-skinning-utils": ("sync", "main", None),
+    "maya-spline-ik": ("sync", "main", None),
+    "maya-toon": ("sync", "main", None),
+    "maya-utility": ("sync", "main", None),
+    "maya-uv-ops": ("sync", "main", None),
+    "maya-vertex-color": ("sync", "main", None),
+    "maya-xform-utils": ("sync", "main", None),
+}
+
+
+# Per-tool overrides (skill, tool) -> (execution, affinity, timeout_hint_secs).
+# Used when the skill default is not right for a specific verb.
+TOOL_OVERRIDES: Dict[Tuple[str, str], ExecAffinity] = {
+    # maya-scene long-running I/O
+    ("maya-scene", "export_scene"): ("async", "main", 300),
+    ("maya-scene", "save_scene"): ("async", "main", 120),
+    ("maya-scene", "open_scene"): ("async", "main", 300),
+    ("maya-scene", "new_scene"): ("async", "main", 60),
+    # maya-scene-assembly definition is fast; create/add can be slow
+    ("maya-scene-assembly", "create_assembly_definition"): ("async", "main", 120),
+    ("maya-scene-assembly", "create_assembly_reference"): ("async", "main", 120),
+    # maya-render long-running overrides (playblast/capture hit render engine)
+    ("maya-render", "get_render_settings"): ("sync", "main", None),
+    ("maya-render", "set_render_settings"): ("sync", "main", None),
+    ("maya-render", "set_render_quality"): ("sync", "main", None),
+    ("maya-render", "get_scene_render_stats"): ("sync", "main", None),
+    ("maya-render", "export_selection"): ("async", "main", 300),
+    ("maya-render", "import_file"): ("async", "main", 300),
+    # maya-render-farm — all async
+    ("maya-render-farm", "get_render_job_status"): ("sync", "any", None),
+    # maya-scripting execute_* stays sync; long scripts submitted separately
+    # maya-cache
+    ("maya-cache", "list_geometry_caches"): ("sync", "main", None),
+    ("maya-cache", "delete_geometry_cache"): ("sync", "main", None),
+    # maya-mocap
+    ("maya-mocap", "create_hik_definition"): ("sync", "main", None),
+    ("maya-mocap", "clean_mocap_keys"): ("sync", "main", None),
+    # maya-xgen fast meta ops
+    ("maya-xgen", "list_descriptions"): ("sync", "main", None),
+    ("maya-xgen", "get_xgen_attribute"): ("sync", "main", None),
+    ("maya-xgen", "set_xgen_attribute"): ("sync", "main", None),
+    # maya-bifrost fast meta ops
+    ("maya-bifrost", "list_bifrost_graphs"): ("sync", "main", None),
+    ("maya-bifrost", "connect_bifrost_ports"): ("sync", "main", None),
+    ("maya-bifrost", "set_bifrost_property"): ("sync", "main", None),
+    ("maya-bifrost", "add_bifrost_node"): ("sync", "main", None),
+    # maya-grooming fast meta ops
+    ("maya-grooming", "list_hair_systems"): ("sync", "main", None),
+    ("maya-grooming", "set_nhair_attribute"): ("sync", "main", None),
+    # maya-ocean fast meta ops
+    ("maya-ocean", "list_ocean_surfaces"): ("sync", "main", None),
+    ("maya-ocean", "set_ocean_attribute"): ("sync", "main", None),
+    ("maya-ocean", "add_ocean_wake"): ("sync", "main", None),
+    # maya-fluid fast meta ops
+    ("maya-fluid", "list_fluid_containers"): ("sync", "main", None),
+    ("maya-fluid", "delete_fluid_container"): ("sync", "main", None),
+    ("maya-fluid", "set_fluid_attribute"): ("sync", "main", None),
+    # maya-cloth-sim fast meta ops
+    ("maya-cloth-sim", "list_ncloth_objects"): ("sync", "main", None),
+    ("maya-cloth-sim", "set_ncloth_attribute"): ("sync", "main", None),
+    ("maya-cloth-sim", "create_ncloth"): ("sync", "main", None),
+    # maya-dynamics fast meta ops
+    ("maya-dynamics", "list_ncloth_nodes"): ("sync", "main", None),
+    ("maya-dynamics", "list_nrigid_nodes"): ("sync", "main", None),
+    ("maya-dynamics", "set_ncloth_attribute"): ("sync", "main", None),
+    ("maya-dynamics", "set_nrigid_attribute"): ("sync", "main", None),
+    ("maya-dynamics", "set_nucleus_attribute"): ("sync", "main", None),
+    ("maya-dynamics", "create_nucleus"): ("sync", "main", None),
+    ("maya-dynamics", "create_ncloth"): ("sync", "main", None),
+    ("maya-dynamics", "create_nrigid"): ("sync", "main", None),
+    ("maya-dynamics", "connect_field_to_objects"): ("sync", "main", None),
+    ("maya-dynamics", "create_dynamic_field"): ("sync", "main", None),
+    # maya-muscle fast meta ops
+    ("maya-muscle", "list_muscles"): ("sync", "main", None),
+    ("maya-muscle", "set_muscle_attribute"): ("sync", "main", None),
+    ("maya-muscle", "create_muscle_capsule"): ("sync", "main", None),
+    # maya-nparticles fast meta ops
+    ("maya-nparticles", "list_nparticle_systems"): ("sync", "main", None),
+    ("maya-nparticles", "set_nparticle_attribute"): ("sync", "main", None),
+    ("maya-nparticles", "add_field_to_nparticles"): ("sync", "main", None),
+    ("maya-nparticles", "create_nparticle_emitter"): ("sync", "main", None),
+    # maya-texture-bake fast meta ops
+    ("maya-texture-bake", "list_bake_sets"): ("sync", "main", None),
+    ("maya-texture-bake", "list_color_spaces"): ("sync", "main", None),
+    ("maya-texture-bake", "set_color_management"): ("sync", "main", None),
+    # maya-shot-export meta
+    ("maya-shot-export", "get_shot_info"): ("sync", "main", None),
+}
+
+
+READ_ONLY_PREFIXES = ("get_", "list_", "query_", "describe_", "read_")
+
+
+def classify(skill: str, tool_name: str) -> ExecAffinity:
+    """Return ``(execution, affinity, timeout_hint_secs)`` for a tool."""
+    override = TOOL_OVERRIDES.get((skill, tool_name))
+    if override is not None:
+        return override
+
+    default = SKILL_DEFAULTS.get(skill)
+    if default is None:
+        # Unknown skill — conservative: sync + main (Maya cmds assumed).
+        return ("sync", "main", None)
+
+    execution, affinity, timeout = default
+
+    # Read-only verbs are always sync regardless of skill default.
+    if tool_name.startswith(READ_ONLY_PREFIXES):
+        return ("sync", affinity, None)
+
+    return (execution, affinity, timeout)
+
+
+def annotate_tool(tool: dict, skill: str) -> bool:
+    """Populate ``execution``/``affinity``/``timeout_hint_secs``.
+
+    Returns ``True`` if anything was changed.
+    """
+    if not isinstance(tool, dict):
+        return False
+
+    name = tool.get("name")
+    if not isinstance(name, str):
+        return False
+
+    execution, affinity, timeout = classify(skill, name)
+    changed = False
+
+    if tool.get("execution") != execution:
+        tool["execution"] = execution
+        changed = True
+
+    if tool.get("affinity") != affinity:
+        tool["affinity"] = affinity
+        changed = True
+
+    if execution == "async":
+        if tool.get("timeout_hint_secs") != timeout:
+            tool["timeout_hint_secs"] = timeout
+            changed = True
+    else:
+        # Drop any stale hint on sync tools.
+        if "timeout_hint_secs" in tool:
+            del tool["timeout_hint_secs"]
+            changed = True
+
+    return changed
+
+
+def dump_tool(tool: dict) -> str:
+    """Dump a single tool as a YAML list entry with stable key ordering."""
+    # Preferred key order for readability.
+    order = [
+        "name",
+        "description",
+        "execution",
+        "affinity",
+        "timeout_hint_secs",
+        "source_file",
+        "annotations",
+    ]
+    ordered: Dict[str, object] = {}
+    for key in order:
+        if key in tool:
+            ordered[key] = tool[key]
+    for key, value in tool.items():
+        if key not in ordered:
+            ordered[key] = value
+
+    # yaml.dump with the single-entry dict, then prefix the first line with "- ".
+    rendered = yaml.safe_dump(ordered, sort_keys=False, default_flow_style=False).rstrip("\n")
+    lines = rendered.splitlines()
+    out_lines: List[str] = []
+    for i, line in enumerate(lines):
+        if i == 0:
+            out_lines.append(f"- {line}")
+        else:
+            out_lines.append(f"  {line}")
+    return "\n".join(out_lines)
+
+
+def annotate_file(path: Path) -> bool:
+    """Annotate a single ``tools.yaml`` file in place.  Returns ``True`` on change."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    tools = data.get("tools")
+    if not isinstance(tools, list):
+        return False
+
+    skill = path.parent.name
+    changed_any = False
+    for tool in tools:
+        if annotate_tool(tool, skill):
+            changed_any = True
+
+    if not changed_any:
+        return False
+
+    header = "tools:\n"
+    body = "\n".join(dump_tool(t) for t in tools) + "\n"
+    path.write_text(header + body, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--skills-root",
+        default="src/dcc_mcp_maya/skills",
+        help="Path to skills directory (default: src/dcc_mcp_maya/skills)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not modify files; exit non-zero if any file would be changed.",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.skills_root)
+    if not root.is_dir():
+        print(f"ERROR: {root} is not a directory", file=sys.stderr)
+        return 2
+
+    files = sorted(root.glob("*/tools.yaml"))
+    changed: List[Path] = []
+    for file in files:
+        if args.check:
+            original = file.read_text(encoding="utf-8")
+            data = yaml.safe_load(original) or {}
+            tools = data.get("tools") or []
+            dirty = False
+            for tool in tools:
+                snapshot = dict(tool) if isinstance(tool, dict) else None
+                if annotate_tool(tool, file.parent.name):
+                    dirty = True
+                if snapshot is not None and isinstance(tool, dict):
+                    tool.clear()
+                    tool.update(snapshot)
+            if dirty:
+                changed.append(file)
+        else:
+            if annotate_file(file):
+                changed.append(file)
+
+    if args.check:
+        if changed:
+            print("The following tools.yaml files are missing affinity annotations:")
+            for path in changed:
+                print(f"  {path}")
+            return 1
+        print(f"All {len(files)} tools.yaml files are annotated.")
+        return 0
+
+    print(f"Annotated {len(changed)} of {len(files)} tools.yaml files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lint_skill_affinity.py
+++ b/tools/lint_skill_affinity.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""CI lint for ``execution``/``affinity`` in bundled ``tools.yaml`` files.
+
+Fails (exit 1) when any bundled tool is missing ``affinity`` or when an
+``execution: async`` tool is missing ``timeout_hint_secs``.  See issue #84
+for the acceptance criteria.
+
+Designed as a companion to :mod:`tools.annotate_skill_affinity` — the
+annotator writes the fields, this linter enforces them in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("ERROR: PyYAML is required (pip install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+
+VALID_EXECUTION = {"sync", "async"}
+VALID_AFFINITY = {"main", "any", "named"}
+
+
+def lint_file(path: Path) -> List[Tuple[str, str]]:
+    """Return a list of ``(rule, message)`` for every problem in *path*."""
+    problems: List[Tuple[str, str]] = []
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        return [("YAML_PARSE_ERROR", f"{path}: {exc}")]
+
+    tools = data.get("tools")
+    if not isinstance(tools, list):
+        # Skills without tools.yaml payloads are skipped silently.
+        return problems
+
+    for tool in tools:
+        if not isinstance(tool, dict):
+            problems.append(("MALFORMED_TOOL", f"{path}: non-mapping entry {tool!r}"))
+            continue
+
+        name = tool.get("name", "<unnamed>")
+
+        affinity = tool.get("affinity")
+        if affinity is None:
+            problems.append(("MISSING_AFFINITY", f"{path}: tool '{name}' has no affinity"))
+        elif affinity not in VALID_AFFINITY:
+            problems.append(
+                ("INVALID_AFFINITY", f"{path}: tool '{name}' affinity={affinity!r} not in {sorted(VALID_AFFINITY)}")
+            )
+
+        execution = tool.get("execution")
+        if execution is None:
+            problems.append(("MISSING_EXECUTION", f"{path}: tool '{name}' has no execution"))
+        elif execution not in VALID_EXECUTION:
+            problems.append(
+                ("INVALID_EXECUTION", f"{path}: tool '{name}' execution={execution!r} not in {sorted(VALID_EXECUTION)}")
+            )
+
+        if execution == "async":
+            timeout = tool.get("timeout_hint_secs")
+            if timeout is None:
+                problems.append(
+                    (
+                        "MISSING_TIMEOUT_HINT",
+                        f"{path}: async tool '{name}' has no timeout_hint_secs",
+                    )
+                )
+            elif not isinstance(timeout, int) or timeout <= 0:
+                problems.append(
+                    (
+                        "INVALID_TIMEOUT_HINT",
+                        f"{path}: async tool '{name}' timeout_hint_secs must be a positive int, got {timeout!r}",
+                    )
+                )
+
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--skills-root",
+        default="src/dcc_mcp_maya/skills",
+        help="Path to skills directory (default: src/dcc_mcp_maya/skills)",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.skills_root)
+    if not root.is_dir():
+        print(f"ERROR: {root} is not a directory", file=sys.stderr)
+        return 2
+
+    files = sorted(root.glob("*/tools.yaml"))
+    all_problems: List[Tuple[str, str]] = []
+    for file in files:
+        all_problems.extend(lint_file(file))
+
+    if all_problems:
+        for rule, message in all_problems:
+            print(f"[{rule}] {message}")
+        print(f"\n{len(all_problems)} problem(s) found in {len(files)} file(s).", file=sys.stderr)
+        return 1
+
+    print(f"OK: {len(files)} tools.yaml files pass affinity lint.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes part of #84.

Every bundled tool in `src/dcc_mcp_maya/skills/*/tools.yaml` now declares
`execution` (`sync`|`async`), `affinity` (`main`|`any`), and, for async
tools, `timeout_hint_secs`. This is the Maya-side half of the contract
introduced by `dcc-mcp-core` #317/#318/#332 — without these fields the
gateway has no way to dispatch long-running tools as Jobs, and main-thread
affine tools risk being scheduled on a worker thread.

### What changed

- **64 `tools.yaml` files annotated** using a per-skill-family default
  table plus tool-name overrides (read-only verbs collapse to `sync`;
  long-running families like `maya-render`, `maya-texture-bake`,
  `maya-cache`, `maya-render-farm`, `maya-shot-export` default to
  `async` with sensible timeout hints).
- **`tools/annotate_skill_affinity.py`** — idempotent one-shot helper
  used to generate the annotations; runs clean a second time.
- **`tools/lint_skill_affinity.py`** — CI gate that fails if any tool
  is missing `affinity`/`execution` or if an async tool is missing
  `timeout_hint_secs`. Wired into `.github/workflows/ci.yml` under the
  existing `lint-skills` job.
- **`tests/test_skill_affinity.py`** — 7 pytest cases covering every
  acceptance criterion that doesn't require a running `MayaMcpServer`.
- **README.md** — new *Authoring Skills: Execution & Affinity* section
  for third-party skill authors.

### Out of scope

The `tools/list` pytest assertion that `deferredHint: true` is emitted
for all async tools is **deferred**: it requires the SKILL.md parser in
`dcc-mcp-core` #317 to surface the new fields through `ToolDeclaration`.
Once core #317/#318 land in a release, a follow-up PR will add that
assertion.

## Test plan

- [x] `python tools/lint_skill_affinity.py` → exits 0 on this tree.
- [x] `python tools/annotate_skill_affinity.py` → reports `Annotated 0 of 64`
      (idempotent).
- [x] `pytest tests/test_skill_affinity.py -v` → 7 passed.
- [x] `pytest tests/` → 3098 passed, 11 skipped, 52 deselected (no regressions).
- [x] `ruff check tools/annotate_skill_affinity.py tools/lint_skill_affinity.py tests/test_skill_affinity.py` → clean.
- [ ] CI green on GitHub.

## Dependencies

- Pairs with (but does not block on) core #317 / #318 / #332.
