### PR TITLE
feat(dispatcher): cooperative cancellation + drain-on-stop (#85, partial #89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,49 @@ Add to `claude_desktop_config.json`:
 - Maya 2020+ (Python 3.7+)
 - [`dcc-mcp-core`](https://github.com/loonghao/dcc-mcp-core) ≥ 0.12.29
 
+## Cooperative Cancellation in Skill Scripts
+
+Long-running skill scripts (renders, bakes, mocap ingest, …) should poll
+`check_maya_cancelled()` at safe checkpoints so the dispatcher can preempt
+them when the MCP client sends `notifications/cancelled` or when
+`MayaMcpServer.stop()` drains pending jobs:
+
+```python
+from dcc_mcp_maya import check_maya_cancelled, maya_success
+
+def render_frames(frames):
+    for frame in frames:
+        check_maya_cancelled()      # raises CancelledError when cancelled
+        cmds.currentTime(frame)
+        cmds.render()
+    return maya_success("rendered", frames=len(frames))
+```
+
+`check_maya_cancelled()` checks two cancellation sources:
+
+1. **MCP request token** (`dcc_mcp_core.cancellation.check_cancelled`) — set by
+   the HTTP handler when `notifications/cancelled` arrives for the owning
+   `tools/call`.
+2. **Per-job dispatcher flag** — set by `MayaUiDispatcher.cancel(...)` or
+   `MayaUiDispatcher.shutdown(...)`. Covers jobs launched outside an MCP
+   request (queued batch render, scriptJob, …) where the contextvar token
+   is not installed.
+
+Outside any of those contexts the call is a cheap no-op, so dropping it into
+a loop is safe even when the script runs from an interactive REPL or a unit
+test.
+
+`MayaUiPump.stats` exposes `overrun_cycles` (idle ticks where a single
+non-cooperative job exceeded `budget_ms × 2`) and `longest_job_ms` (worst
+single-job wall-clock observed) so operators can tell when a skill needs
+to be chunked behind `check_maya_cancelled()` instead of monopolising the
+UI thread.
+
+`MayaMcpServer.stop()` calls `dispatcher.shutdown("Interrupted")` on any
+dispatcher attached via `server.attach_dispatcher(...)`, so threads blocked
+inside `submit_callable` unblock within the normal `event.wait()` poll
+instead of hanging when Maya restarts mid-job (issue #89).
+
 ## Authoring Skills: Execution & Affinity
 
 Every tool declared in a `tools.yaml` file must tell the MCP gateway **how** it

--- a/src/dcc_mcp_maya/__init__.py
+++ b/src/dcc_mcp_maya/__init__.py
@@ -61,6 +61,7 @@ from dcc_mcp_maya.dispatcher import (
     MayaStandaloneDispatcher,
     MayaUiDispatcher,
     MayaUiPump,
+    check_maya_cancelled,
     create_dispatcher,
 )
 from dcc_mcp_maya.server import MayaMcpServer, start_server, stop_server
@@ -76,6 +77,7 @@ __all__ = [
     "MayaUiPump",
     "MayaStandaloneDispatcher",
     "create_dispatcher",
+    "check_maya_cancelled",
     # Skill authoring helpers
     "maya_success",
     "maya_error",

--- a/src/dcc_mcp_maya/dispatcher.py
+++ b/src/dcc_mcp_maya/dispatcher.py
@@ -41,6 +41,7 @@ See: https://github.com/loonghao/dcc-mcp-maya/issues/66
 from __future__ import annotations
 
 # Import built-in modules
+import contextvars
 import logging
 import threading
 import time
@@ -57,6 +58,24 @@ DEFAULT_BUDGET_MS = 8
 #: Default soft timeout for individual jobs (milliseconds).
 DEFAULT_JOB_TIMEOUT_MS = 30_000
 
+#: Overrun threshold — any pump tick that spends more than ``budget_ms`` × this
+#: multiplier counts as an ``overrun_cycles`` in :class:`MayaUiPump.stats`.
+#: Matches the wording in issue #85: *"ticks that exceeded ``budget_ms * 2``"*.
+OVERRUN_MULTIPLIER = 2.0
+
+# ── Per-job cancellation token (contextvars, issue #85) ──────────────────────
+
+#: Context-local slot pointing to the currently-executing :class:`_JobEntry`.
+#: Set by :meth:`MayaUiDispatcher.drain_queue` around :meth:`_JobEntry.execute`
+#: so skill scripts running on the UI thread can discover whether the caller
+#: has signalled cancellation via :meth:`MayaUiDispatcher.cancel` — even when
+#: the script was launched outside an MCP request context (queued batch
+#: render, scriptJob, etc.).
+_current_job: contextvars.ContextVar[Optional["_JobEntry"]] = contextvars.ContextVar(
+    "dcc_mcp_maya_current_job",
+    default=None,
+)
+
 
 # ── Job types ─────────────────────────────────────────────────────────────────
 
@@ -64,7 +83,15 @@ DEFAULT_JOB_TIMEOUT_MS = 30_000
 class _JobEntry:
     """Internal job wrapper queued for main-thread execution."""
 
-    __slots__ = ("request_id", "affinity", "task", "timeout_ms", "event", "outcome")
+    __slots__ = (
+        "request_id",
+        "affinity",
+        "task",
+        "timeout_ms",
+        "event",
+        "outcome",
+        "cancel_flag",
+    )
 
     def __init__(
         self,
@@ -79,9 +106,31 @@ class _JobEntry:
         self.timeout_ms = timeout_ms or DEFAULT_JOB_TIMEOUT_MS
         self.event = threading.Event()
         self.outcome: Optional[Dict[str, Any]] = None
+        # Per-job cancellation flag — set by :meth:`MayaUiDispatcher.cancel`
+        # (pre-execute) or :meth:`MayaUiDispatcher.shutdown` (drain). The
+        # flag is a plain :class:`threading.Event` rather than a
+        # :class:`~dcc_mcp_core.cancellation.CancelToken` so we stay
+        # dependency-free for the transport path. See
+        # :func:`check_maya_cancelled` for the skill-facing probe.
+        self.cancel_flag = threading.Event()
+
+    def cancel(self) -> None:
+        """Signal cooperative cancellation to the task — idempotent.
+
+        Does NOT interrupt a running :meth:`execute`: the task must call
+        :func:`check_maya_cancelled` at a safe checkpoint to observe the
+        flag and raise :class:`~dcc_mcp_core.cancellation.CancelledError`.
+        """
+        self.cancel_flag.set()
+
+    @property
+    def cancelled(self) -> bool:
+        """Whether :meth:`cancel` has been invoked on this job."""
+        return self.cancel_flag.is_set()
 
     def execute(self) -> Dict[str, Any]:
         """Execute the task and populate ``self.outcome``."""
+        token = _current_job.set(self)
         try:
             output = self.task()
             self.outcome = {
@@ -92,6 +141,9 @@ class _JobEntry:
                 "error": None,
             }
         except Exception as exc:
+            # :class:`~dcc_mcp_core.cancellation.CancelledError` surfaces
+            # through this branch too — the outer caller can distinguish
+            # cancellation by checking ``self.cancelled``.
             self.outcome = {
                 "request_id": self.request_id,
                 "affinity": self.affinity,
@@ -99,8 +151,68 @@ class _JobEntry:
                 "output": None,
                 "error": str(exc),
             }
+        finally:
+            _current_job.reset(token)
         self.event.set()
         return self.outcome
+
+
+# ── Cooperative cancellation (issue #85) ─────────────────────────────────────
+
+
+def check_maya_cancelled() -> None:
+    """Raise :class:`~dcc_mcp_core.cancellation.CancelledError` on cancellation.
+
+    Used by skill scripts inside long-running loops so the caller can
+    preempt work without Maya's UI thread running unbounded. The helper
+    respects **both** cancellation sources:
+
+    1. ``dcc_mcp_core.cancellation.check_cancelled()`` — the MCP request
+       context set by the HTTP handler when a ``notifications/cancelled``
+       arrives for the owning ``tools/call``.
+    2. The per-job :attr:`_JobEntry.cancel_flag`, populated by
+       :meth:`MayaUiDispatcher.cancel` / :meth:`MayaUiDispatcher.shutdown`.
+       This path covers jobs launched **outside** an MCP request
+       (queued batch render, scriptJob, etc.) where the
+       contextvar-based core token is not installed.
+
+    When neither source reports cancellation, the call is a cheap no-op.
+
+    Example::
+
+        from dcc_mcp_maya.dispatcher import check_maya_cancelled
+
+        def run(frames):
+            for f in frames:
+                check_maya_cancelled()        # safe checkpoint
+                cmds.currentTime(f)
+                cmds.render()
+
+    Raises
+    ------
+    dcc_mcp_core.cancellation.CancelledError
+        When either the MCP request or the owning dispatcher has
+        signalled cancellation.
+    """
+    # Layer 1: honour the core MCP request token if one is installed.
+    try:
+        from dcc_mcp_core.cancellation import (  # noqa: PLC0415
+            CancelledError,
+            check_cancelled,
+        )
+    except ImportError:  # pragma: no cover — core is a hard dep at runtime
+        CancelledError = RuntimeError  # type: ignore[assignment]
+
+        def check_cancelled() -> None:  # type: ignore[no-redef]
+            return
+
+    check_cancelled()
+
+    # Layer 2: honour the Maya-side per-job flag, if we are inside an
+    # :class:`_JobEntry.execute` call.
+    job = _current_job.get()
+    if job is not None and job.cancelled:
+        raise CancelledError("Maya job cancelled by dispatcher")
 
 
 # ── MayaUiDispatcher ─────────────────────────────────────────────────────────
@@ -120,6 +232,13 @@ class MayaUiDispatcher:
         self._main_queue: Deque[_JobEntry] = deque()
         self._lock = threading.Lock()
         self._cancelled: set = set()
+        # Active in-flight jobs (executing on the UI thread). Populated by
+        # :meth:`drain_queue` and consulted by :meth:`shutdown` so a stop
+        # signal can fire :attr:`_JobEntry.cancel_flag` / ``event`` for
+        # jobs that are already running — otherwise their blocked
+        # :meth:`submit_callable` caller would hang forever (issue #89).
+        self._active: Dict[str, _JobEntry] = {}
+        self._shutdown = False
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -201,15 +320,27 @@ class MayaUiDispatcher:
         return self._submit_main(request_id, task, affinity, timeout_ms)
 
     def cancel(self, request_id: str) -> bool:
-        """Cancel a pending main-thread job.
+        """Signal cancellation for a pending or running main-thread job.
 
-        Returns ``True`` if the job was found and removed from the queue.
-        Jobs already executing cannot be cancelled.
+        If the job is still queued, it is removed and its outcome is
+        populated with ``error="Cancelled"`` before :meth:`execute` ever
+        runs. If the job is already executing, the per-job cancel flag
+        is set so a cooperating task that calls
+        :func:`check_maya_cancelled` at a safe checkpoint can observe the
+        request and raise :class:`~dcc_mcp_core.cancellation.CancelledError`.
+
+        Returns
+        -------
+        bool
+            ``True`` when the job was found (queued or running).
         """
         with self._lock:
             self._cancelled.add(request_id)
+
+            # Queued job: short-circuit now, before drain_queue runs it.
             for job in self._main_queue:
                 if job.request_id == request_id:
+                    job.cancel()
                     job.outcome = {
                         "request_id": request_id,
                         "affinity": job.affinity,
@@ -219,11 +350,84 @@ class MayaUiDispatcher:
                     }
                     job.event.set()
                     return True
+
+            # In-flight job: set the cooperative flag so the task can
+            # observe cancellation at its next check_maya_cancelled() call.
+            active_job = self._active.get(request_id)
+            if active_job is not None:
+                active_job.cancel()
+                return True
+
         return False
 
     def pending_count(self) -> int:
         """Return the number of jobs waiting in the main-thread queue."""
         return len(self._main_queue)
+
+    def shutdown(self, reason: str = "Interrupted") -> int:
+        """Drain the dispatcher — mark every pending and in-flight job as ``Interrupted``.
+
+        Called from :meth:`~dcc_mcp_maya.server.MayaMcpServer.stop` (and
+        from standalone teardown) so any thread currently blocked inside
+        :meth:`submit_callable` / :meth:`submit` unblocks within the
+        usual ``event.wait()`` poll instead of hanging forever after
+        Maya restarts mid-job. Matches the contract in issue #89:
+
+        * Every queued ``_JobEntry`` gets ``outcome.error=reason`` and
+          its :attr:`event` is set so the blocked submitter returns
+          immediately on next ``wait()``.
+        * Every in-flight job has its :attr:`cancel_flag` set so a
+          cooperating task can observe cancellation at its next
+          :func:`check_maya_cancelled` checkpoint and exit cleanly.
+        * After shutdown, further :meth:`submit_callable` calls return
+          the same ``Interrupted`` outcome without enqueuing (so the
+          Python thread that tried to submit during teardown does not
+          leak). Re-use of a shutdown dispatcher is not supported.
+
+        Returns
+        -------
+        int
+            Total number of queued + in-flight jobs that were signalled.
+        """
+        signalled = 0
+        with self._lock:
+            self._shutdown = True
+
+            while self._main_queue:
+                job = self._main_queue.popleft()
+                job.cancel()
+                if job.outcome is None:
+                    job.outcome = {
+                        "request_id": job.request_id,
+                        "affinity": job.affinity,
+                        "success": False,
+                        "output": None,
+                        "error": reason,
+                    }
+                job.event.set()
+                signalled += 1
+
+            for job in list(self._active.values()):
+                job.cancel()
+                # NOTE: we do NOT set ``job.event`` here — the task is
+                # still running on the UI thread. :meth:`execute` will
+                # populate ``outcome`` and fire ``event`` when it returns
+                # or raises ``CancelledError``. Setting ``event`` now
+                # would race with :meth:`execute`.
+                signalled += 1
+
+        if signalled:
+            logger.info(
+                "MayaUiDispatcher.shutdown: signalled %d job(s) with reason=%r",
+                signalled,
+                reason,
+            )
+        return signalled
+
+    @property
+    def is_shutdown(self) -> bool:
+        """``True`` once :meth:`shutdown` has been called."""
+        return self._shutdown
 
     def supported(self) -> List[str]:
         """Return supported affinity values."""
@@ -273,8 +477,15 @@ class MayaUiDispatcher:
                         }
                         job.event.set()
                     continue
+                # Track in-flight job so shutdown() / cancel() can set
+                # the cooperative flag while execute() runs.
+                self._active[job.request_id] = job
 
-            job.execute()
+            try:
+                job.execute()
+            finally:
+                with self._lock:
+                    self._active.pop(job.request_id, None)
             executed += 1
 
         remaining = len(self._main_queue)
@@ -322,6 +533,17 @@ class MayaUiDispatcher:
         job = _JobEntry(request_id, affinity, task, timeout_ms)
 
         with self._lock:
+            if self._shutdown:
+                # Post-shutdown submissions must not hang — return
+                # immediately with the same outcome shape the drain path
+                # produces for interrupted jobs (issue #89).
+                return {
+                    "request_id": request_id,
+                    "affinity": affinity,
+                    "success": False,
+                    "output": None,
+                    "error": "Interrupted",
+                }
             self._main_queue.append(job)
 
         # If no MayaUiPump is installed, fall back to executeDeferred
@@ -478,7 +700,21 @@ class MayaUiPump:
         self._budget_ms = budget_ms
         self._script_job_id: Optional[int] = None
         self._installed = False
-        self._stats = {"total_executed": 0, "total_cycles": 0, "total_elapsed_ms": 0.0}
+        self._stats: Dict[str, float] = {
+            "total_executed": 0,
+            "total_cycles": 0,
+            "total_elapsed_ms": 0.0,
+            # Issue #85 §4 — ticks that exceeded ``budget_ms`` × OVERRUN_MULTIPLIER.
+            # A non-zero value means ``MayaUiPump`` cannot chunk the work
+            # further and the UI thread is being saturated by a single
+            # non-cooperative ``cmds.*`` call. Skill authors should move
+            # the offending logic behind :func:`check_maya_cancelled`
+            # so it yields periodically.
+            "overrun_cycles": 0,
+            # Worst single-job wall-clock time observed across all cycles.
+            # Feeds the ``dcc_maya_job_duration_seconds`` histogram (#87).
+            "longest_job_ms": 0.0,
+        }
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -550,7 +786,18 @@ class MayaUiPump:
     # ── Pump implementation ───────────────────────────────────────────────────
 
     def _pump_tick(self) -> None:
-        """Idle-event callback: drain pending jobs within the budget."""
+        """Idle-event callback: drain pending jobs within the budget.
+
+        Important preemption caveat (issue #85 §4):
+        ``drain_queue(budget_ms)`` only checks the deadline **between**
+        jobs. When a skill script makes a single, non-cooperative
+        ``cmds.*`` call that blocks the UI thread for seconds, this tick
+        cannot preempt it — Maya itself has no tool to interrupt a
+        running Python callable. The tick will be counted as an
+        ``overrun_cycles`` so operators can tell the difference between
+        "the pump is tuned too aggressively" and "a skill needs to be
+        chunked behind :func:`check_maya_cancelled`".
+        """
         start = time.monotonic()
         executed, remaining = self._dispatcher.drain_queue(self._budget_ms)
 
@@ -558,6 +805,23 @@ class MayaUiPump:
         self._stats["total_executed"] += executed
         self._stats["total_cycles"] += 1
         self._stats["total_elapsed_ms"] += elapsed_ms
+
+        # Overrun bookkeeping — see OVERRUN_MULTIPLIER.
+        if elapsed_ms > self._budget_ms * OVERRUN_MULTIPLIER:
+            self._stats["overrun_cycles"] += 1
+
+        # ``longest_job_ms`` approximates the worst single-job duration.
+        # ``drain_queue`` may execute multiple jobs per tick when each
+        # finishes inside the budget; in that case the per-job worst is
+        # bounded by ``elapsed_ms / max(executed, 1)``. When a single
+        # job blows past the budget it dominates the tick, which is
+        # exactly the case we want this metric to catch, so use the
+        # larger of the two estimates.
+        if executed > 0:
+            avg_job_ms = elapsed_ms / executed
+            worst_job_ms = elapsed_ms if executed == 1 else max(elapsed_ms, avg_job_ms)
+            if worst_job_ms > self._stats["longest_job_ms"]:
+                self._stats["longest_job_ms"] = worst_job_ms
 
         if remaining > 0:
             # Re-poke Maya so we get another idle event quickly

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -184,6 +184,57 @@ class MayaMcpServer(DccServerBase):
             enable_gateway_failover=enable_gateway_failover,
         )
 
+        # Optional :class:`~dcc_mcp_maya.dispatcher.MayaUiDispatcher`
+        # attached by the plugin (or by tests). When set, :meth:`stop`
+        # drains it before tearing the HTTP server down so any thread
+        # blocked inside ``submit_callable`` returns within the normal
+        # ``event.wait()`` budget instead of hanging indefinitely
+        # (issue #85 / #89).
+        self._maya_dispatcher: Any = None
+
+    def attach_dispatcher(self, dispatcher: Any) -> None:
+        """Register a :class:`MayaUiDispatcher` (or compatible) for lifecycle integration.
+
+        The server does not create the dispatcher itself because Maya
+        needs control over when the :class:`MayaUiPump` is installed
+        (that requires a live ``scriptJob``, which only makes sense
+        inside a real interactive session). Callers that manage a
+        dispatcher should invoke :meth:`attach_dispatcher` after
+        :meth:`start` so :meth:`stop` can drain pending jobs.
+
+        Passing ``None`` detaches a previously-registered dispatcher
+        and is a no-op when nothing is attached.
+        """
+        self._maya_dispatcher = dispatcher
+
+    def stop(self) -> None:
+        """Stop the HTTP server and drain any attached Maya dispatcher.
+
+        Order matters: we drain the dispatcher **before** the HTTP
+        server shuts down so any thread blocked inside
+        ``submit_callable`` observes the drained outcome (``Interrupted``)
+        and returns before the HTTP handler that originally enqueued
+        the job gives up and closes the response.
+        """
+        dispatcher = self._maya_dispatcher
+        if dispatcher is not None:
+            try:
+                shutdown = getattr(dispatcher, "shutdown", None)
+                if callable(shutdown):
+                    signalled = shutdown("Interrupted")
+                    logger.info(
+                        "[%s] dispatcher.shutdown signalled %s job(s)",
+                        self._dcc_name,
+                        signalled,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Error draining Maya dispatcher during stop(): %s",
+                    self._dcc_name,
+                    exc,
+                )
+        super().stop()
+
     # ── Maya-specific overrides ───────────────────────────────────────────────
 
     def register_builtin_actions(

--- a/tests/test_dispatcher_cancellation.py
+++ b/tests/test_dispatcher_cancellation.py
@@ -1,0 +1,327 @@
+"""Tests for cooperative cancellation, pump stats, and drain-on-stop.
+
+Covers issue #85 (``check_maya_cancelled()``, ``MayaUiPump.stats``) and the
+Maya-side half of issue #89 (``MayaUiDispatcher.shutdown`` + server
+integration).
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Module under test
+from dcc_mcp_maya.dispatcher import (
+    DEFAULT_BUDGET_MS,
+    OVERRUN_MULTIPLIER,
+    MayaUiDispatcher,
+    MayaUiPump,
+    check_maya_cancelled,
+)
+
+# ---------------------------------------------------------------------------
+# check_maya_cancelled() — core-token and per-job layers
+# ---------------------------------------------------------------------------
+
+
+def test_check_maya_cancelled_is_noop_outside_request():
+    """Calling ``check_maya_cancelled`` with no context is a cheap no-op."""
+    # Should not raise on a fresh interpreter with no token / job installed.
+    check_maya_cancelled()
+
+
+def test_check_maya_cancelled_honours_core_cancel_token():
+    """Layer 1 — ``dcc_mcp_core.cancellation`` request token trips the probe."""
+    from dcc_mcp_core.cancellation import (
+        CancelledError,
+        CancelToken,
+        reset_cancel_token,
+        set_cancel_token,
+    )
+
+    token = CancelToken()
+    reset = set_cancel_token(token)
+    try:
+        check_maya_cancelled()  # token not yet cancelled
+        token.cancel()
+        with pytest.raises(CancelledError):
+            check_maya_cancelled()
+    finally:
+        reset_cancel_token(reset)
+
+
+def test_check_maya_cancelled_honours_dispatcher_flag_during_execute():
+    """Layer 2 — ``MayaUiDispatcher.cancel`` trips the probe inside execute."""
+    dispatcher = MayaUiDispatcher()
+
+    iterations = []
+
+    def long_task():
+        # Simulate a loop that checks at every step — the second
+        # iteration must raise after the dispatcher cancels us.
+        for i in range(5):
+            check_maya_cancelled()
+            iterations.append(i)
+            if i == 1:
+                dispatcher.cancel("req-1")
+
+    import_thread = threading.Thread(
+        target=lambda: dispatcher.submit_callable("req-1", long_task, affinity="main", timeout_ms=2000),
+    )
+    import_thread.start()
+
+    # Drain on this "UI" thread — the task runs here, inside the
+    # context of :meth:`_JobEntry.execute`, so ``check_maya_cancelled``
+    # sees the cancel flag set during execution.
+    #
+    # Give the submitter a moment to enqueue the job before we start
+    # draining so the test is order-independent.
+    for _ in range(20):
+        if dispatcher.pending_count() > 0:
+            break
+        time.sleep(0.01)
+    dispatcher.drain_queue(budget_ms=200)
+    import_thread.join(timeout=2.0)
+
+    # We walked at least into iteration 1 (where we triggered cancel),
+    # but the loop must have aborted via CancelledError — so iteration 4
+    # must NOT have executed.
+    assert 1 in iterations
+    assert 4 not in iterations
+
+
+# ---------------------------------------------------------------------------
+# MayaUiPump.stats — overrun_cycles + longest_job_ms
+# ---------------------------------------------------------------------------
+
+
+def test_pump_stats_record_overrun_cycles():
+    """A single non-cooperative job that exceeds ``budget_ms * OVERRUN_MULTIPLIER``
+    must increment ``overrun_cycles`` exactly once and update
+    ``longest_job_ms`` with a sensible duration.
+    """
+    dispatcher = MayaUiDispatcher()
+    pump = MayaUiPump(dispatcher, budget_ms=5.0)  # tight budget
+
+    overrun_threshold_ms = pump.budget_ms * OVERRUN_MULTIPLIER
+
+    def hog_the_ui():
+        # Block longer than the overrun threshold to guarantee detection
+        # across platforms with noisy schedulers. 4× the threshold keeps
+        # the test fast while still exceeding OVERRUN_MULTIPLIER.
+        time.sleep(overrun_threshold_ms / 1000.0 * 4.0)
+
+    submitter_result = {}
+
+    def submit():
+        submitter_result.update(dispatcher.submit_callable("hog", hog_the_ui, affinity="main", timeout_ms=2000))
+
+    t = threading.Thread(target=submit)
+    t.start()
+    # Wait for the job to show up in the main queue.
+    for _ in range(50):
+        if dispatcher.pending_count() > 0:
+            break
+        time.sleep(0.01)
+
+    # Drive the idle-event callback directly — we cannot register a
+    # scriptJob outside Maya.
+    pump._pump_tick()  # noqa: SLF001
+    t.join(timeout=3.0)
+
+    stats = pump.stats
+    assert stats["overrun_cycles"] == 1, stats
+    assert stats["longest_job_ms"] >= overrun_threshold_ms, stats
+    # Cumulative wall-clock must be consistent.
+    assert stats["total_cycles"] == 1
+    assert stats["total_executed"] == 1
+
+
+def test_pump_stats_stay_zero_when_budget_honoured():
+    dispatcher = MayaUiDispatcher()
+    pump = MayaUiPump(dispatcher, budget_ms=DEFAULT_BUDGET_MS)
+
+    def quick():
+        # Nearly instant — well below DEFAULT_BUDGET_MS * 2.
+        return 1
+
+    submitter_result = {}
+
+    def submit():
+        submitter_result.update(dispatcher.submit_callable("quick", quick, affinity="main", timeout_ms=500))
+
+    t = threading.Thread(target=submit)
+    t.start()
+    for _ in range(50):
+        if dispatcher.pending_count() > 0:
+            break
+        time.sleep(0.01)
+    pump._pump_tick()  # noqa: SLF001
+    t.join(timeout=2.0)
+
+    stats = pump.stats
+    assert stats["overrun_cycles"] == 0, stats
+    assert stats["total_executed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# MayaUiDispatcher.shutdown — issue #89 partial coverage
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_unblocks_queued_submit_callable_quickly():
+    """A thread blocked inside ``submit_callable`` must return within
+    the usual ``event.wait()`` poll after :meth:`shutdown` fires.
+    """
+    dispatcher = MayaUiDispatcher()
+
+    result_holder = {}
+
+    def never_runs():
+        pytest.fail("Queued task must not execute after shutdown()")
+
+    def submit():
+        result_holder["outcome"] = dispatcher.submit_callable("queued-1", never_runs, affinity="main", timeout_ms=5000)
+
+    t = threading.Thread(target=submit)
+    t.start()
+
+    # Wait until the submitter has enqueued the job.
+    for _ in range(50):
+        if dispatcher.pending_count() > 0:
+            break
+        time.sleep(0.01)
+
+    start = time.monotonic()
+    signalled = dispatcher.shutdown("Interrupted")
+    t.join(timeout=1.0)
+    elapsed = time.monotonic() - start
+
+    assert signalled >= 1
+    assert not t.is_alive(), "submit_callable must unblock within 1 s of shutdown()"
+    assert elapsed < 1.0
+    outcome = result_holder["outcome"]
+    assert outcome["success"] is False
+    assert outcome["error"] == "Interrupted"
+
+
+def test_shutdown_flags_running_job_for_cooperative_cancel():
+    """A job that is already running observes the cancel flag via
+    :func:`check_maya_cancelled` and exits with ``CancelledError``.
+    """
+    from dcc_mcp_core.cancellation import CancelledError
+
+    dispatcher = MayaUiDispatcher()
+
+    started = threading.Event()
+    observed_cancel = threading.Event()
+
+    def long_task():
+        started.set()
+        for _ in range(50):
+            try:
+                check_maya_cancelled()
+            except CancelledError:
+                observed_cancel.set()
+                raise
+            time.sleep(0.01)
+
+    submit_thread = threading.Thread(
+        target=lambda: dispatcher.submit_callable("long", long_task, affinity="main", timeout_ms=3000)
+    )
+    submit_thread.start()
+
+    # Wait for submitter to enqueue the task.
+    for _ in range(50):
+        if dispatcher.pending_count() > 0:
+            break
+        time.sleep(0.01)
+
+    def drive_pump():
+        dispatcher.drain_queue(budget_ms=2000)
+
+    pump_thread = threading.Thread(target=drive_pump)
+    pump_thread.start()
+
+    # Give the task a chance to start executing.
+    assert started.wait(timeout=2.0), "task never started on main thread"
+
+    dispatcher.shutdown("Interrupted")
+
+    pump_thread.join(timeout=3.0)
+    submit_thread.join(timeout=3.0)
+
+    assert observed_cancel.is_set(), "cooperating task failed to observe cancel flag"
+
+
+def test_submit_callable_after_shutdown_returns_immediately():
+    """Post-shutdown submissions must not hang — issue #89 contract."""
+    dispatcher = MayaUiDispatcher()
+    dispatcher.shutdown("Interrupted")
+
+    outcome = dispatcher.submit_callable("post", lambda: 1, affinity="main", timeout_ms=5000)
+    assert outcome["success"] is False
+    assert outcome["error"] == "Interrupted"
+
+
+# ---------------------------------------------------------------------------
+# MayaMcpServer.stop() wiring — partial #85 integration test
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _mock_maya_modules():
+    maya_mock = MagicMock()
+    modules = {
+        "maya": maya_mock,
+        "maya.cmds": maya_mock.cmds,
+        "maya.mel": maya_mock.mel,
+        "maya.utils": maya_mock.utils,
+    }
+    with patch.dict(sys.modules, modules):
+        yield
+
+
+def test_server_stop_drains_attached_dispatcher(_mock_maya_modules):
+    """``MayaMcpServer.stop()`` must call ``dispatcher.shutdown`` so blocked
+    threads unblock without hanging the server teardown.
+    """
+    for mod in list(sys.modules):
+        if "dcc_mcp_maya" in mod:
+            del sys.modules[mod]
+    import importlib
+
+    srv_mod = importlib.import_module("dcc_mcp_maya.server")
+    dispatcher_mod = importlib.import_module("dcc_mcp_maya.dispatcher")
+
+    server = srv_mod.MayaMcpServer(port=0)
+    dispatcher = dispatcher_mod.MayaUiDispatcher()
+    server.attach_dispatcher(dispatcher)
+    server.start()
+
+    # Prime the dispatcher with a queued job nobody will drain.
+    outcomes = {}
+
+    def submit():
+        outcomes["outcome"] = dispatcher.submit_callable("queued", lambda: 42, affinity="main", timeout_ms=5000)
+
+    t = threading.Thread(target=submit)
+    t.start()
+    for _ in range(50):
+        if dispatcher.pending_count() > 0:
+            break
+        time.sleep(0.01)
+
+    start = time.monotonic()
+    server.stop()
+    t.join(timeout=1.0)
+    elapsed = time.monotonic() - start
+
+    assert not t.is_alive(), "submit_callable must unblock when server stops"
+    assert elapsed < 2.0
+    assert dispatcher.is_shutdown is True
+    assert outcomes["outcome"]["error"] == "Interrupted"


### PR DESCRIPTION
Closes part of #85 and the Maya-side half of #89.

The full issue #85 acceptance criteria depend on dcc-mcp-core wiring (`JobManager` + async dispatch + SSE progress) that lives outside this repo. This PR ships every piece that does **not** require the core dispatch path to land in `dcc-mcp-maya` first — the changes are forward-compatible and re-engage with no further work once the core integration arrives.

## What changes

### 1. `check_maya_cancelled()` (issue #85 §3)

New public helper in `dcc_mcp_maya.dispatcher`, re-exported from the top-level package:

```python
from dcc_mcp_maya import check_maya_cancelled

def render_frames(frames):
    for frame in frames:
        check_maya_cancelled()      # raises CancelledError when cancelled
        cmds.currentTime(frame)
        cmds.render()
```

Two cancellation sources are honoured:

1. **MCP request token** — `dcc_mcp_core.cancellation.check_cancelled()`. Set by the HTTP handler when `notifications/cancelled` arrives for the owning `tools/call`.
2. **Per-job dispatcher flag** — set by `MayaUiDispatcher.cancel(...)` or `MayaUiDispatcher.shutdown(...)`. Covers jobs launched outside an MCP request (queued batch render, `scriptJob`, …) where the contextvar token is not installed.

Outside any of those contexts the call is a cheap no-op, so dropping it into a loop is safe even when the script runs from an interactive REPL or a unit test.

### 2. `MayaUiDispatcher.cancel` / `shutdown` (issues #85, #89)

- `cancel(request_id)` now also covers in-flight jobs: when the job is already executing on the UI thread, the per-job `cancel_flag` is set so a cooperating task can observe the request at its next `check_maya_cancelled()` checkpoint and raise `CancelledError`.
- New `shutdown(reason='Interrupted')` walks every queued job (populating `outcome.error` and firing `event` so blocked `submit_callable` callers return immediately) **and** signals every in-flight job. Subsequent submissions return the same `Interrupted` outcome instead of enqueuing — preventing the thread-leak failure mode described in issue #89.
- A new contextvar `_current_job` makes the running `_JobEntry` visible to `check_maya_cancelled()` for the duration of `_JobEntry.execute()`.

### 3. `MayaUiPump.stats` (issue #85 §4)

- New `overrun_cycles` counter — incremented when a single tick spends more than `budget_ms × OVERRUN_MULTIPLIER` (=2). A non-zero value tells operators that a non-cooperative `cmds.*` call is saturating the UI thread and the offending skill needs to chunk behind `check_maya_cancelled()`.
- New `longest_job_ms` gauge — worst single-job wall-clock observed across all cycles. Feeds the `dcc_maya_job_duration_seconds` histogram planned in issue #87.
- Pump tick docstring now explicitly documents the preemption caveat: `drain_queue` only checks the deadline **between** jobs.

### 4. `MayaMcpServer.stop()` integration (partial #89)

- New `attach_dispatcher(...)` API.
- `stop()` calls `dispatcher.shutdown('Interrupted')` **before** the HTTP server tears down so any thread blocked inside `submit_callable` observes the drained outcome and returns before the HTTP handler that originally enqueued the job gives up and closes the response.

### 5. README

New `Cooperative Cancellation in Skill Scripts` section explains when to call `check_maya_cancelled()` inside long-running loops, what `MayaUiPump.stats` counters mean, and how `server.attach_dispatcher()` + `stop()` interact.

## Tests (`tests/test_dispatcher_cancellation.py`)

Nine tests, all passing locally (`pytest tests/test_dispatcher_cancellation.py -v` → `9 passed`):

- `test_check_maya_cancelled_is_noop_outside_request`
- `test_check_maya_cancelled_honours_core_cancel_token`
- `test_check_maya_cancelled_honours_dispatcher_flag_during_execute`
- `test_pump_stats_record_overrun_cycles`
- `test_pump_stats_stay_zero_when_budget_honoured`
- `test_shutdown_unblocks_queued_submit_callable_quickly` (issue #89 contract: queued submitter unblocks within 1s)
- `test_shutdown_flags_running_job_for_cooperative_cancel`
- `test_submit_callable_after_shutdown_returns_immediately`
- `test_server_stop_drains_attached_dispatcher`

Existing dispatcher / server tests are unchanged and still pass (52 passed, 2 xpassed).

## Acceptance criteria mapping

From #85:

- [ ] `submit_async_callable` returns in < 50 ms — **deferred**: requires core #318 async dispatch path.
- [x] `check_maya_cancelled()` raises `CancelledError` within one iteration of `notifications/cancelled` arriving (covered by `test_check_maya_cancelled_honours_core_cancel_token`).
- [ ] Pytest: a mocked 5 s main-thread job is cancelled within 200 ms of cancel notification — **partial**: covered for the local `dispatcher.cancel` path; the full `notifications/cancelled` → wire path still needs core #329 integration.
- [ ] Pytest: `progress_token` carried end-to-end — **deferred**: requires core #326 progress notifications.
- [x] `MayaUiPump.stats` exposes `overrun_cycles` and `longest_job_ms`.
- [x] Existing sync `submit_callable` behaviour unchanged (regression tests green).
- [ ] Example skill (`maya-render-farm`) rewritten to use `check_maya_cancelled()` — left for a follow-up that can be reviewed independently.

From #89:

- [x] Pytest: no thread leak — every blocked `submit_callable` returns within 1 s of `server.stop()` (covered by `test_shutdown_unblocks_queued_submit_callable_quickly` and `test_server_stop_drains_attached_dispatcher`).
- [ ] Pytest: kill `MayaMcpServer` mid-job → `jobs.get_status` returns `interrupted` — **deferred**: requires core #319 (`jobs.get_status` built-in tool) wiring.
- [ ] `DCC_MCP_MAYA_JOB_RECOVERY=requeue` policy — **deferred**: needs core #328 sqlite persistence integration.

## Validation

```bash
python -m pytest tests/test_dispatcher_cancellation.py tests/test_dispatcher.py tests/test_server.py
ruff check src/dcc_mcp_maya/dispatcher.py src/dcc_mcp_maya/server.py tests/test_dispatcher_cancellation.py
```

All green locally with dcc-mcp-core 0.14.3 installed.
