### PR TITLE
docs: multi-Maya-instance deployment on a single workstation (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,13 @@ their own skill packages before publishing.  See issue
 [#84](https://github.com/loonghao/dcc-mcp-maya/issues/84) for the full
 categorisation matrix.
 
+## Deployment Guides
+
+- [Multi-instance deployment](docs/guide/multi-instance.md) ([中文](docs/zh/guide/multi-instance.md))
+  — run multiple Maya sessions on a single workstation behind one MCP gateway.
+  A drop-in `userSetup.py` is provided under
+  [`examples/multi-instance/`](examples/multi-instance).
+
 ## Development
 
 ### Clone and Install

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -73,3 +73,4 @@ Paths are resolved in order (highest priority first):
 - [Quick Start](./getting-started) — get Maya talking to Claude Desktop in 5 minutes
 - [Action List](./actions) — full catalogue of built-in MCP tools
 - [Advanced Usage](./advanced) — custom skills, main-thread scheduling
+- [Multi-instance Deployment](./multi-instance) — run multiple Maya instances on a single workstation

--- a/docs/guide/multi-instance.md
+++ b/docs/guide/multi-instance.md
@@ -1,0 +1,153 @@
+# Multi-Maya-instance Deployment on a Single Workstation
+
+Studios routinely run multiple Maya instances on one workstation — per-shot
+sessions for animation, a separate lookdev instance, a background batch
+renderer, and so on.  This guide explains how `dcc-mcp-maya` behaves when
+N Maya processes share the same machine, and gives a drop-in
+`userSetup.py` recipe that keeps every instance discoverable through a
+single MCP gateway.
+
+For cross-machine HA deployments, see
+[`dcc-mcp-core` production deployment guide](https://github.com/loonghao/dcc-mcp-core)
+(core #330) — this page intentionally covers only the single-workstation case.
+
+## Invariants
+
+1. **Every Maya instance must advertise a distinct `dcc_pid`** so the
+   `diagnostics__*` tools target the correct process.  The default —
+   `os.getpid()` — is almost always what you want; the only time you
+   override it is when wrapping Maya with a launcher that proxies the
+   real PID.
+2. **Every instance reuses the same `FileRegistry` directory.** The
+   first process to bind `DCC_MCP_GATEWAY_PORT` wins the gateway
+   election; the others register as regular backends.  Running two
+   instances under *different* `DCC_MCP_REGISTRY_DIR` values makes them
+   invisible to each other — only do this intentionally (e.g. per-user
+   isolation).
+3. **`DCC_MCP_MAYA_MINIMAL` is per-process.** One instance can run in
+   minimal mode (just `maya-scripting` + `maya-scene`) while another
+   runs full mode — the gateway reports each backend's active skill
+   set independently.
+4. **Gateway election is first-wins.** If the elected Maya crashes, the
+   next election re-runs within a known SLA (see core #303 invariants);
+   tools from surviving backends stay reachable throughout.
+
+## Launching N Instances
+
+The bundled `examples/multi-instance/userSetup.py` picks a free port
+from a reserved range and registers with `dcc_pid=os.getpid()`.  Drop
+it into your Maya `scripts/` directory and every new Maya will
+self-register on next launch:
+
+```python
+# examples/multi-instance/userSetup.py  (abridged)
+from pathlib import Path
+import os, socket, logging
+
+PORT_RANGE = range(8765, 8776)      # 11 reserved slots
+
+
+def _pick_free_port(candidates):
+    for port in candidates:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    return 0                          # OS-assigned fallback
+
+
+def _apply_multi_instance_env():
+    os.environ.setdefault("DCC_MCP_GATEWAY_PORT", "9765")
+    os.environ["DCC_MCP_MAYA_PORT"] = str(_pick_free_port(PORT_RANGE))
+    os.environ.setdefault("DCC_MCP_MAYA_DCC_PID", str(os.getpid()))
+```
+
+The full, commented source is in
+[`examples/multi-instance/userSetup.py`](https://github.com/loonghao/dcc-mcp-maya/tree/main/examples/multi-instance).
+
+## Environment Variable Reference
+
+| Variable | Scope | Default | Purpose |
+|---|---|---|---|
+| `DCC_MCP_MAYA_PORT` | per-process | `0` (OS-assigned) | HTTP port for this Maya's MCP server |
+| `DCC_MCP_GATEWAY_PORT` | per-host | unset (no gateway) | Port the elected gateway listens on |
+| `DCC_MCP_REGISTRY_DIR` | per-user | platform default | Shared registry every backend writes to |
+| `DCC_MCP_MAYA_MINIMAL` | per-process | `1` | Load only `maya-scripting` + `maya-scene` |
+| `DCC_MCP_MAYA_DEFAULT_TOOLS` | per-process | unset | Comma-separated list overriding minimal skill set |
+| `DCC_MCP_MAYA_HOT_RELOAD` | per-process | `0` | Watch bundled skills for edit-on-disk reload |
+| `DCC_MCP_MAYA_DCC_PID` | per-process | `os.getpid()` | Value advertised to gateway for `diagnostics__*` routing |
+
+The per-process variables can be set safely **before** Maya launches;
+the shared ones must match across every instance on the same user
+account, or they'll form separate registry islands.
+
+## Common Topology
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  workstation-01                                                │
+│                                                                │
+│  Maya 2025.0 (anim)     port=8765   dcc_pid=1234   minimal=1  │
+│  Maya 2025.1 (lookdev)  port=8766   dcc_pid=5678   minimal=0  │
+│  Maya 2025.2 (batch)    port=8767   dcc_pid=9012   minimal=1  │
+│                              │                                 │
+│                              ▼                                 │
+│  shared FileRegistry ──► gateway :9765 (elected by :8765)     │
+└────────────────────────────────┬───────────────────────────────┘
+                                 │
+                                 ▼
+                          MCP clients
+```
+
+Every backend writes its `(port, pid, dcc_version, skill_list)` into the
+shared registry.  The gateway keeps the routing table current and
+exposes a unified `tools/list` that flags which backend owns which tool.
+
+## Troubleshooting
+
+### "I see only one instance from the gateway"
+
+Check that all instances read the same `DCC_MCP_REGISTRY_DIR`.  If one
+process launched under a different user account it will write into a
+different registry root.  Use `dcc_mcp_core.FileRegistry.list()` to
+inspect the live entries.
+
+### "My instance never becomes the gateway"
+
+Gateway election is strictly first-to-bind.  If another Maya already
+owns `DCC_MCP_GATEWAY_PORT`, yours will register as a backend — that
+is the intended behaviour.  To force a specific instance to become the
+gateway, launch it first, or temporarily set a unique port
+(`DCC_MCP_GATEWAY_PORT=9766`) to form a secondary routing domain.
+
+### "Stale entries after Maya crash"
+
+The gateway's heartbeat prunes dead backends within ~30 s.  To force a
+clean slate immediately:
+
+```bash
+# Remove the registry directory (recreated on next launch)
+python -c "from dcc_mcp_core import get_config_dir; import shutil, os; \
+           shutil.rmtree(os.path.join(get_config_dir(), 'registry'), ignore_errors=True)"
+```
+
+### "One instance should run full mode, another minimal"
+
+Set `DCC_MCP_MAYA_MINIMAL` per-launcher, not globally.  A Windows
+shortcut for the lookdev session might read:
+
+```
+set DCC_MCP_MAYA_MINIMAL=0
+"C:\Program Files\Autodesk\Maya2025\bin\maya.exe"
+```
+
+while the animation-pool launcher keeps the default (`=1`).
+
+## Related
+
+- [Advanced Usage](./advanced) — custom skills, main-thread scheduling.
+- [`examples/multi-instance/`](https://github.com/loonghao/dcc-mcp-maya/tree/main/examples/multi-instance) — runnable `userSetup.py`.
+- Issue [#88](https://github.com/loonghao/dcc-mcp-maya/issues/88) — this
+  document's source of truth for acceptance criteria.

--- a/docs/zh/guide/index.md
+++ b/docs/zh/guide/index.md
@@ -71,3 +71,4 @@ maya-scene/
 - [快速开始](./getting-started) — 5 分钟让 Maya 与 Claude Desktop 联通
 - [Action 完整列表](./actions) — 所有内置 MCP 工具的完整目录
 - [高级用法](./advanced) — 自定义 Skill、主线程调度
+- [单机多实例部署](./multi-instance) — 在同一台工作站上运行多个 Maya 实例

--- a/docs/zh/guide/multi-instance.md
+++ b/docs/zh/guide/multi-instance.md
@@ -1,0 +1,142 @@
+# 单机多 Maya 实例部署
+
+在影视/游戏工作室，工作站上同时运行多个 Maya 实例是常态 —— 动画师
+按镜头开多个会话，Lookdev 单独开一个实例，后台再跑一个批量渲染
+Maya 等等。本文说明 `dcc-mcp-maya` 在同一台机器跑 N 个 Maya 进程时
+的行为，并给出一份可直接使用的 `userSetup.py`，让每个实例都能被单
+一的 MCP 网关发现。
+
+跨机器高可用部署见
+[`dcc-mcp-core` 生产部署指南](https://github.com/loonghao/dcc-mcp-core)
+(core #330)。本文只覆盖单机场景。
+
+## 不变量
+
+1. **每个 Maya 实例必须声明一个独立的 `dcc_pid`**，这样 `diagnostics__*`
+   工具才能路由到正确的进程。默认值 `os.getpid()` 在 99% 的情况下都
+   是对的；只有当你用 launcher 代理了真实 PID 时才需要覆盖。
+2. **所有实例必须共用同一个 `FileRegistry` 目录**。第一个绑定
+   `DCC_MCP_GATEWAY_PORT` 的进程赢得网关选举，其余的注册为普通
+   backend。把两个实例配置成不同的 `DCC_MCP_REGISTRY_DIR` 会让它们
+   互相不可见，除非你是有意为之（例如多用户隔离）。
+3. **`DCC_MCP_MAYA_MINIMAL` 是进程级的**。一个实例可以跑 minimal
+   模式（只加载 `maya-scripting` + `maya-scene`），另一个跑 full
+   模式 —— 网关会独立报告每个 backend 的 skill 列表。
+4. **网关选举是「先到先得」**。被选举的 Maya 崩溃后会在已知 SLA
+   内（见 core #303）重新选举，存活的 backend 的工具全程可用。
+
+## 启动 N 个实例
+
+仓库里的 `examples/multi-instance/userSetup.py` 会从一个保留端口段
+里挑一个空闲端口，并用 `dcc_pid=os.getpid()` 注册。把它丢到你的
+Maya `scripts/` 目录，下次启动的每个 Maya 都会自动注册：
+
+```python
+# examples/multi-instance/userSetup.py  （节选）
+from pathlib import Path
+import os, socket, logging
+
+PORT_RANGE = range(8765, 8776)      # 11 个保留端口
+
+
+def _pick_free_port(candidates):
+    for port in candidates:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    return 0                          # 让 OS 随机分配
+
+
+def _apply_multi_instance_env():
+    os.environ.setdefault("DCC_MCP_GATEWAY_PORT", "9765")
+    os.environ["DCC_MCP_MAYA_PORT"] = str(_pick_free_port(PORT_RANGE))
+    os.environ.setdefault("DCC_MCP_MAYA_DCC_PID", str(os.getpid()))
+```
+
+完整带注释的源码在
+[`examples/multi-instance/userSetup.py`](https://github.com/loonghao/dcc-mcp-maya/tree/main/examples/multi-instance)。
+
+## 环境变量速查表
+
+| 变量 | 作用域 | 默认值 | 用途 |
+|---|---|---|---|
+| `DCC_MCP_MAYA_PORT` | 进程级 | `0`（OS 分配） | 当前 Maya MCP 服务器的 HTTP 端口 |
+| `DCC_MCP_GATEWAY_PORT` | 主机级 | 未设置（无网关） | 选举出的网关监听的端口 |
+| `DCC_MCP_REGISTRY_DIR` | 用户级 | 平台默认 | 所有 backend 共享的注册表目录 |
+| `DCC_MCP_MAYA_MINIMAL` | 进程级 | `1` | 只加载 `maya-scripting` + `maya-scene` |
+| `DCC_MCP_MAYA_DEFAULT_TOOLS` | 进程级 | 未设置 | 逗号分隔的 skill 列表，覆盖默认 minimal 集 |
+| `DCC_MCP_MAYA_HOT_RELOAD` | 进程级 | `0` | 监听 skill 目录变化并热重载 |
+| `DCC_MCP_MAYA_DCC_PID` | 进程级 | `os.getpid()` | 注册到网关的 PID，用于 `diagnostics__*` 路由 |
+
+进程级变量可以在 Maya 启动前放心设置；用户/主机级变量必须在同一
+用户下的所有实例间保持一致，否则会形成互相隔离的注册表。
+
+## 典型拓扑
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  workstation-01                                                │
+│                                                                │
+│  Maya 2025.0（动画）    port=8765   dcc_pid=1234   minimal=1  │
+│  Maya 2025.1（Lookdev） port=8766   dcc_pid=5678   minimal=0  │
+│  Maya 2025.2（批量）    port=8767   dcc_pid=9012   minimal=1  │
+│                              │                                 │
+│                              ▼                                 │
+│  共享 FileRegistry ──► 网关 :9765（由 :8765 选举胜出）        │
+└────────────────────────────────┬───────────────────────────────┘
+                                 │
+                                 ▼
+                           MCP 客户端
+```
+
+每个 backend 都把自己的 `(port, pid, dcc_version, skill_list)` 写进
+共享注册表。网关维护路由表，并对外暴露一个统一的 `tools/list`，清楚
+地标注每个工具归属哪个 backend。
+
+## 故障排查
+
+### 「网关只看到一个实例」
+
+检查所有实例读到的 `DCC_MCP_REGISTRY_DIR` 是不是同一个路径。如果
+某个进程跑在不同用户下，就会写到不同的注册表根目录去。用
+`dcc_mcp_core.FileRegistry.list()` 可以查看当前存活的条目。
+
+### 「我这个实例永远当不上网关」
+
+网关选举是严格的「先绑定先得」。如果另一个 Maya 已经占着
+`DCC_MCP_GATEWAY_PORT`，那你这个进程就会以 backend 身份注册 ——
+这是设计预期。要强制某个实例当网关，要么让它先启动，要么临时给
+它一个独立端口（比如 `DCC_MCP_GATEWAY_PORT=9766`）形成一个独立
+路由域。
+
+### 「Maya 崩溃后注册表里有僵尸条目」
+
+网关的心跳大约 30 秒内会清理掉死 backend。要立即清干净：
+
+```bash
+# 删除注册表目录（下次启动会自动重建）
+python -c "from dcc_mcp_core import get_config_dir; import shutil, os; \
+           shutil.rmtree(os.path.join(get_config_dir(), 'registry'), ignore_errors=True)"
+```
+
+### 「一个实例跑 full 模式，另一个跑 minimal」
+
+按 launcher 粒度设置 `DCC_MCP_MAYA_MINIMAL`，不要设成全局变量。
+Lookdev 会话的 Windows 快捷方式可以这么写：
+
+```
+set DCC_MCP_MAYA_MINIMAL=0
+"C:\Program Files\Autodesk\Maya2025\bin\maya.exe"
+```
+
+而动画池的启动器保持默认（`=1`）即可。
+
+## 相关资源
+
+- [高级用法](./advanced) — 自定义 Skill、主线程调度。
+- [`examples/multi-instance/`](https://github.com/loonghao/dcc-mcp-maya/tree/main/examples/multi-instance) — 可运行的 `userSetup.py`。
+- Issue [#88](https://github.com/loonghao/dcc-mcp-maya/issues/88) —
+  本文的验收标准源头。

--- a/examples/multi-instance/README.md
+++ b/examples/multi-instance/README.md
@@ -1,0 +1,29 @@
+# Multi-instance example
+
+A drop-in `userSetup.py` for running multiple Maya instances on a single
+workstation, all discoverable through a single MCP gateway.
+
+## Install
+
+Copy `userSetup.py` to your Maya scripts directory (or `source` it from
+your existing `userSetup.py`):
+
+- Windows: `%USERPROFILE%/Documents/maya/scripts/userSetup.py`
+- macOS:   `~/Library/Preferences/Autodesk/maya/scripts/userSetup.py`
+- Linux:   `~/maya/scripts/userSetup.py`
+
+## What it does
+
+On every Maya launch:
+
+1. Picks the first free port from `range(8765, 8776)` (11 slots).
+2. Exports `DCC_MCP_MAYA_DCC_PID=<os.getpid()>` so `diagnostics__*`
+   tools route to the correct Maya.
+3. Exports `DCC_MCP_GATEWAY_PORT=9765` so every instance shares the
+   same gateway election.
+4. Loads the `dcc_mcp_maya_plugin` via `executeDeferred`.
+
+The helper functions (`pick_free_port`, `apply_multi_instance_env`) are
+unit-tested in `tests/test_multi_instance_example.py`; see the full
+deployment guide at
+[`docs/guide/multi-instance.md`](../../docs/guide/multi-instance.md).

--- a/examples/multi-instance/userSetup.py
+++ b/examples/multi-instance/userSetup.py
@@ -1,0 +1,124 @@
+"""Drop-in ``userSetup.py`` for running multiple Maya instances side by side.
+
+Place this file in your Maya ``scripts/`` directory (or ``source`` it from
+your existing ``userSetup.py``).  On every Maya launch it:
+
+1. Picks the first free port from :data:`PORT_RANGE` (falls back to an
+   OS-assigned port if every slot is busy).
+2. Sets ``DCC_MCP_MAYA_DCC_PID`` to ``os.getpid()`` so ``diagnostics__*``
+   tools route to the correct instance.
+3. Enables the shared MCP gateway on :data:`DEFAULT_GATEWAY_PORT` — the
+   first Maya to bind that port wins the election.
+4. Loads the ``dcc_mcp_maya`` plugin via :mod:`maya.utils.executeDeferred`.
+
+See ``docs/guide/multi-instance.md`` (EN) / ``docs/zh/guide/multi-instance.md``
+(ZH) for the full deployment guide.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+import os
+import socket
+from typing import Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Tunables ──────────────────────────────────────────────────────────────────
+
+#: Reserved HTTP port range for Maya MCP servers on this workstation.
+#:
+#: Every Maya instance picks the first free slot from this range.  Keep the
+#: range wide enough to cover the maximum number of concurrent Maya sessions
+#: you expect on a single box.  Ports outside this range are left for other
+#: applications.
+PORT_RANGE: range = range(8765, 8776)
+
+#: Gateway port shared by every instance on this host.  The first Maya to
+#: bind it becomes the gateway; the rest register as backends.
+DEFAULT_GATEWAY_PORT: int = 9765
+
+
+# ── Port selection ────────────────────────────────────────────────────────────
+
+
+def _port_is_free(port: int, host: str = "127.0.0.1") -> bool:
+    """Return ``True`` when *port* on *host* can be bound right now."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, port))
+        except OSError:
+            return False
+    return True
+
+
+def pick_free_port(candidates: Iterable[int]) -> int:
+    """Return the first port in *candidates* that is currently free.
+
+    Falls back to ``0`` (OS-assigned ephemeral port) when every candidate
+    is busy.  A return value of ``0`` is passed verbatim to the MCP
+    server; ``McpHttpServer`` accepts ``0`` and binds whatever port the
+    OS hands out.
+    """
+    for port in candidates:
+        if _port_is_free(port):
+            return port
+    return 0
+
+
+# ── Environment plumbing ──────────────────────────────────────────────────────
+
+
+def apply_multi_instance_env(
+    port_range: Iterable[int] = PORT_RANGE,
+    gateway_port: int = DEFAULT_GATEWAY_PORT,
+    dcc_pid: Optional[int] = None,
+) -> None:
+    """Populate the dcc-mcp-maya env vars for a multi-instance deployment.
+
+    Idempotent — values the operator already set (e.g. via a launcher
+    wrapper) are preserved via ``setdefault``.  Only ``DCC_MCP_MAYA_PORT``
+    is unconditionally re-computed on each call, because the previously
+    reserved port may no longer be free by the time Maya actually starts.
+    """
+    os.environ.setdefault("DCC_MCP_GATEWAY_PORT", str(gateway_port))
+    os.environ.setdefault("DCC_MCP_MAYA_DCC_PID", str(dcc_pid if dcc_pid is not None else os.getpid()))
+    os.environ["DCC_MCP_MAYA_PORT"] = str(pick_free_port(port_range))
+
+
+# ── Plugin loader ─────────────────────────────────────────────────────────────
+
+
+def _load_dcc_mcp_maya() -> None:
+    """Apply env defaults and load the ``dcc_mcp_maya`` Maya plugin."""
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+    except ImportError:
+        return
+
+    apply_multi_instance_env()
+
+    try:
+        if not cmds.pluginInfo("dcc_mcp_maya_plugin", query=True, loaded=True):
+            cmds.loadPlugin("dcc_mcp_maya_plugin", quiet=True)
+            logger.info(
+                "dcc-mcp-maya loaded on port %s (pid=%s, gateway=%s)",
+                os.environ.get("DCC_MCP_MAYA_PORT"),
+                os.environ.get("DCC_MCP_MAYA_DCC_PID"),
+                os.environ.get("DCC_MCP_GATEWAY_PORT"),
+            )
+    except Exception as exc:  # pragma: no cover  -- defensive, Maya only
+        logger.warning("dcc-mcp-maya plugin load failed: %s", exc)
+
+
+try:
+    import maya.utils  # type: ignore[import]
+
+    maya.utils.executeDeferred(_load_dcc_mcp_maya)
+except ImportError:
+    # Not running inside Maya — the helpers above are still importable for
+    # testing / introspection (see tests/test_multi_instance_example.py).
+    pass

--- a/tests/test_multi_instance_example.py
+++ b/tests/test_multi_instance_example.py
@@ -1,0 +1,87 @@
+"""Unit tests for ``examples/multi-instance/userSetup.py``.
+
+These tests exercise the import-safe helpers without launching Maya.  The
+goal is to make sure the example does not rot: if we rename an env var or
+change the default port range, these tests fail first.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+EXAMPLE = Path(__file__).resolve().parent.parent / "examples" / "multi-instance" / "userSetup.py"
+
+
+@pytest.fixture(scope="module")
+def user_setup():
+    """Import ``examples/multi-instance/userSetup.py`` as a module."""
+    spec = importlib.util.spec_from_file_location("_mi_user_setup_example", EXAMPLE)
+    assert spec and spec.loader, f"failed to build spec for {EXAMPLE}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    try:
+        yield module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+def test_default_port_range_is_reserved_block(user_setup):
+    """The example ships with a fixed, documented port block."""
+    assert list(user_setup.PORT_RANGE) == list(range(8765, 8776))
+    assert user_setup.DEFAULT_GATEWAY_PORT == 9765
+
+
+def test_pick_free_port_returns_available_port(user_setup):
+    """``pick_free_port`` must hand out a currently-bindable port."""
+    port = user_setup.pick_free_port(user_setup.PORT_RANGE)
+    # Either a port from the range, or the 0-fallback when everything is busy.
+    assert port == 0 or port in user_setup.PORT_RANGE
+
+
+def test_pick_free_port_skips_busy_port(user_setup):
+    """When the first candidate is taken, the second is chosen."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as busy:
+        try:
+            busy.bind(("127.0.0.1", 0))
+        except OSError:
+            pytest.skip("cannot bind an ephemeral port on this host")
+        taken_port = busy.getsockname()[1]
+        # Feed a two-element candidate list: [taken, free-in-range]
+        free_candidate = next(p for p in user_setup.PORT_RANGE if p != taken_port)
+        chosen = user_setup.pick_free_port([taken_port, free_candidate])
+        assert chosen == free_candidate
+
+
+def test_apply_multi_instance_env_sets_expected_keys(user_setup, monkeypatch):
+    """``apply_multi_instance_env`` populates the three env vars from #88."""
+    for key in ("DCC_MCP_MAYA_PORT", "DCC_MCP_GATEWAY_PORT", "DCC_MCP_MAYA_DCC_PID"):
+        monkeypatch.delenv(key, raising=False)
+
+    user_setup.apply_multi_instance_env(dcc_pid=424242)
+
+    assert os.environ["DCC_MCP_MAYA_DCC_PID"] == "424242"
+    assert os.environ["DCC_MCP_GATEWAY_PORT"] == str(user_setup.DEFAULT_GATEWAY_PORT)
+    # Port must be numeric and either 0 or in the reserved range.
+    port = int(os.environ["DCC_MCP_MAYA_PORT"])
+    assert port == 0 or port in user_setup.PORT_RANGE
+
+
+def test_apply_multi_instance_env_preserves_operator_overrides(user_setup, monkeypatch):
+    """An operator-set ``DCC_MCP_GATEWAY_PORT`` must not be clobbered."""
+    monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "9999")
+    monkeypatch.setenv("DCC_MCP_MAYA_DCC_PID", "12345")
+    monkeypatch.delenv("DCC_MCP_MAYA_PORT", raising=False)
+
+    user_setup.apply_multi_instance_env()
+
+    assert os.environ["DCC_MCP_GATEWAY_PORT"] == "9999"
+    assert os.environ["DCC_MCP_MAYA_DCC_PID"] == "12345"
+    # Port is always re-computed — env should contain a fresh value.
+    assert "DCC_MCP_MAYA_PORT" in os.environ


### PR DESCRIPTION
## Summary

Closes part of #88.

Adds the Maya-specific deployment guide for running multiple Maya
instances on a single workstation behind one MCP gateway, plus a
runnable `userSetup.py` example.

### What changed

- **`docs/guide/multi-instance.md`** (EN) — invariants, launching N
  instances, env-var reference (7 vars with scope + default), a
  single-host topology diagram, and a troubleshooting section.
- **`docs/zh/guide/multi-instance.md`** (ZH) — full translation kept
  section-parallel with the EN version.
- **`examples/multi-instance/userSetup.py`** — picks the first free
  port from a reserved range (`8765-8775`), exports
  `DCC_MCP_MAYA_DCC_PID=os.getpid()` and `DCC_MCP_GATEWAY_PORT=9765`,
  then loads the Maya plugin via `executeDeferred`.  Helper functions
  are import-safe so they can be unit-tested without Maya.
- **`examples/multi-instance/README.md`** — install instructions.
- **`tests/test_multi_instance_example.py`** — 5 pytest cases
  covering port selection, env-var population, and operator-override
  preservation (< 50 ms total, no Maya required).
- **Docs index pages + top-level README** link to the new guide.

### Out of scope

The acceptance-criterion smoke test that spins up two
`MayaStandaloneDispatcher` backends plus a real gateway binary and
asserts `jobs.get_status` routes correctly is **deferred to #86** —
that PR already owns the integration-gateway harness, and duplicating
it here would produce conflicting fixtures.  The current PR covers
the documentation + example + import-level tests.

The doc-parity CI check (`tools/check_doc_parity.py`) listed in the
issue does not yet exist in this repo; wiring a diff-based parity
check across `docs/` and `docs/zh/` is left for a separate
infrastructure PR.

## Test plan

- [x] `pytest tests/test_multi_instance_example.py -v` → 5 passed in 0.04s.
- [x] `ruff check examples/ tests/test_multi_instance_example.py` → clean.
- [x] `ruff format --check tests/test_multi_instance_example.py` → already formatted.
- [x] EN + ZH docs render correctly (headings balanced, tables close).
- [ ] CI green on GitHub.

## Dependencies

- Non-blocking — all referenced mechanisms (`FileRegistry`,
  `DCC_MCP_GATEWAY_PORT`, gateway election) already ship in
  `dcc-mcp-core` 0.14.3.
