### PR TITLE
feat(skills): implement layered skill architecture with explicit routing (#100)

### DIFF
--- a/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-animation
-description: Maya animation keyframes, timeline, curves and simulation baking
+description: Maya animation keyframes, timeline, curves, constraint baking, and simulation caching. Use when creating or editing time-based motion. Not for rigging setup or render output — use maya-rigging or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - animation
     - keyframe
     - timeline
-    search-hint: keyframe, timeline, animate, curves, bake, simulation, constraint,
+    search-hint: animate motion, keyframe, timeline, curve editing, bake simulation
       tangent
     depends: []
     tools: tools.yaml

--- a/src/dcc_mcp_maya/skills/maya-animation/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-animation/tools.yaml
@@ -3,11 +3,21 @@ tools:
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: bake_simulation
   description: Bake simulation / constraints to keyframes on objects
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_keyframes
   description: Delete keyframes from an object within an optional frame range
   execution: sync
@@ -16,6 +26,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: export_animation_curves
   execution: sync
   affinity: main
@@ -23,6 +38,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_current_time
   description: Get the current frame number
   execution: sync
@@ -31,6 +51,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_frame_range
   execution: sync
   affinity: main
@@ -38,6 +63,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_keyframes
   description: Get all keyframe times for an object / attribute
   execution: sync
@@ -46,10 +76,20 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: import_animation_curves
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_animation_curves
   execution: sync
   affinity: main
@@ -57,6 +97,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: query_scene_time_info
   execution: sync
   affinity: main
@@ -64,12 +109,22 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_animation_curve_tangent
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_current_time
   description: Set the current frame number
   execution: sync
@@ -77,6 +132,11 @@ tools:
   annotations:
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_keyframe
   description: Set a keyframe on an object at the given time
   execution: sync
@@ -84,6 +144,11 @@ tools:
   annotations:
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_timeline
   description: Set the playback and animation timeline range
   execution: sync
@@ -91,3 +156,7 @@ tools:
   annotations:
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-annotation/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-annotation/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: maya-annotation
-description: Maya viewport annotations — create, update, list and remove text/arrow
-  annotation nodes
+description: Maya viewport annotations — create, update, list, and remove text and arrow annotations. Use when adding visual notes and markers in the viewport. Not for scene helpers or locators — use maya-scene-utils for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - annotation
     - viewport
     - text
-    search-hint: annotation, label, text, viewport, note, create annotation
+    search-hint: viewport note, text annotation, arrow marker, visual note
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-annotation/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-annotation/tools.yaml
@@ -2,20 +2,39 @@ tools:
 - name: create_annotation
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_annotation
   execution: sync
   affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_annotations
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: update_annotation
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-arnold-aov/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-arnold-aov/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-arnold-aov
-description: Arnold AOV (Arbitrary Output Variable) management for multi-pass rendering
+description: Arnold AOV management for multi-pass rendering — configure beauty, lighting, and custom Arbitrary Output Variables. Use when working with Arnold-specific render outputs. Not for standard Maya render passes or light setup — use maya-render-passes or maya-lighting for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - aov
     - render
     - passes
-    search-hint: arnold, aov, render pass, beauty, lighting
+    search-hint: Arnold output, AOV configuration, multi-pass Arnold
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-arnold-aov/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-arnold-aov/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_aov
   execution: sync
   affinity: main
@@ -10,12 +15,22 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: enable_aov
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_aovs
   execution: sync
   affinity: main
@@ -23,9 +38,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_aov_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-attributes/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-attributes/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-attributes
-description: Maya node attribute get/set and custom attribute management
+description: Maya node attribute management — get, set, lock, unlock, and create custom attributes. Use when reading or writing node properties. Not for scene-level operations, node connections, or scripting — use maya-scene, maya-node-graph, or maya-scripting for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - attribute
     - node
     - utility
-    search-hint: attribute, property, value, lock, unlock, set attr
+    search-hint: node property, custom attribute, get value, set attribute
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-attributes/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-attributes/tools.yaml
@@ -2,26 +2,50 @@ tools:
 - name: add_attribute
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_attribute
   execution: sync
   affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_attribute
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_attributes
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-audio/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-audio/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: maya-audio
-description: Maya audio — import audio files, set timeline audio, list and remove
-  audio nodes
+description: Maya audio management — import audio files, set timeline audio, list and remove sound nodes. Use when synchronizing audio to animation timelines. Not for animation keyframing or video editing — use maya-animation or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - audio
     - sound
     - timeline
-    search-hint: audio, sound, import audio, timeline audio, sound node
+    search-hint: sync audio, timeline sound, import audio, sound node
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-audio/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-audio/tools.yaml
@@ -2,20 +2,39 @@ tools:
 - name: import_audio
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_audio
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: remove_audio
   execution: sync
   affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_timeline_audio
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-bifrost/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-bifrost/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-bifrost
-description: Bifrost visual programming graph management for simulations and effects
+description: Bifrost visual programming graph management for simulations and effects. Use when building complex procedural simulations in Bifrost. Not for traditional Maya dynamics or particle systems — use maya-dynamics or maya-nparticles for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - simulation
     - vfx
     - graph
-    search-hint: bifrost, simulation, graph, node, vellum
+    search-hint: Bifrost graph, procedural simulation, visual programming
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-bifrost/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-bifrost/tools.yaml
@@ -3,15 +3,30 @@ tools:
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: connect_bifrost_ports
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_bifrost_graph
   execution: async
   affinity: main
   timeout_hint_secs: 600
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_bifrost_graphs
   execution: sync
   affinity: main
@@ -19,9 +34,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_bifrost_property
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-blend-shape-utils/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-blend-shape-utils/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-blend-shape-utils
-description: Maya blend shape utilities — create, inspect, and drive blend shape deformers
+description: Maya blend shape utilities — create, inspect, and drive blend shape deformers and targets. Use when building facial or morph targets. Not for skin cluster weighting or general deformation — use maya-skinning-utils or maya-deformers for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - deformer
     - morph
     - facial
-    search-hint: blend shape, morph, target, deform
+    search-hint: morph target, facial expression, blend shape driver
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-blend-shape-utils/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-blend-shape-utils/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_blend_shape_weights
   execution: sync
   affinity: main
@@ -10,6 +15,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_blend_shapes
   execution: sync
   affinity: main
@@ -17,9 +27,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_blend_shape_weight
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-cache/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-cache/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: maya-cache
-description: Maya geometry cache — create, attach, list and delete geometry caches
-  for mesh deformations
+description: Maya geometry cache — create, attach, list, and delete geometry caches. Use when baking deformation to disk for playback. Not for GPU cache optimization or render caching — use maya-gpu-cache or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - cache
     - geometry
     - simulation
-    search-hint: cache, geometry cache, bake, deformation
+    search-hint: bake deformation, geometry cache, playback cache, deformation disk
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-cache/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-cache/tools.yaml
@@ -3,19 +3,38 @@ tools:
   execution: async
   affinity: main
   timeout_hint_secs: 300
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_geometry_cache
   execution: async
   affinity: main
   timeout_hint_secs: 300
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_geometry_cache
   execution: sync
   affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_geometry_caches
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-camera-sequence/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-camera-sequence/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-camera-sequence
-description: Maya camera sequencer — create, list, trim, and bake camera cuts for
-  multi-shot sequences
+description: Maya camera sequencer — create, list, trim, and bake camera cuts for multi-shot timelines. Use when managing editorial shot cuts within Maya. Not for single camera setup or rendering — use maya-cameras or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - sequencer
     - shots
     - animation
-    search-hint: camera, sequence, film, multi-camera
+    search-hint: shot cut, camera sequence, editorial timeline, multi-camera
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-camera-sequence/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-camera-sequence/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_shot
   execution: sync
   affinity: main
@@ -10,6 +15,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_shots
   execution: sync
   affinity: main
@@ -17,9 +27,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_shot_range
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-cameras/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-cameras/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-cameras
-description: Maya camera creation and attribute management
+description: Maya camera creation and attribute management — perspective, orthographic, film back, and focal length. Use when setting up viewing cameras for scenes. Not for camera sequencing or shot-based workflows — use maya-camera-sequence or maya-shot-export for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - viewport
     - focal
     - film
-    search-hint: camera, film, focal, persp, orthographic
+    search-hint: setup camera, film back, focal length, perspective orthographic
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-cameras/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-cameras/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_camera_info
   execution: sync
   affinity: main
@@ -10,6 +15,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_all_cameras
   execution: sync
   affinity: main
@@ -17,15 +27,29 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_active_camera
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_camera_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-cloth-sim/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-cloth-sim/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-cloth-sim
-description: Maya nCloth simulation setup and management actions
+description: Maya nCloth simulation setup and management — create cloth, set collision, and adjust properties. Use when simulating fabric and garments. Not for rigid-body dynamics or fluid — use maya-dynamics or maya-fluid for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - ncloth
     - simulation
     - dynamics
-    search-hint: cloth, ncloth, simulation, fabric, collision
+    search-hint: fabric simulation, garment cloth, nCloth collision
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-cloth-sim/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-cloth-sim/tools.yaml
@@ -4,10 +4,20 @@ tools:
   affinity: main
   timeout_hint_secs: 600
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_ncloth
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_ncloth_objects
   execution: sync
   affinity: main
@@ -15,9 +25,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_ncloth_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-color-grading/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-color-grading/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-color-grading
-description: Maya color management — query and set color space, apply color correction
-  nodes to render settings
+description: Maya color management — query and set color space, apply LUTs and color correction. Use when managing color pipeline and look consistency. Not for material creation or lighting — use maya-materials or maya-lighting for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - color-management
     - aces
     - rendering
-    search-hint: color, grading, lut, grade
+    search-hint: color space, LUT, color pipeline, look consistency
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-color-grading/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-color-grading/tools.yaml
@@ -5,6 +5,11 @@ tools:
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_color_management_info
   execution: sync
   affinity: main
@@ -12,15 +17,29 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_rendering_space
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_view_transform
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-constraints-advanced/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-constraints-advanced/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-constraints-advanced
-description: Advanced Maya constraints — pole vector, IK handle constraints, space-switch
-  baking and constraint blending
+description: Advanced Maya constraints — pole vector, IK handle constraints, space switching, and weighted constraint networks. Use when building complex rigging constraint setups. Not for basic single constraints or non-rigging tasks — use maya-constraints or maya-rig-utils for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - rigging
     - ik
     - space-switch
-    search-hint: constraint, parent, aim, orient, advanced
+    search-hint: advanced rig constraint, space switch, pole vector, IK handle
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-constraints-advanced/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-constraints-advanced/tools.yaml
@@ -3,10 +3,20 @@ tools:
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: bake_constraint
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_constraint_weights
   execution: sync
   affinity: main
@@ -14,9 +24,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_constraint_weight
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-constraints/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-constraints/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-constraints
-description: Maya constraints — parent, point, orient, scale, aim and weighted constraints
+description: Maya constraints — parent, point, orient, scale, and aim constraints with weights. Use when establishing spatial relationships between objects. Not for advanced space switching or IK handles — use maya-constraints-advanced or maya-rigging for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +15,7 @@ metadata:
     - parent
     - orient
     - aim
-    search-hint: constraint, parent, orient, aim, point, scale
+    search-hint: spatial relationship, parent constraint, aim constraint, follow
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-constraints/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-constraints/tools.yaml
@@ -3,10 +3,20 @@ tools:
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_constraint_weighted
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_constraints
   execution: sync
   affinity: main
@@ -14,6 +24,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: remove_constraint
   execution: sync
   affinity: main
@@ -21,3 +36,7 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-deformers/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-deformers/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-deformers
-description: Maya advanced deformers — cluster, lattice, wire, sculpt and deformer
-  stack management
+description: Maya deformers — cluster, lattice, wire, sculpt, bend, twist, and nonlinear deformers. Use when adding procedural shape deformation to geometry. Not for skin cluster weighting or blend shapes — use maya-skinning-utils or maya-blend-shape-utils for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - rigging
     - cluster
     - lattice
-    search-hint: deformer, bend, twist, lattice, nonlinear
+    search-hint: deform geometry, lattice, bend, twist, nonlinear shape
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-deformers/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-deformers/tools.yaml
@@ -5,29 +5,63 @@ tools:
   annotations:
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: cleanup_mesh
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_cluster
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_lattice
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: sculpt_deformer
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_cluster_weights
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: wire_deformer
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-display/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-display/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-display
-description: Maya display layers and viewport shading mode management
+description: Maya display layers and viewport shading mode management — create layers, toggle visibility, and set wireframe/shaded modes. Use when controlling visual feedback in the viewport. Not for render layer setup or final output — use maya-render-layers or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - display
     - layer
     - visibility
-    search-hint: display, visibility, show, hide, wireframe, layer
+    search-hint: viewport visibility, display layer, wireframe shaded, show hide
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-display/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-display/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_display_layer
   execution: sync
   affinity: main
@@ -10,6 +15,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_display_layers
   execution: sync
   affinity: main
@@ -17,9 +27,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_display_layer
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-dynamics/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-dynamics/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-dynamics
-description: Maya nDynamics — nucleus, nCloth, nRigid and dynamic fields
+description: Maya nDynamics — nucleus, nCloth, nRigid, and dynamic fields. Use when adding physics-based motion to objects. Not for fluid simulation or particle effects — use maya-fluid or maya-nparticles for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - ncloth
     - simulation
     - effects
-    search-hint: dynamics, particle, ncloth, fluid, simulation
+    search-hint: physics simulation, nucleus, ncloth, dynamic field
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-dynamics/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-dynamics/tools.yaml
@@ -3,22 +3,47 @@ tools:
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_dynamic_field
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_ncloth
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_nrigid
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_nucleus
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_ncloth_nodes
   execution: sync
   affinity: main
@@ -26,6 +51,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_nrigid_nodes
   execution: sync
   affinity: main
@@ -33,21 +63,40 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_ncloth_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_nrigid_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_nucleus_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-export-preset/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-export-preset/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-export-preset
-description: Maya export preset management actions for saving and loading export configurations
+description: Maya export preset management — save and load export configurations for FBX, OBJ, and Alembic. Use when standardizing export settings across a project. Not for one-off exports or pipeline publishing — use maya-scene or maya-pipeline for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +15,7 @@ metadata:
     - pipeline
     - fbx
     - alembic
-    search-hint: export, preset, format, fbx, obj
+    search-hint: standardize export, export configuration, FBX OBJ preset
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-export-preset/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-export-preset/tools.yaml
@@ -5,15 +5,34 @@ tools:
   annotations:
     destructive_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_export_presets
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: load_export_preset
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: save_export_preset
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-expressions/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-expressions/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-expressions
-description: Maya expression nodes — create, list and delete procedural expressions
+description: Maya expression nodes — create, list, and delete procedural expressions that drive attributes. Use when building procedural animation or rig logic. Not for keyframe animation or general scripting — use maya-animation or maya-scripting for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - expression
     - scripting
     - procedural
-    search-hint: expression, script, attribute, driven key
+    search-hint: procedural animation, expression node, drive attribute
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-expressions/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-expressions/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_expression
   execution: sync
   affinity: main
@@ -10,10 +15,20 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: edit_expression
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_expressions
   execution: sync
   affinity: main
@@ -21,3 +36,7 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-fluid/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-fluid/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-fluid
-description: Maya fluid (nFluid/legacy fluid container) simulation actions
+description: Maya fluid simulation — nFluid and legacy fluid container setup. Use when creating volumetric fluid effects. Not for particle systems or ocean surfaces — use maya-nparticles or maya-ocean for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - simulation
     - dynamics
     - nfluid
-    search-hint: fluid, container, voxel, simulation
+    search-hint: volumetric fluid, smoke fire, nFluid container
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-fluid/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-fluid/tools.yaml
@@ -4,6 +4,11 @@ tools:
   affinity: main
   timeout_hint_secs: 600
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_fluid_container
   execution: sync
   affinity: main
@@ -11,6 +16,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_fluid_containers
   execution: sync
   affinity: main
@@ -18,9 +28,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_fluid_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-gpu-cache/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-gpu-cache/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-gpu-cache
-description: Maya GPU cache utilities — export, import, and manage gpuCache nodes
-  for viewport performance
+description: Maya GPU cache utilities — export, import, and manage gpuCache nodes for performance. Use when optimizing heavy scenes with cached geometry. Not for Alembic workflows or standard geometry cache — use maya-cache or maya-scene for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - alembic
     - viewport
     - performance
-    search-hint: gpu cache, alembic, cache, performance
+    search-hint: optimize scene, GPU cache, heavy geometry, performance cache
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-gpu-cache/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-gpu-cache/tools.yaml
@@ -5,15 +5,34 @@ tools:
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: import_gpu_cache
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_gpu_caches
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: refresh_gpu_cache
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-grooming/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-grooming/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-grooming
-description: Maya XGen / nHair grooming and hair system actions
+description: Maya XGen and nHair grooming and hair system actions. Use when styling hair and fur with interactive grooming tools. Not for XGen procedural generation or simulation — use maya-xgen or maya-dynamics for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - hair
     - nhair
     - dynamics
-    search-hint: groom, hair, xgen, nhair, follicle
+    search-hint: style hair fur, interactive grooming, nHair system
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-grooming/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-grooming/tools.yaml
@@ -4,11 +4,21 @@ tools:
   affinity: main
   timeout_hint_secs: 300
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_nhair_system
   execution: async
   affinity: main
   timeout_hint_secs: 300
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_hair_systems
   execution: sync
   affinity: main
@@ -16,9 +26,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_nhair_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-hdri/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-hdri/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-hdri
-description: Maya HDRI environment lighting — load HDR images, configure IBL domes,
-  adjust exposure and rotation
+description: Maya HDRI environment lighting — load HDR images, configure IBL domes, and adjust exposure. Use when setting up image-based ambient lighting. Not for standard light creation or material authoring — use maya-lighting or maya-materials for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - ibl
     - lighting
     - environment
-    search-hint: hdri, ibl, environment, dome light, image based lighting
+    search-hint: IBL setup, HDRI dome, environment lighting, ambient illumination
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-hdri/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-hdri/tools.yaml
@@ -6,19 +6,38 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: load_hdri
   execution: sync
   affinity: main
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_hdri_exposure
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_hdri_rotation
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-instancer/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-instancer/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-instancer
-description: Maya instancer utilities — create and configure particle instancers for
-  scattering geometry
+description: Maya instancer utilities — create and configure particle instancers for object replication. Use when replicating geometry via particle systems. Not for MASH networks or manual duplication — use maya-mash or maya-scene for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - particles
     - scatter
     - motion-graphics
-    search-hint: instancer, particle instancer, instance, scatter
+    search-hint: object replication, particle instancer, instance geometry
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-instancer/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-instancer/tools.yaml
@@ -3,10 +3,20 @@ tools:
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_instancer
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_instancers
   execution: sync
   affinity: main
@@ -14,9 +24,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_instancer_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-light-rig/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-light-rig/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-light-rig
-description: Maya light rig — create standard three-point lighting rigs, HDRI dome
-  setups, and manage light groups
+description: Maya light rig utilities — create standard three-point lighting rigs and HDRI dome setups. Use when deploying pre-configured lighting templates. Not for individual light creation or color grading — use maya-lighting or maya-color-grading for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - light-rig
     - three-point
     - hdri
-    search-hint: light, rig, three-point, studio setup
+    search-hint: lighting template, three-point rig, studio setup, dome rig
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-light-rig/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-light-rig/tools.yaml
@@ -3,10 +3,20 @@ tools:
   execution: sync
   affinity: main
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_three_point_rig
   execution: sync
   affinity: main
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_light_rigs
   execution: sync
   affinity: main
@@ -14,9 +24,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_light_rig_intensity
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-lighting/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-lighting/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-lighting
-description: Maya scene lighting — create, modify and query light nodes
+description: Maya scene lighting — create, modify, and query directional, point, spot, area, and ambient lights. Use when setting up illumination for a scene. Not for HDRI environments or toon shading — use maya-hdri or maya-toon for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - lighting
     - light
     - render
-    search-hint: light, directional, point, spot, area, ambient
+    search-hint: scene illumination, light setup, directional point spot light
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-lighting/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-lighting/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_light
   execution: sync
   affinity: main
@@ -10,6 +15,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_lights
   execution: sync
   affinity: main
@@ -17,9 +27,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_light_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-mash/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-mash/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-mash
-description: Maya MASH motion graphics network — create, modify and query MASH networks
+description: Maya MASH motion graphics network — create, modify, and query MASH networks for procedural distribution. Use when scattering or distributing objects procedurally. Not for standard particle effects or instancing — use maya-nparticles or maya-instancer for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - motion-graphics
     - instancer
     - dynamics
-    search-hint: mash, motion graphics, distribute, scatter
+    search-hint: procedural distribution, scatter objects, motion graphics MASH
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-mash/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-mash/tools.yaml
@@ -3,10 +3,20 @@ tools:
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_network
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_network
   execution: sync
   affinity: main
@@ -14,6 +24,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_networks
   execution: sync
   affinity: main
@@ -21,9 +36,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_mash_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-material-library/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-material-library/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-material-library
-description: Maya material library — save, load, and manage reusable material presets
-  stored as JSON or Maya files
+description: Maya material library — save, load, and manage reusable material presets and shader collections. Use when reusing materials across assets. Not for creating new materials from scratch or rendering — use maya-materials or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - library
     - shading
     - presets
-    search-hint: material, library, shader, preset
+    search-hint: reuse material, material preset, shader library, share material
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-material-library/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-material-library/tools.yaml
@@ -6,6 +6,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_materials
   execution: sync
   affinity: main
@@ -13,11 +18,25 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: load_material
   execution: sync
   affinity: main
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: save_material
   execution: sync
   affinity: main
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-materials/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-materials/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-materials
-description: Maya shading materials — create, assign, query and manage material networks
+description: Maya shading materials — create, assign, query, and manage Lambert, Blinn, and surface shader networks. Use when building basic material assignments. Not for material library management or advanced render setups — use maya-material-library or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - material
     - shader
     - shading
-    search-hint: material, shader, lambert, blinn, assign, surface
+    search-hint: assign shader, basic material, surface shader, lambert blinn
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-materials/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-materials/tools.yaml
@@ -5,10 +5,20 @@ tools:
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_material
   execution: sync
   affinity: main
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_material_connections
   execution: sync
   affinity: main
@@ -16,6 +26,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_shader_assignment
   execution: sync
   affinity: main
@@ -23,6 +38,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_materials
   execution: sync
   affinity: main
@@ -30,6 +50,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_shading_groups
   execution: sync
   affinity: main
@@ -37,15 +62,29 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: reset_to_default_material
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_material_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-mesh-ops
-description: Maya polygon mesh operations — subdivision, cleanup, boolean, UV-based
-  selection and proxy generation
+description: Maya polygon mesh editing operations — bevel, extrude, bridge, combine, separate, cleanup, and boolean. Use when modifying existing polygon geometry. Not for primitive creation, UV layout, or rendering — use maya-primitives, maya-uv-ops, or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - polygon
     - geometry
     - topology
-    search-hint: mesh, bevel, bridge, extrude, combine, separate
+    search-hint: edit mesh, modify polygons, boolean, cleanup, subdivide geometry
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/tools.yaml
@@ -5,22 +5,47 @@ tools:
   annotations:
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: cleanup_mesh
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: combine_meshes
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_proxy_mesh
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: extract_faces
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_mesh_edge_info
   execution: sync
   affinity: main
@@ -28,6 +53,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_poly_count
   execution: sync
   affinity: main
@@ -35,23 +65,52 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: merge_vertices
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: mirror_mesh
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: select_by_material
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: separate_mesh
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: triangulate
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-mocap/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-mocap/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-mocap
-description: Motion capture data import, retargeting and cleanup for Maya
+description: Motion capture data import, retargeting, and cleanup for Maya. Use when bringing external mocap data onto rigs. Not for keyframe animation or rigging — use maya-animation or maya-rigging for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +15,7 @@ metadata:
     - retarget
     - hik
     - bvh
-    search-hint: mocap, motion capture, retarget, fbx
+    search-hint: mocap retarget, motion capture import, cleanup retargeting
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-mocap/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-mocap/tools.yaml
@@ -4,16 +4,35 @@ tools:
   affinity: main
   timeout_hint_secs: 300
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: clean_mocap_keys
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_hik_definition
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: import_mocap
   execution: async
   affinity: main
   timeout_hint_secs: 300
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-muscle/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-muscle/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-muscle
-description: Maya Muscle system for secondary motion — create muscles, capsules, and
-  skin simulation
+description: Maya Muscle system — create muscles, capsules, and tissue deformers for secondary motion. Use when adding anatomical deformation to characters. Not for standard skin clusters or blend shapes — use maya-skinning-utils or maya-blend-shape-utils for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - simulation
     - secondary-motion
     - rig
-    search-hint: muscle, cMuscle, tissue, deformation
+    search-hint: anatomical deformation, muscle tissue, secondary motion
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-muscle/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-muscle/tools.yaml
@@ -6,10 +6,20 @@ tools:
   annotations:
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_muscle_capsule
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_muscles
   execution: sync
   affinity: main
@@ -17,9 +27,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_muscle_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-namespaces/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-namespaces/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-namespaces
-description: Maya namespace management — create, rename, merge, and remove namespaces
-  for asset organization
+description: Maya namespace management — create, rename, merge, and remove namespaces. Use when organizing scenes with references and name collisions. Not for file referencing itself or scene structure — use maya-references or maya-scene for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - pipeline
     - rigging
     - scene-management
-    search-hint: namespace, reference, scene, organize
+    search-hint: organize namespaces, resolve name collision, namespace hierarchy
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-namespaces/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-namespaces/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_namespace
   execution: sync
   affinity: main
@@ -10,6 +15,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_namespaces
   execution: sync
   affinity: main
@@ -17,6 +27,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: remove_namespace
   execution: sync
   affinity: main
@@ -24,15 +39,29 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: rename_namespace
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_namespace
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-node-graph/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-node-graph
-description: Maya node graph — connect/disconnect attributes, query history and topology
+description: Maya node graph operations — connect and disconnect attributes, query construction history and DG topology. Use when working with dependency graph connections. Not for attribute value editing or scene file operations — use maya-attributes or maya-scene for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - attribute
     - graph
     - utility
-    search-hint: node, graph, connection, attribute, editor
+    search-hint: node connection, DG topology, construction history, attribute link
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-node-graph/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/tools.yaml
@@ -4,39 +4,83 @@ tools:
   affinity: main
   annotations:
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: connect_attr
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_history
   execution: sync
   affinity: main
   annotations:
     destructive_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: disconnect_attr
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_dag_path
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_connections
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_history
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: smooth_mesh
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: transfer_attributes
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-nparticles/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-nparticles/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-nparticles
-description: Maya nParticles — create and configure nParticle systems, set fields,
-  and query simulation state
+description: Maya nParticles — create and configure nParticle systems, set fields, and adjust properties. Use when creating particle effects like smoke, dust, or sparks. Not for fluid dynamics or cloth simulation — use maya-fluid or maya-cloth-sim for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - dynamics
     - simulation
     - vfx
-    search-hint: nparticle, particle, dynamics, simulation
+    search-hint: particle effect, smoke dust sparks, nParticle system
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-nparticles/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-nparticles/tools.yaml
@@ -3,10 +3,20 @@ tools:
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_nparticle_emitter
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_nparticle_systems
   execution: sync
   affinity: main
@@ -14,9 +24,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_nparticle_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-ocean/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-ocean/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-ocean
-description: Maya ocean (Bifrost/Maya Ocean shader) surface simulation actions
+description: Maya ocean surface simulation — Bifrost and Maya Ocean shader setup. Use when creating large-scale water surfaces. Not for fluid volumes or particle splashes — use maya-fluid or maya-nparticles for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - fluid
     - simulation
     - environment
-    search-hint: ocean, water, wave, fluid, simulation
+    search-hint: water surface, ocean wave, large scale water
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-ocean/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-ocean/tools.yaml
@@ -3,11 +3,21 @@ tools:
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_ocean
   execution: async
   affinity: main
   timeout_hint_secs: 300
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_ocean_surfaces
   execution: sync
   affinity: main
@@ -15,9 +25,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_ocean_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-paint-effects/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-paint-effects/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-paint-effects
-description: Maya Paint Effects — create, attach, and manage stroke brushes and Paint
-  Effects presets on surfaces
+description: Maya Paint Effects — create, attach, and manage stroke brushes and Paint Effects nodes. Use when painting procedural 2D/3D strokes. Not for texture painting or vertex color — use maya-texture-bake or maya-vertex-color for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - strokes
     - brushes
     - stylized
-    search-hint: paint effects, stroke, brush, 3d paint
+    search-hint: procedural stroke, paint brush, 2D 3D paint effects
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-paint-effects/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-paint-effects/tools.yaml
@@ -3,10 +3,20 @@ tools:
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_stroke
   execution: sync
   affinity: main
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_stroke
   execution: sync
   affinity: main
@@ -14,6 +24,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_strokes
   execution: sync
   affinity: main
@@ -21,3 +36,7 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-pipeline/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-pipeline/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-pipeline
-description: 'Pipeline integration utilities for Maya scenes: metadata, asset publishing
-  and project setup'
+description: Pipeline integration utilities for Maya scenes — metadata tagging, asset publishing, and project workspace setup. Use when managing assets through a production pipeline. Not for individual object creation, mesh editing, or rendering — use maya-primitives, maya-mesh-ops, or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - asset
     - publish
     - project
-    search-hint: pipeline, publish, export, import, workflow
+    search-hint: asset publish, production pipeline, metadata tagging, project workspace
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-pipeline/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-pipeline/tools.yaml
@@ -6,17 +6,36 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: publish_asset
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_project
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: tag_asset_metadata
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-pose-library/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-pose-library/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-pose-library
-description: Maya pose library — save, load, apply, and manage character poses as
-  JSON snapshots
+description: Maya pose library — save, load, apply, and manage character poses as presets. Use when reusing character poses across scenes. Not for animation curves or rigging setup — use maya-animation or maya-rigging for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - pose
     - library
     - rigging
-    search-hint: pose, library, save pose, apply pose
+    search-hint: save load pose, character pose preset, reuse pose
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-pose-library/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-pose-library/tools.yaml
@@ -6,15 +6,34 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: load_pose
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: mirror_pose
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: save_pose
   execution: sync
   affinity: main
   group: animation
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-primitives
-description: Maya polygon primitive creation and basic transform operations
+description: Maya polygon primitive creation and basic transform operations — spheres, cubes, cylinders, planes, and transforms. Use when creating individual basic geometry from scratch. Not for complex mesh editing, UV operations, or material assignment — use maya-mesh-ops, maya-uv-ops, or maya-materials for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - geometry
     - primitives
     - create
-    search-hint: create, sphere, cube, plane, cylinder, primitive, polygon
+    search-hint: create basic geometry, add primitive, simple shape, individual mesh
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-primitives/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-primitives/tools.yaml
@@ -4,21 +4,41 @@ tools:
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_cylinder
   description: Create a polygon cylinder
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_plane
   description: Create a polygon plane
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_sphere
   description: Create a polygon sphere
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_objects
   description: Delete objects from the Maya scene
   execution: sync
@@ -27,6 +47,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_transform
   description: Get translate/rotate/scale of an object
   execution: sync
@@ -35,6 +60,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: rename_object
   description: Rename an object in the scene
   execution: sync
@@ -42,6 +72,11 @@ tools:
   annotations:
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_transform
   description: Set translate/rotate/scale on an object
   execution: sync
@@ -49,3 +84,7 @@ tools:
   annotations:
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-proxy-mesh/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-proxy-mesh/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-proxy-mesh
-description: Maya proxy mesh management — create, swap, and manage low-res proxy stand-ins
+description: Maya proxy mesh management — create, swap, and manage low-res proxy stand-ins. Use when working with level-of-detail workflows. Not for full scene assembly or rendering — use maya-scene-assembly or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - lod
     - performance
     - mesh
-    search-hint: proxy, level of detail, LOD, lightweight
+    search-hint: LOD proxy, low res stand-in, level of detail, swap proxy
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-proxy-mesh/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-proxy-mesh/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_proxies
   execution: sync
   affinity: main
@@ -10,13 +15,27 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_proxy_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: swap_proxy
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-references/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-references/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-references
-description: Maya file references and namespace management
+description: Maya file reference management — load, unload, replace, and query references with namespace handling. Use when linking external scene files. Not for namespace-only operations or import/export — use maya-namespaces or maya-scene for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - reference
     - namespace
     - scene
-    search-hint: reference, import, namespace, link, file
+    search-hint: link external file, reference scene, unload reference, proxy reference
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-references/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-references/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_namespaces
   execution: sync
   affinity: main
@@ -10,6 +15,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_references
   execution: sync
   affinity: main
@@ -17,10 +27,20 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: reload_reference
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: remove_reference
   execution: sync
   affinity: main
@@ -28,7 +48,16 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: unload_reference
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-render-farm/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-render-farm/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-render-farm
-description: Maya render farm — prepare scenes, write render job configs, and submit
-  to local or Deadline render queues
+description: Maya render farm integration — prepare scenes, write render job configs, and submit to deadline queues. Use when sending scenes to distributed render systems. Not for local rendering or render layer setup — use maya-render or maya-render-layers for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - farm
     - deadline
     - pipeline
-    search-hint: render farm, deadline, batch, submit
+    search-hint: submit render job, distributed render, deadline queue, farm submission
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-render-farm/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render-farm/tools.yaml
@@ -6,18 +6,37 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: submit_to_deadline
   execution: async
   affinity: main
   timeout_hint_secs: 900
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: validate_scene_for_farm
   execution: async
   affinity: main
   timeout_hint_secs: 900
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: write_render_job
   execution: async
   affinity: main
   timeout_hint_secs: 900
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-render-layers/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-render-layers/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-render-layers
-description: Maya render layers — create, assign, list and manage render layer overrides
+description: Maya render layers — create, assign objects, list, and manage render layer overrides. Use when splitting a scene into multi-pass render configurations. Not for render pass elements or final submission — use maya-render-passes or maya-render-farm for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - render
     - layer
     - renderlayer
-    search-hint: render layer, override, pass, layer
+    search-hint: multi-pass setup, render layer override, split passes
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-render-layers/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render-layers/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_render_layer
   execution: sync
   affinity: main
@@ -10,6 +15,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_render_layers
   execution: sync
   affinity: main
@@ -17,15 +27,29 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_render_layer
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_render_layer_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-render-passes/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-render-passes/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-render-passes
-description: Maya render passes — create, list, and configure render pass/AOV elements
-  for multi-pass compositing
+description: Maya render passes and AOV elements — create, list, and configure beauty, diffuse, specular, and custom passes. Use when setting up per-channel image decomposition. Not for render layer management or lighting — use maya-render-layers or maya-lighting for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - passes
     - aov
     - compositing
-    search-hint: render pass, aov, beauty, diffuse, specular
+    search-hint: AOV setup, beauty diffuse specular, channel decomposition
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-render-passes/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render-passes/tools.yaml
@@ -3,12 +3,22 @@ tools:
   execution: sync
   affinity: main
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: enable_render_pass
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_render_passes
   execution: sync
   affinity: main
@@ -16,9 +26,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_render_pass_output
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-render/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-render/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-render
-description: Maya render settings and viewport capture
+description: Maya render settings and viewport capture — configure render globals, playblast, and viewport snapshots. Use when producing final or preview images. Not for modeling, animation editing, or render farm submission — use maya-mesh-ops, maya-animation, or maya-render-farm for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - render
     - playblast
     - settings
-    search-hint: render, settings, playblast, capture, viewport
+    search-hint: final output, preview render, playblast, viewport capture
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-render/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render/tools.yaml
@@ -4,6 +4,11 @@ tools:
   affinity: main
   timeout_hint_secs: 600
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: export_selection
   execution: async
   affinity: main
@@ -12,6 +17,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_render_settings
   description: Query current render settings
   execution: sync
@@ -20,6 +30,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_scene_render_stats
   execution: sync
   affinity: main
@@ -27,23 +42,43 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: import_file
   execution: async
   affinity: main
   timeout_hint_secs: 300
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: playblast
   description: Capture a viewport screenshot as a base64-encoded PNG
   execution: async
   affinity: main
   timeout_hint_secs: 600
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_render_quality
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_render_settings
   description: Set render parameters (resolution, frame range, renderer, image format)
   execution: sync
@@ -51,3 +86,7 @@ tools:
   annotations:
     idempotent_hint: true
   group: rendering
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-rig-utils/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-rig-utils/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-rig-utils
-description: Maya rig utilities — space switching, control curve shapes, rig connections,
-  and attribute locking
+description: Maya rig utilities — space switching, control curve shapes, rig connections, and mirroring. Use when supporting and extending existing rigs. Not for full rig creation or animation — use maya-rigging or maya-animation for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - controls
     - space-switch
     - attributes
-    search-hint: rig, utility, mirror, constraint, helper
+    search-hint: rig helper, space switch, control shape, mirror rig
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-rig-utils/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-rig-utils/tools.yaml
@@ -3,15 +3,34 @@ tools:
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: connect_attributes
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_control_curve
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: lock_hide_attributes
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-rigging/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-rigging/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-rigging
-description: Maya rigging — joints, IK, skin clusters, deformers, blend shapes and
-  constraints
+description: Maya character rigging workflow — joints, IK, skin clusters, deformers, blend shapes, and control curves. Use when building character or prop rigs. Not for animation keyframing or final scene assembly — use maya-animation or maya-scene-assembly for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - skeleton
     - deformer
     - animation
-    search-hint: rig, joint, bind, skin, IK, FK, control
+    search-hint: build character rig, skeleton setup, skin bind, control curve
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-rigging/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-rigging/tools.yaml
@@ -5,55 +5,114 @@ tools:
   annotations:
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: blend_shape_add_target
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_blend_shape
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_curve
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_ik_handle
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_joint
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: mirror_joints
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_driven_key
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_ik_fk_blend
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_joint_limit
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_joint_orient
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: skin_cluster_bind
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-scene-assembly/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scene-assembly/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-scene-assembly
-description: Maya Scene Assembly — manage Assembly Definition, Assembly Reference,
-  and representation LODs
+description: Maya Scene Assembly — manage Assembly Definition, Assembly Reference, and level-of-detail workflows. Use when assembling large environments from asset references. Not for individual proxy creation or file referencing — use maya-proxy-mesh or maya-references for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -15,7 +15,7 @@ metadata:
     - reference
     - pipeline
     - assembly
-    search-hint: scene assembly, asset, level, publish
+    search-hint: assemble environment, large scene, assembly definition, LOD workflow
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-scene-assembly/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene-assembly/tools.yaml
@@ -3,16 +3,31 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_assembly_definition
   execution: async
   affinity: main
   timeout_hint_secs: 120
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_assembly_reference
   execution: async
   affinity: main
   timeout_hint_secs: 120
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_assemblies
   execution: sync
   affinity: main
@@ -20,3 +35,7 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-scene-utils/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scene-utils/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-scene-utils
-description: Maya scene utilities — pivot, alignment, annotation, color override and
-  viewport shading
+description: Maya scene helper utilities — pivot alignment, annotation, color override, and locator creation. Use when adding helper objects and visual cues to a scene. Not for modeling or rendering — use maya-mesh-ops or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - utility
     - display
     - viewport
-    search-hint: scene, utility, annotation, locator, helper
+    search-hint: scene helper, locator, annotation, color override, alignment
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-scene-utils/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene-utils/tools.yaml
@@ -3,35 +3,69 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_annotation
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_polygon_text
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_object_color
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_pivot
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_shading_mode
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: toggle_gpu_override
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-scene/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scene/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-scene
-description: Maya scene management — create, open, save, list, select and manipulate
-  scene objects
+description: Maya scene management — create new scenes, open, save, import, export, and list scene contents. Use when managing scene files and top-level hierarchy. Not for individual object creation or mesh editing — use maya-primitives or maya-mesh-ops for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -15,7 +15,7 @@ metadata:
     - open
     - save
     - manage
-    search-hint: new scene, open, save, list objects, hierarchy, select
+    search-hint: manage scene file, open save import export, scene hierarchy
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
@@ -3,14 +3,29 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_locator
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: duplicate_object
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: export_scene
   execution: async
   affinity: main
@@ -19,10 +34,20 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: freeze_transforms
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_bounding_box
   execution: sync
   affinity: main
@@ -30,6 +55,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_scene_info
   description: Return a hierarchical DAG description of the current scene
   execution: sync
@@ -38,6 +68,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: core
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_selection
   description: Return the current Maya selection
   execution: sync
@@ -46,6 +81,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: core
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_session_info
   description: Return Maya version, scene path, and basic session statistics
   execution: sync
@@ -54,9 +94,19 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: core
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: group_objects
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_cameras
   execution: sync
   affinity: main
@@ -64,6 +114,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_objects
   description: List objects in the current Maya scene
   execution: sync
@@ -72,10 +127,20 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: lock_object
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: new_scene
   description: Create a new empty Maya scene
   execution: async
@@ -85,6 +150,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: open_scene
   description: Open a Maya scene file from disk
   execution: async
@@ -94,26 +164,51 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: parent_object
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: save_scene
   description: Save the current Maya scene
   execution: async
   affinity: main
   timeout_hint_secs: 120
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: select_by_type
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_frame_rate
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_selection
   description: Set the active Maya selection
   execution: sync
@@ -121,9 +216,18 @@ tools:
   annotations:
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_visibility
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-scripting/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scripting/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-scripting
-description: Execute MEL/Python scripts inside Maya; broad scripting utilities across
-  all domains
+description: Execute MEL and Python scripts inside Maya; broad scripting utilities across the Maya API. Use when automating tasks that lack dedicated tools. Not for specific modeling, animation, or rendering operations — use maya-mesh-ops, maya-animation, or maya-render for those.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -15,7 +15,7 @@ metadata:
     - python
     - utility
     - dangerous
-    search-hint: script, mel, python, expression, execute
+    search-hint: automate task, run script, MEL Python, custom automation
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
@@ -3,38 +3,83 @@ tools:
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: attributes
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: cameras
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: constraints
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: deformer_advanced
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: display
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: dynamics
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: execute_mel
   execution: sync
   affinity: main
   group: core
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: execute_python
   execution: sync
   affinity: main
   group: core
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: expressions
   execution: sync
   affinity: main
@@ -42,6 +87,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_script_node
   execution: sync
   affinity: main
@@ -49,10 +99,20 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: lighting
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_mel_procedures
   execution: sync
   affinity: main
@@ -60,67 +120,151 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: materials
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: mesh_ops
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: namespaces
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: node_attrs
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: node_graph
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: references
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: render
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: render_layers
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: rigging
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: scene_utils
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: sets
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: skin_weights
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: texture_bake
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: utility
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: uv_ops
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: vertex_color
   execution: sync
   affinity: main
   group: extended
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-selection/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-selection/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: maya-selection
-description: Maya selection utilities — filter, grow, shrink, invert, and convert
-  selections
+description: Maya selection utilities — filter by type, grow, shrink, invert, and convert selections. Use when controlling which objects or components are active. Not for scene hierarchy queries or display visibility — use maya-scene or maya-display for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - selection
     - filter
     - component
-    search-hint: select, filter, type, hierarchy, component
+    search-hint: filter selection, select by type, component selection, invert selection
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-selection/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-selection/tools.yaml
@@ -3,19 +3,43 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: grow_selection
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: invert_selection
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: select_similar
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: shrink_selection
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-sets/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-sets/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-sets
-description: Maya object sets — create, add to, remove from and list Maya sets
+description: Maya object set management — create sets, add and remove members, and query set contents. Use when grouping objects for render, deformation, or organization. Not for display layers or hierarchical grouping — use maya-display or maya-scene for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - set
     - collection
     - utility
-    search-hint: set, group, partition, render, deformer set
+    search-hint: group objects, object set, render set, deformer set, partition
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-sets/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-sets/tools.yaml
@@ -3,10 +3,20 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_set
   execution: sync
   affinity: main
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_sets
   execution: sync
   affinity: main
@@ -14,6 +24,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: remove_from_set
   execution: sync
   affinity: main
@@ -21,3 +36,7 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-shot-export/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-shot-export/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-shot-export
-description: Maya shot export — export shots, frame ranges, cameras, and FBX/Alembic
-  sequences for production pipelines
+description: Maya shot export — export shots, frame ranges, cameras, and FBX/Alembic for editorial. Use when packaging shot data for downstream departments. Not for full pipeline publishing or scene assembly — use maya-pipeline or maya-scene-assembly for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - shot
     - pipeline
     - production
-    search-hint: shot, export, sequence, frame range, publish
+    search-hint: package shot data, export frame range, editorial delivery
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-shot-export/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-shot-export/tools.yaml
@@ -6,6 +6,11 @@ tools:
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: export_shot_alembic
   execution: async
   affinity: main
@@ -13,6 +18,11 @@ tools:
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: export_shot_fbx
   execution: async
   affinity: main
@@ -20,9 +30,18 @@ tools:
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_shot_info
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-skinning-utils/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-skinning-utils/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-skinning-utils
-description: Maya skinning utilities — copy weights, normalize, mirror, prune, and
-  query skin cluster data
+description: Maya skinning utilities — copy weights, normalize, mirror, prune, and smooth skin weights. Use when refining character skin deformation. Not for joint creation or blend shapes — use maya-rigging or maya-blend-shape-utils for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - skin-cluster
     - weights
     - rigging
-    search-hint: skin, weight, bind, copy weights, smooth
+    search-hint: refine skin weights, copy mirror weights, smooth deformation
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-skinning-utils/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-skinning-utils/tools.yaml
@@ -3,15 +3,34 @@ tools:
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: mirror_skin_weights
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: normalize_skin_weights
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: prune_skin_weights
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-spline-ik/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-spline-ik/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-spline-ik
-description: Maya spline IK utilities — create and configure spline IK chains for
-  ribbon/spine rigs
+description: Maya spline IK utilities — create and configure spline IK chains for spine and ribbon setups. Use when building flexible joint chains in rigs. Not for standard single-chain IK or full rig creation — use maya-rigging or maya-rig-utils for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - spline
     - rigging
     - spine
-    search-hint: spline IK, curve, ribbon, spine
+    search-hint: spine rig, ribbon setup, flexible joint chain, spline IK
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-spline-ik/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-spline-ik/tools.yaml
@@ -3,10 +3,20 @@ tools:
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_spline_ik
   execution: sync
   affinity: main
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_spline_ik_handles
   execution: sync
   affinity: main
@@ -14,9 +24,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_spline_ik_twist
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-texture-bake/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-texture-bake/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-texture-bake
-description: Maya texture baking — bake lighting, AO, normals, and custom maps from
-  3D geometry to texture
+description: Maya texture baking — bake lighting, AO, normals, and custom maps from high-res to low-res geometry. Use when generating static texture maps for game or render assets. Not for material assignment or UV layout — use maya-materials or maya-uv-ops for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -15,7 +15,7 @@ metadata:
     - ao
     - lighting
     - normals
-    search-hint: bake, texture, light map, normal map
+    search-hint: bake texture map, AO normal, high to low res, static map
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-texture-bake/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-texture-bake/tools.yaml
@@ -4,16 +4,31 @@ tools:
   affinity: main
   timeout_hint_secs: 600
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: bake_lighting
   execution: async
   affinity: main
   timeout_hint_secs: 600
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: bake_textures
   execution: async
   affinity: main
   timeout_hint_secs: 600
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_bake_sets
   execution: sync
   affinity: main
@@ -21,6 +36,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_color_spaces
   execution: sync
   affinity: main
@@ -28,14 +48,28 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_color_management
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: transfer_maps
   execution: async
   affinity: main
   timeout_hint_secs: 600
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-toon/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-toon/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-toon
-description: Maya toon shading — create toon outlines, fill shaders, and cel-shading
-  looks using Maya's built-in toon system
+description: Maya toon shading — create toon outlines, fill shaders, and cel-shading networks. Use when producing stylized non-photorealistic looks. Not for standard PBR materials or photoreal lighting — use maya-materials or maya-lighting for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - shading
     - npr
     - stylized
-    search-hint: toon, outline, cartoon, cel shading
+    search-hint: stylized look, cel shading, toon outline, NPR
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-toon/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-toon/tools.yaml
@@ -3,10 +3,20 @@ tools:
   execution: sync
   affinity: main
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_toon_shader
   execution: sync
   affinity: main
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_toon_outlines
   execution: sync
   affinity: main
@@ -14,9 +24,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_outline_width
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: shading-lighting
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-utility/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-utility/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-utility
-description: Maya utility nodes and scene statistics
+description: Maya utility nodes and scene statistics — freeze transforms, center pivot, and convert units. Use when performing general scene cleanup and normalization. Not for modeling, animation, or rendering — use maya-mesh-ops, maya-animation, or maya-render for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - utility
     - node
     - scene
-    search-hint: utility, transform, freeze, center pivot, convert
+    search-hint: scene cleanup, freeze transform, center pivot, normalize units
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-utility/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-utility/tools.yaml
@@ -2,18 +2,37 @@ tools:
 - name: clean_scene
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_utility_node
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_scene_statistics
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_node_connections
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: maya-uv-ops
-description: Maya UV operations — create, delete, project, unfold and normalize UV
-  layouts
+description: Maya UV operations — create, delete, project, unfold, layout, and normalize UV sets. Use when working with texture coordinates and UV layouts. Not for mesh modeling, material authoring, or texture baking — use maya-mesh-ops, maya-materials, or maya-texture-bake for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - uv
     - texture
     - geometry
-    search-hint: UV, unfold, layout, planar map, texture coordinates
+    search-hint: layout UVs, unfold UV, texture coordinates, UV projection
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/tools.yaml
@@ -3,10 +3,20 @@ tools:
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: create_uv_set
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_uv_set
   execution: sync
   affinity: main
@@ -14,6 +24,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_uv_info
   execution: sync
   affinity: main
@@ -21,6 +36,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_uv_shell_info
   execution: sync
   affinity: main
@@ -28,15 +48,34 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: normalize_uvs
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: project_uvs
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: unfold_uvs
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-vertex-color/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-vertex-color/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: maya-vertex-color
-description: Maya vertex color and color set management
+description: Maya vertex color and color set management — paint, assign, and display per-vertex colors. Use when adding color data to mesh vertices. Not for texture mapping or material color — use maya-uv-ops or maya-materials for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
     - vertex
     - color
     - paint
-    search-hint: vertex color, paint, color set, display
+    search-hint: per-vertex color, paint vertex, color set, vertex paint
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-vertex-color/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-vertex-color/tools.yaml
@@ -3,6 +3,11 @@ tools:
   execution: sync
   affinity: main
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_vertex_color
   execution: sync
   affinity: main
@@ -10,6 +15,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: remove_vertex_colors
   execution: sync
   affinity: main
@@ -17,9 +27,18 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_vertex_color
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: modeling
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-xform-utils/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-xform-utils/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: maya-xform-utils
-description: Maya transform utilities — freeze, reset, match, bake, and mirror transforms
+description: Maya transform utilities — freeze, reset, match, bake, and mirror transforms and pivots. Use when adjusting object positioning and orientation. Not for animation curves or rigging constraints — use maya-animation or maya-constraints for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -13,7 +14,7 @@ metadata:
     - xform
     - freeze
     - pivot
-    search-hint: transform, pivot, align, freeze, reset
+    search-hint: adjust transform, freeze pivot, align objects, bake transform
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-xform-utils/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-xform-utils/tools.yaml
@@ -2,14 +2,33 @@ tools:
 - name: bake_transforms
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: freeze_transforms
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: match_transforms
   execution: sync
   affinity: main
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: reset_pivot
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log

--- a/src/dcc_mcp_maya/skills/maya-xgen/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-xgen/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: maya-xgen
-description: Maya XGen hair and fur operations — create, list, preview and manage
-  XGen descriptions
+description: Maya XGen hair and fur operations — create, list, preview, and manage XGen descriptions. Use when generating hair, fur, or feather grooms. Not for nHair dynamics or general grooming — use maya-grooming or maya-dynamics for that.
 license: MIT
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:
     dcc: maya
+    layer: domain
     version: 1.0.0
     tags:
     - maya
@@ -14,7 +14,7 @@ metadata:
     - hair
     - fur
     - grooming
-    search-hint: xgen, hair, fur, feather, groom
+    search-hint: hair fur generation, XGen description, groom hair
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-xgen/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-xgen/tools.yaml
@@ -4,6 +4,11 @@ tools:
   affinity: main
   timeout_hint_secs: 300
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: delete_description
   execution: async
   affinity: main
@@ -12,6 +17,11 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: get_xgen_attribute
   execution: sync
   affinity: main
@@ -19,6 +29,11 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: list_descriptions
   execution: sync
   affinity: main
@@ -26,9 +41,18 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log
+
 - name: set_xgen_attribute
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: simulation-fx
+  next-tools:
+    on-failure:
+    - dcc_diagnostics__screenshot
+    - dcc_diagnostics__audit_log


### PR DESCRIPTION
## Summary

Closes #100.

Introduce a two-layer skill architecture to eliminate AI agent routing ambiguity when multiple skills share overlapping keywords.

## Changes

- **All 67 SKILL.md files**: add `metadata.dcc-mcp.layer: domain`
- **All descriptions**: rewrite with explicit negative routing sentence (`Not for X — use Y for that.`)
- **All search-hints**: reworded to be intent-oriented (not mechanism-oriented)
- **All tools.yaml**: add `next-tools.on-failure` pointing to `dcc_diagnostics__screenshot` and `dcc_diagnostics__audit_log`

## Acceptance Criteria

- [x] All skills have `dcc-mcp.layer` metadata tag
- [x] All skill descriptions include a "Not for X — use Y" routing sentence
- [x] All domain skill tools have `on-failure` pointing to `dcc_diagnostics__*`
- [x] `search-hint` keywords are intent-oriented