### PR TITLE
feat(skills): maya-render-farm honours cooperative cancellation (#85)

### DIFF
--- a/src/dcc_mcp_maya/skills/maya-render-farm/scripts/validate_scene_for_farm.py
+++ b/src/dcc_mcp_maya/skills/maya-render-farm/scripts/validate_scene_for_farm.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 import os
 
 # Import local modules
+from dcc_mcp_core.cancellation import CancelledError
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.dispatcher import check_maya_cancelled
 
 
 def validate_scene_for_farm() -> dict:
@@ -19,6 +22,13 @@ def validate_scene_for_farm() -> dict:
     - No unloaded references
     - Render frame range is set (startFrame < endFrame)
     - Active render layer exists
+
+    Cooperative cancellation (issue #85):
+        A scene with thousands of file nodes or references can take several
+        seconds to validate.  We call :func:`check_maya_cancelled` between
+        each node so an MCP ``notifications/cancelled`` or a dispatcher
+        ``cancel(...)`` aborts the scan promptly instead of blocking the
+        UI thread until every node is inspected.
 
     Returns:
         ToolResult dict with ``context.issues`` list and ``context.valid`` flag.
@@ -37,6 +47,10 @@ def validate_scene_for_farm() -> dict:
         # 2. Missing file textures
         file_nodes = cmds.ls(type="file") or []
         for fn in file_nodes:
+            # Cooperative cancellation checkpoint — cheap no-op outside
+            # an MCP request, raises ``CancelledError`` when the owning
+            # ``tools/call`` is cancelled or the dispatcher is shutting down.
+            check_maya_cancelled()
             try:
                 tex_path = cmds.getAttr("{}.fileTextureName".format(fn)) or ""
                 if tex_path and not os.path.isfile(tex_path):
@@ -47,6 +61,7 @@ def validate_scene_for_farm() -> dict:
         # 3. Unloaded references
         refs = cmds.file(q=True, reference=True) or []
         for ref in refs:
+            check_maya_cancelled()
             try:
                 loaded = cmds.referenceQuery(ref, isLoaded=True)
                 if not loaded:
@@ -90,6 +105,11 @@ def validate_scene_for_farm() -> dict:
             )
     except ImportError:
         return skill_error("Maya not available", "maya.cmds could not be imported")
+    except CancelledError:
+        # Cooperative cancellation — propagate so the dispatcher can mark
+        # the job as cancelled rather than reporting it as a generic
+        # skill exception (issue #85).
+        raise
     except Exception as exc:
         return skill_exception(exc, message="Failed to validate scene")
 

--- a/tests/test_render_farm_cancellation.py
+++ b/tests/test_render_farm_cancellation.py
@@ -1,0 +1,116 @@
+"""Tests for cooperative cancellation inside the ``maya-render-farm`` skill.
+
+Covers the final outstanding bullet of issue #85: the example skill
+(``maya-render-farm``) must use :func:`check_maya_cancelled` at safe
+checkpoints inside its per-node loops so a long validation scan can be
+aborted promptly instead of blocking the UI thread until the full scene
+has been inspected.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from dcc_mcp_core.cancellation import (
+    CancelledError,
+    CancelToken,
+    reset_cancel_token,
+    set_cancel_token,
+)
+
+SKILL_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "dcc_mcp_maya"
+    / "skills"
+    / "maya-render-farm"
+    / "scripts"
+    / "validate_scene_for_farm.py"
+)
+
+
+@pytest.fixture
+def validate_module(monkeypatch):
+    """Import ``validate_scene_for_farm.py`` with ``maya.cmds`` stubbed out.
+
+    The skill script does ``import maya.cmds`` lazily inside the function
+    body, so we install a mocked ``maya.cmds`` module in ``sys.modules``
+    before the function runs.  Ten synthetic ``file`` nodes give the per-
+    node cancellation checkpoint something to iterate over.
+    """
+
+    maya_cmds = MagicMock()
+    # Scene is saved so the loop is actually reached.
+    maya_cmds.file.return_value = "/tmp/fake.ma"
+    # 10 file nodes — more than enough to test a mid-loop cancellation.
+    maya_cmds.ls.return_value = [f"file{i}" for i in range(10)]
+    maya_cmds.getAttr.return_value = "/nonexistent/tex.png"
+
+    maya_pkg = MagicMock()
+    maya_pkg.cmds = maya_cmds
+    monkeypatch.setitem(sys.modules, "maya", maya_pkg)
+    monkeypatch.setitem(sys.modules, "maya.cmds", maya_cmds)
+
+    # Load the skill script as a standalone module.
+    spec = importlib.util.spec_from_file_location("validate_scene_for_farm_under_test", SKILL_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, maya_cmds
+
+
+def test_validate_scene_for_farm_imports_check_maya_cancelled(validate_module):
+    """Regression guard — the skill must keep using the public probe."""
+    module, _ = validate_module
+    source = SKILL_SCRIPT.read_text(encoding="utf-8")
+    assert "from dcc_mcp_maya.dispatcher import check_maya_cancelled" in source
+    # It must be called at least twice — once per loop (file nodes + refs).
+    assert source.count("check_maya_cancelled()") >= 2
+    # And the imported name is actually bound in the module namespace.
+    assert hasattr(module, "check_maya_cancelled")
+
+
+def test_validate_scene_for_farm_honours_cancellation_mid_scan(validate_module):
+    """A cancel after the first file node must abort before the scan finishes.
+
+    We install a core ``CancelToken``, cancel it from inside the first
+    ``cmds.getAttr`` call, and assert:
+
+    1. ``validate_scene_for_farm`` propagates ``CancelledError`` — it does
+       **not** swallow the cancellation into ``skill_exception``.
+    2. Only the first iteration touched ``getAttr``; the remaining nine
+       nodes are skipped (cooperative cancellation semantics, not
+       best-effort).
+    """
+
+    module, maya_cmds = validate_module
+
+    token = CancelToken()
+    reset = set_cancel_token(token)
+
+    call_counter = {"get_attr": 0}
+
+    def _getattr_then_cancel(_attr):
+        call_counter["get_attr"] += 1
+        if call_counter["get_attr"] == 1:
+            # Simulate ``notifications/cancelled`` arriving just after the
+            # first node's attribute has been fetched but before the next
+            # loop iteration's ``check_maya_cancelled`` checkpoint fires.
+            token.cancel()
+        return "/nonexistent/tex.png"
+
+    maya_cmds.getAttr.side_effect = _getattr_then_cancel
+
+    try:
+        with pytest.raises(CancelledError):
+            module.validate_scene_for_farm()
+    finally:
+        reset_cancel_token(reset)
+
+    # Only one node was inspected before the probe aborted the scan.
+    assert call_counter["get_attr"] == 1
+    # The reference loop should not have run at all.
+    assert maya_cmds.referenceQuery.call_count == 0


### PR DESCRIPTION
Closes the final open acceptance-criterion bullet of #85 — "Example skill (`maya-render-farm`) rewritten to use `check_maya_cancelled()` inside the per-frame loop."

## Summary

- **`validate_scene_for_farm.py`** gains a cooperative-cancellation checkpoint at the top of each inner loop (file-texture scan + reference scan). Large scenes can now abort within one iteration of `notifications/cancelled` instead of blocking the UI thread until every node has been inspected.
- The broad `except Exception` guard now re-raises `CancelledError` before falling through to `skill_exception`, so the dispatcher sees the cancellation as a cancellation — not a generic skill failure.
- The other three scripts in the skill (`submit_to_deadline`, `write_render_job`, `get_render_job_status`) have no per-iteration main-thread work, so they do not need the probe; a checkpoint on their single `subprocess.run` call would be dead code.

## Test plan

- [x] `pytest tests/test_render_farm_cancellation.py -v` → 2 passed
- [x] `pytest tests/` → 3114 passed, 11 skipped, 2 xpassed (no regressions)
- [x] `python tools/lint_skills.py --error-only`
- [x] `python tools/lint_skill_affinity.py`
- [x] `ruff check` + `ruff format --check` clean on changed files

## Remaining on #85

The remaining unchecked bullets all need `dcc-mcp-core` work that has not landed yet (`JobManager`, core #318 async dispatch, core #326 SSE progress, core #329 `check_cancelled` wiring from `notifications/cancelled`). They'll unblock naturally once the pinned core is bumped.
