### PR TITLE
chore: align with dcc-mcp-core 0.14+ and clean adapter/docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,7 @@ def create_sphere(radius: float = 1.0) -> dict:
 
 - **src/dcc_mcp_maya/server.py** — `MayaMcpServer` (constructor, `register_builtin_actions`, `start`, `stop`, metrics, job persistence).
 - **src/dcc_mcp_maya/dispatcher.py** — `MayaUiDispatcher`, `MayaStandaloneDispatcher`, `MayaUiPump`, `check_maya_cancelled`.
-- **src/dcc_mcp_maya/plugin.py** — Maya plugin entry point (`initializePlugin`, `uninitializePlugin`, menu, gateway auto-config).
-- **src/dcc_mcp_maya/skill_executor.py** — `MayaInternalSkillExecutor` (in-process `exec()` path).
+- **maya/plugin/dcc_mcp_maya_plugin.py** — Maya plugin entry point (`initializePlugin`, `uninitializePlugin`, menu, gateway auto-config).
 - **tests/** — 50+ unit tests, E2E tests (tahv/mayapy 2022–2025), multi-instance gateway tests.
 
 ### Layer 4 — You Are an AI Agent Reading This

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -474,9 +474,7 @@ Gateway exposes meta-tools: `list_dcc_instances`, `connect_to_dcc`, `get_dcc_ins
 | `src/dcc_mcp_maya/server.py` | `MayaMcpServer`, discovery, metrics, jobs |
 | `src/dcc_mcp_maya/dispatcher.py` | Thread dispatchers, pump, cancellation |
 | `src/dcc_mcp_maya/api.py` | 18 skill-authoring helpers |
-| `src/dcc_mcp_maya/plugin.py` | Maya plugin entry point |
 | `src/dcc_mcp_maya/capabilities.py` | DCC capability declarations |
-| `src/dcc_mcp_maya/skill_executor.py` | In-process skill execution |
 | `src/dcc_mcp_maya/skills/` | 64 built-in skill packages |
 | `docs/` | VitePress site (EN + ZH) |
 | `tests/` | pytest suite |

--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -56,6 +56,12 @@ Configuration
 ``DCC_MCP_REGISTRY_DIR``
     Directory for the shared ``FileRegistry`` JSON.  Defaults to OS temp dir.
 
+``DCC_MCP_MAYA_WINDOW_TITLE``
+    Optional substring of the main Maya window title, passed to the MCP server
+    as ``dcc_window_title`` for instance-bound diagnostics and screenshot routing
+    (``dcc-mcp-core`` 0.14+).  Usually unnecessary; same-process PID resolution
+    is the default.
+
 ``DCC_MCP_PYTHON_EXECUTABLE``
     Python interpreter for skill worker subprocesses.  Auto-set to
     ``sys.executable`` (i.e. ``mayapy``) at plugin load time.
@@ -199,13 +205,18 @@ def _resolve_config():
         dcc_version = str(cmds.about(version=True))
     except Exception:
         dcc_version = None
-    return {
+    out = {
         "port": port,
         "server_name": server_name,
         "gateway_port": gateway_port if gateway_port > 0 else None,
         "registry_dir": registry_dir,
         "dcc_version": dcc_version,
     }
+    # Optional: helps WindowFinder / diagnostics__screenshot when PIDs are ambiguous
+    wtitle = os.environ.get("DCC_MCP_MAYA_WINDOW_TITLE", "").strip()
+    if wtitle:
+        out["dcc_window_title"] = wtitle
+    return out
 
 
 def _export_worker_env() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "dcc-mcp-core>=0.13.2,<1.0.0",
+    "dcc-mcp-core>=0.14.0,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -279,6 +279,10 @@ class MayaMcpServer(DccServerBase):
         if effective_job_path:
             self._config.job_storage_path = effective_job_path
             logger.info("[%s] Job storage: %s", "maya", effective_job_path)
+        elif job_storage_path is not None and not str(job_storage_path).strip():
+            # ``""`` means disable persistence; clear path set by :class:`DccServerBase`
+            # in ``_init_job_persistence`` (see tests/test_server_job_metrics.py).
+            self._config.job_storage_path = ""
 
         # Job-recovery policy (issue #89).  Stored for use in
         # :meth:`register_builtin_actions` where we can log the effective

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -79,6 +79,10 @@ _MINIMAL_DEACTIVATE_GROUPS: dict[str, list[str]] = {
 #   DCC_MCP_MAYA_JOB_RECOVERY=requeue
 #       → re-queue idempotent interrupted jobs on startup (issue #89;
 #         default behaviour is "drop" as documented in the issue).
+#   DCC_MCP_MAYA_WINDOW_TITLE=...
+#       → passed as ``dcc_window_title`` to :class:`MayaMcpServer` (diagnostics
+#         / screenshot routing; dcc-mcp-core 0.14+).  The Maya plugin sets this
+#         when the env var is non-empty.
 _ENV_MINIMAL = "DCC_MCP_MAYA_MINIMAL"
 _ENV_DEFAULT_TOOLS = "DCC_MCP_MAYA_DEFAULT_TOOLS"
 _ENV_METRICS = "DCC_MCP_MAYA_METRICS"
@@ -150,9 +154,9 @@ class MayaMcpServer(DccServerBase):
     - Maya version detection via ``cmds.about(version=True)``
     - Minimal-mode startup: only core skills are loaded, the rest
       remain as ``__skill__`` stubs for progressive activation
-    - Optional ``register_builtin_actions()`` override that also installs
-      IPC diagnostic handlers via
-      ``dcc_mcp_core.dcc_server.register_diagnostic_handlers``
+    - ``register_builtin_actions()`` (minimal / full skill loading); instance-bound
+      diagnostic IPC + MCP tools are registered in
+      :meth:`~dcc_mcp_core.server_base.DccServerBase.start` (0.14+)
     - Maya-specific TransportManager wrappers
       (``bind_and_register``, ``find_best_service``, ``rank_services``)
     - Prometheus ``/metrics`` endpoint support (issue #87)
@@ -207,6 +211,14 @@ class MayaMcpServer(DccServerBase):
             storage on startup.  ``"drop"`` (default) discards them;
             ``"requeue"`` re-submits idempotent jobs automatically.
             ``None`` reads ``DCC_MCP_MAYA_JOB_RECOVERY`` env var.
+        dcc_pid: Owning Maya process id for ``diagnostics__*`` tools and IPC
+            screenshot routing.  Defaults to :func:`os.getpid` (same as
+            :class:`~dcc_mcp_core.server_base.DccServerBase`).
+        dcc_window_title: Substring to locate the Maya main window (e.g. for
+            captures) when no handle is set.  Optional; PID-based lookup
+            usually suffices.
+        dcc_window_handle: Native window handle (HWND, etc.) when pre-resolved;
+            takes precedence over title/PID resolution.
     """
 
     def __init__(
@@ -222,6 +234,9 @@ class MayaMcpServer(DccServerBase):
         metrics_enabled: Optional[bool] = None,
         job_storage_path: Optional[str] = None,
         job_recovery: Optional[str] = None,
+        dcc_pid: Optional[int] = None,
+        dcc_window_title: Optional[str] = None,
+        dcc_window_handle: Optional[int] = None,
     ) -> None:
         super().__init__(
             dcc_name="maya",
@@ -234,6 +249,9 @@ class MayaMcpServer(DccServerBase):
             dcc_version=dcc_version,
             scene=scene,
             enable_gateway_failover=enable_gateway_failover,
+            dcc_pid=dcc_pid,
+            dcc_window_title=dcc_window_title,
+            dcc_window_handle=dcc_window_handle,
         )
 
         # ── Prometheus metrics (issue #87) ────────────────────────────────────
@@ -390,13 +408,8 @@ class MayaMcpServer(DccServerBase):
             # Default minimal mode
             self._load_minimal_skills(_MINIMAL_SKILLS)
 
-        # Phase 3: register diagnostic IPC handlers
-        try:
-            from dcc_mcp_core.dcc_server import register_diagnostic_handlers  # noqa: PLC0415
-
-            register_diagnostic_handlers(self._server, dcc_name="maya")
-        except Exception as exc:
-            logger.debug("Failed to register diagnostic handlers: %s", exc)
+        # Diagnostic IPC + ``diagnostics__*`` MCP tools are registered in
+        # :meth:`DccServerBase.start` with full instance context (pid / window).
 
         return self
 
@@ -556,6 +569,9 @@ def start_server(
     metrics_enabled: Optional[bool] = None,
     job_storage_path: Optional[str] = None,
     job_recovery: Optional[str] = None,
+    dcc_pid: Optional[int] = None,
+    dcc_window_title: Optional[str] = None,
+    dcc_window_handle: Optional[int] = None,
     **kwargs: Any,
 ) -> Any:
     """Start (or return the already-running) Maya MCP server.
@@ -584,6 +600,9 @@ def start_server(
         job_recovery: Recovery policy for interrupted jobs: ``"drop"``
             (default) or ``"requeue"``.  Also honours
             ``DCC_MCP_MAYA_JOB_RECOVERY``.
+        dcc_pid: Maya process id for diagnostics (see :class:`MayaMcpServer`).
+        dcc_window_title: Window title substring for diagnostic capture.
+        dcc_window_handle: Pre-resolved native window handle.
         **kwargs: Forwarded to :class:`MayaMcpServer`.
 
     Returns:
@@ -597,6 +616,11 @@ def start_server(
     """
     global _server_instance
 
+    if dcc_window_title is None:
+        w = os.environ.get("DCC_MCP_MAYA_WINDOW_TITLE", "").strip()
+        if w:
+            dcc_window_title = w
+
     if register_builtins:
         # Create server instance and call register_builtin_actions with minimal
         with _server_lock:
@@ -608,6 +632,9 @@ def start_server(
                 metrics_enabled=metrics_enabled,
                 job_storage_path=job_storage_path,
                 job_recovery=job_recovery,
+                dcc_pid=dcc_pid,
+                dcc_window_title=dcc_window_title,
+                dcc_window_handle=dcc_window_handle,
                 **kwargs,
             )
             _instance_holder[0] = server
@@ -646,6 +673,12 @@ def start_server(
             include_bundled=include_bundled,
             enable_hot_reload=enable_hot_reload,
             hot_reload_env_var="DCC_MCP_MAYA_HOT_RELOAD",
+            metrics_enabled=metrics_enabled,
+            job_storage_path=job_storage_path,
+            job_recovery=job_recovery,
+            dcc_pid=dcc_pid,
+            dcc_window_title=dcc_window_title,
+            dcc_window_handle=dcc_window_handle,
             **kwargs,
         )
         _server_instance = _instance_holder[0]


### PR DESCRIPTION
## Summary

This PR aligns **dcc-mcp-maya** with **dcc-mcp-core 0.14+** instance-bound diagnostics, bumps the core dependency range, documents optional `dcc_window_title` for diagnostics, and removes stale documentation references.

## Changes

- **Dependencies:** `dcc-mcp-core>=0.14.0,<1.0.0` (IPC renames: `dispatch_tool`, `get_tool_metrics`, etc.).
- **MayaMcpServer / `start_server`:** forward `dcc_pid`, `dcc_window_title`, `dcc_window_handle` to `DccServerBase`; optional `DCC_MCP_MAYA_WINDOW_TITLE` env.
- **Diagnostics:** remove duplicate `register_diagnostic_handlers` from `register_builtin_actions` — full registration (IPC + MCP tools with pid/window/resolver) already runs in `DccServerBase.start()`.
- **Plugin:** pass `dcc_window_title` from `DCC_MCP_MAYA_WINDOW_TITLE` when set; document the env var.
- **`create_dcc_server` path:** forward metrics, job, and DCC window kwargs to `MayaMcpServer`.
- **Job storage:** `job_storage_path=""` now clears the path set by the base `DccServerBase._init_job_persistence` (disables DB persistence for that server).
- **Docs:** `AGENTS.md` and `llms-full.txt` — remove non-existent `skill_executor` / wrong `plugin.py` paths; point Layer 3 to `maya/plugin/dcc_mcp_maya_plugin.py`.

## Related

- In-process skill execution: #108
- dcc-mcp-core doc follow-up: https://github.com/loonghao/dcc-mcp-core/issues/421

## Testing

- `pytest` (default marker exclusions) passed locally including `tests/test_server_job_metrics.py`.
