### PR TITLE
fix: set non-core tool groups to default_active: false for progressive exposure

### DIFF
--- a/src/dcc_mcp_maya/skills/maya-display/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-display/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: scene-management
   description: Scene management, organization, and navigation tools
-  default_active: true
+  default_active: false
   tools:
   - create_display_layer
   - delete_display_layer

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: modeling
   description: Geometry creation, editing, and UV tools
-  default_active: true
+  default_active: false
   tools:
   - apply_subdivision
   - cleanup_mesh

--- a/src/dcc_mcp_maya/skills/maya-namespaces/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-namespaces/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: scene-management
   description: Scene management, organization, and navigation tools
-  default_active: true
+  default_active: false
   tools:
   - create_namespace
   - delete_namespace

--- a/src/dcc_mcp_maya/skills/maya-pipeline/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-pipeline/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: scene-management
   description: Scene management, organization, and navigation tools
-  default_active: true
+  default_active: false
   tools:
   - get_asset_metadata
   - publish_asset

--- a/src/dcc_mcp_maya/skills/maya-primitives/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-primitives/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: modeling
   description: Geometry creation, editing, and UV tools
-  default_active: true
+  default_active: false
   tools:
   - create_cube
   - create_cylinder

--- a/src/dcc_mcp_maya/skills/maya-proxy-mesh/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-proxy-mesh/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: modeling
   description: Geometry creation, editing, and UV tools
-  default_active: true
+  default_active: false
   tools:
   - create_proxy
   - list_proxies

--- a/src/dcc_mcp_maya/skills/maya-references/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-references/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: scene-management
   description: Scene management, organization, and navigation tools
-  default_active: true
+  default_active: false
   tools:
   - create_reference
   - list_namespaces

--- a/src/dcc_mcp_maya/skills/maya-scene-assembly/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene-assembly/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: scene-management
   description: Scene management, organization, and navigation tools
-  default_active: true
+  default_active: false
   tools:
   - add_assembly_representation
   - create_assembly_definition

--- a/src/dcc_mcp_maya/skills/maya-scene-utils/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene-utils/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: scene-management
   description: Scene management, organization, and navigation tools
-  default_active: true
+  default_active: false
   tools:
   - align_objects
   - create_annotation

--- a/src/dcc_mcp_maya/skills/maya-scene/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene/groups.yaml
@@ -8,7 +8,7 @@ groups:
   - get_session_info
 - name: scene-management
   description: Scene management, organization, and navigation tools
-  default_active: true
+  default_active: false
   tools:
   - center_pivot
   - create_locator

--- a/src/dcc_mcp_maya/skills/maya-scripting/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scripting/groups.yaml
@@ -7,7 +7,7 @@ groups:
   - execute_python
 - name: extended
   description: Extended scripting utilities across all domains
-  default_active: true
+  default_active: false
   tools:
   - animation
   - attributes

--- a/src/dcc_mcp_maya/skills/maya-selection/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-selection/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: scene-management
   description: Scene management, organization, and navigation tools
-  default_active: true
+  default_active: false
   tools:
   - convert_selection
   - grow_selection

--- a/src/dcc_mcp_maya/skills/maya-sets/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-sets/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: scene-management
   description: Scene management, organization, and navigation tools
-  default_active: true
+  default_active: false
   tools:
   - add_to_set
   - create_set

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: modeling
   description: Geometry creation, editing, and UV tools
-  default_active: true
+  default_active: false
   tools:
   - copy_uvs
   - create_uv_set

--- a/src/dcc_mcp_maya/skills/maya-vertex-color/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-vertex-color/groups.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: modeling
   description: Geometry creation, editing, and UV tools
-  default_active: true
+  default_active: false
   tools:
   - create_color_set
   - get_vertex_color


### PR DESCRIPTION
## Problem

All skill groups except the core groups had `default_active: true`, which caused every tool in every loaded skill to be eagerly exposed on `tools/list`. This defeats the progressive tool exposure design where non-essential groups should remain as stubs until explicitly activated via `activate_tool_group()`.

When a skill is loaded, all its groups marked `default_active: true` get their tools immediately flattened into the tool list. For `maya-scripting` alone this meant 29 tools (2 core + 27 extended) appeared at once, drowning the AI agent in choices and causing it to call tools by incorrect names.

## Fix

Set `default_active: false` on all non-core tool groups across 15 skills. Only the two core groups remain active by default:

- `maya-scripting/core` (execute_mel, execute_python) — `default_active: true`
- `maya-scene/core` (get_scene_info, get_selection, get_session_info) — `default_active: true`

All other groups now appear as `__group__<name>` stubs that the AI must explicitly activate before use.

## Skills Changed

| Skill | Group | Before | After |
|-------|-------|--------|-------|
| maya-scripting | extended | true | false |
| maya-scene | scene-management | true | false |
| maya-display | scene-management | true | false |
| maya-mesh-ops | modeling | true | false |
| maya-namespaces | scene-management | true | false |
| maya-pipeline | scene-management | true | false |
| maya-primitives | modeling | true | false |
| maya-proxy-mesh | modeling | true | false |
| maya-references | scene-management | true | false |
| maya-scene-assembly | scene-management | true | false |
| maya-scene-utils | scene-management | true | false |
| maya-selection | scene-management | true | false |
| maya-sets | scene-management | true | false |
| maya-uv-ops | modeling | true | false |
| maya-vertex-color | modeling | true | false |

## Impact

After this change, a fresh Maya session with `maya-scripting` + `maya-scene` loaded will expose only ~5 core tools + 2 group stubs instead of 50+ flattened tools. The AI can then `activate_tool_group("extended")` or `activate_tool_group("scene-management")` on demand.
