### PR TITLE
fix(executor): integrate register_handler for dcc-mcp-core 0.14.14 in-process executor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "dcc-mcp-core>=0.14.0,<1.0.0",
+    "dcc-mcp-core>=0.14.14,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_maya/__init__.py
+++ b/src/dcc_mcp_maya/__init__.py
@@ -61,8 +61,12 @@ from dcc_mcp_maya.dispatcher import (
     MayaStandaloneDispatcher,
     MayaUiDispatcher,
     MayaUiPump,
+    PyPumpedDispatcher,
+    PyStandaloneDispatcher,
+    _CorePump,
     check_maya_cancelled,
     create_dispatcher,
+    create_pumped_dispatcher,
 )
 from dcc_mcp_maya.server import MayaMcpServer, start_server, stop_server
 
@@ -72,12 +76,17 @@ __all__ = [
     "MayaMcpServer",
     "start_server",
     "stop_server",
-    # Dispatchers
+    # Dispatchers — Python-side (callable dispatch, main-thread affinity)
     "MayaUiDispatcher",
     "MayaUiPump",
     "MayaStandaloneDispatcher",
     "create_dispatcher",
     "check_maya_cancelled",
+    # Dispatchers — Rust-backed (string-payload dispatch, dcc-mcp-core 0.14.14+)
+    "PyPumpedDispatcher",
+    "PyStandaloneDispatcher",
+    "_CorePump",
+    "create_pumped_dispatcher",
     # Skill authoring helpers
     "maya_success",
     "maya_error",

--- a/src/dcc_mcp_maya/dispatcher.py
+++ b/src/dcc_mcp_maya/dispatcher.py
@@ -50,6 +50,22 @@ from typing import Any, Callable, Deque, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+# ── Core dispatcher re-exports ────────────────────────────────────────────────
+# dcc-mcp-core 0.14.14 ships ``PyPumpedDispatcher`` (Rust-backed, main-thread
+# pump) and ``PyStandaloneDispatcher`` (immediate synchronous dispatch).  We
+# re-export them here so callers can import from a single module without caring
+# whether the Rust extension is present.
+#
+# ``PyPumpedDispatcher`` is the Rust equivalent of :class:`MayaUiDispatcher`
+# for *string-payload* dispatch (IPC-style).  For *callable* dispatch —
+# required by the in-process executor — :class:`MayaUiDispatcher` must be
+# used.  The two dispatchers are complementary, not mutually exclusive.
+try:
+    from dcc_mcp_core import PyPumpedDispatcher, PyStandaloneDispatcher  # noqa: F401
+except ImportError:  # pragma: no cover — core is a hard dep at runtime
+    PyPumpedDispatcher = None  # type: ignore[assignment,misc]
+    PyStandaloneDispatcher = None  # type: ignore[assignment,misc]
+
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 #: Default time budget (milliseconds) per idle-event pump cycle.
@@ -985,13 +1001,24 @@ class MayaUiPump:
                 pass
 
 
-# ── Factory helper ────────────────────────────────────────────────────────────
+# ── Factory helpers ───────────────────────────────────────────────────────────
 
 
 def create_dispatcher(
     budget_ms: float = DEFAULT_BUDGET_MS,
 ) -> Tuple[Any, Optional[MayaUiPump]]:
     """Create the appropriate dispatcher for the current Maya environment.
+
+    Returns a ``(dispatcher, pump)`` pair where *dispatcher* is a
+    :class:`MayaUiDispatcher` (interactive) or
+    :class:`MayaStandaloneDispatcher` (batch / ``mayapy``), and *pump* is a
+    :class:`MayaUiPump` or ``None`` respectively.
+
+    The returned :class:`MayaUiDispatcher` supports ``submit_callable`` for
+    routing arbitrary Python callables to Maya's UI thread — required by the
+    in-process skill executor.  Use :func:`create_pumped_dispatcher` when
+    you want the Rust-backed :class:`PyPumpedDispatcher` (string-payload
+    dispatch only) instead.
 
     Returns
     -------
@@ -1011,3 +1038,131 @@ def create_dispatcher(
     dispatcher = MayaUiDispatcher()
     pump = MayaUiPump(dispatcher, budget_ms=budget_ms)
     return dispatcher, pump
+
+
+def create_pumped_dispatcher(
+    budget_ms: float = DEFAULT_BUDGET_MS,
+) -> Tuple[Any, Optional["_CorePump"]]:
+    """Create a Rust-backed :class:`PyPumpedDispatcher` for the current Maya environment.
+
+    This is an alternative to :func:`create_dispatcher` that returns the
+    core's ``PyPumpedDispatcher`` instead of :class:`MayaUiDispatcher`.
+    Use it when you need IPC-style string-payload dispatch routed through
+    the Rust main-thread pump.
+
+    .. note::
+        ``PyPumpedDispatcher`` only supports ``submit(action_name, payload,
+        affinity)`` where *payload* is a string.  It cannot dispatch arbitrary
+        Python callables.  For in-process skill execution, the
+        :class:`MayaUiDispatcher` returned by :func:`create_dispatcher` must
+        be used.
+
+    Returns
+    -------
+    tuple[PyPumpedDispatcher | MayaStandaloneDispatcher, _CorePump | None]
+        A ``(dispatcher, pump)`` pair.  Returns
+        ``(MayaStandaloneDispatcher(), None)`` when not inside an interactive
+        Maya session or when ``PyPumpedDispatcher`` is not available.
+    """
+    if PyPumpedDispatcher is None:
+        logger.warning("PyPumpedDispatcher not available — falling back to MayaStandaloneDispatcher")
+        return MayaStandaloneDispatcher(), None
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        is_batch = cmds.about(batch=True)
+    except ImportError:
+        is_batch = True
+
+    if is_batch:
+        return MayaStandaloneDispatcher(), None
+
+    core_dispatcher = PyPumpedDispatcher(budget_ms=int(budget_ms))
+    pump = _CorePump(core_dispatcher, budget_ms=budget_ms)
+    return core_dispatcher, pump
+
+
+class _CorePump:
+    """Idle-event pump adapter for :class:`PyPumpedDispatcher`.
+
+    Wraps :class:`PyPumpedDispatcher` in the same scriptJob-based idle hook
+    that :class:`MayaUiPump` uses for :class:`MayaUiDispatcher`, so callers
+    can treat both pump types identically (``install()`` / ``uninstall()``).
+
+    Parameters
+    ----------
+    dispatcher:
+        A :class:`PyPumpedDispatcher` instance whose :meth:`pump` method
+        should be called on each idle tick.
+    budget_ms:
+        Maximum milliseconds for each pump call.  Passed to
+        :meth:`PyPumpedDispatcher.pump_with_budget`.
+    """
+
+    def __init__(self, dispatcher: Any, budget_ms: float = DEFAULT_BUDGET_MS) -> None:
+        self._dispatcher = dispatcher
+        self._budget_ms = budget_ms
+        self._script_job_id: Optional[int] = None
+        self._installed = False
+
+    @property
+    def is_installed(self) -> bool:
+        """``True`` if the idle scriptJob is currently active."""
+        return self._installed
+
+    def install(self) -> bool:
+        """Register the idle-event scriptJob with Maya."""
+        if self._installed:
+            return True
+        try:
+            import maya.cmds as cmds  # noqa: PLC0415
+
+            self._script_job_id = cmds.scriptJob(
+                event=["idle", self._pump_tick],
+                protected=True,
+            )
+            self._installed = True
+            logger.info(
+                "_CorePump installed (scriptJob=%d, budget=%.1f ms)",
+                self._script_job_id,
+                self._budget_ms,
+            )
+            return True
+        except ImportError:
+            logger.warning("_CorePump: maya.cmds not available — install skipped")
+            return False
+        except Exception as exc:
+            logger.error("_CorePump: failed to install scriptJob: %s", exc)
+            return False
+
+    def uninstall(self) -> None:
+        """Remove the idle-event scriptJob from Maya."""
+        if not self._installed:
+            return
+        try:
+            import maya.cmds as cmds  # noqa: PLC0415
+
+            if self._script_job_id is not None:
+                cmds.scriptJob(kill=self._script_job_id, force=True)
+                logger.info("_CorePump uninstalled (scriptJob=%d)", self._script_job_id)
+        except Exception as exc:
+            logger.warning("_CorePump: error removing scriptJob: %s", exc)
+        finally:
+            self._script_job_id = None
+            self._installed = False
+
+    def _pump_tick(self) -> None:
+        """Idle-event callback — drain pending Rust-side main-thread jobs."""
+        try:
+            stats = self._dispatcher.pump_with_budget(int(self._budget_ms))
+            remaining = stats.get("remaining", 0) if isinstance(stats, dict) else 0
+            if remaining > 0:
+                try:
+                    import maya.cmds as cmds  # noqa: PLC0415
+
+                    cmds.refresh(force=True)
+                except Exception:
+                    pass
+        except Exception as exc:
+            logger.debug("_CorePump._pump_tick error: %s", exc)

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -143,6 +143,69 @@ def _maya_available() -> bool:
         return False
 
 
+def _run_skill_script(script_path: str, params: dict) -> dict:
+    """Load and execute a skill script in the current Python process.
+
+    Implements the ``main(**params)`` calling convention used by all
+    ``dcc-mcp-maya`` skill scripts.  The ``if __name__ == "__main__":
+    run_main(main)`` guard is intentionally **not** triggered so that
+    parameters are forwarded directly without subprocess stdout.
+
+    Parameters
+    ----------
+    script_path:
+        Path to the skill Python script.
+    params:
+        Keyword arguments forwarded to ``main(**params)``.
+
+    Returns
+    -------
+    dict
+        The ``{"success": ..., "message": ..., ...}`` result dict.
+    """
+    import importlib.util  # noqa: PLC0415
+
+    spec = importlib.util.spec_from_file_location("_maya_skill_script", script_path)
+    if spec is None or spec.loader is None:
+        return {"success": False, "message": "Cannot load skill script: {}".format(script_path)}
+
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    except SystemExit:
+        pass
+    except Exception as exc:  # noqa: BLE001
+        try:
+            from dcc_mcp_core.skill import skill_exception  # noqa: PLC0415
+
+            return skill_exception(exc, message="Error loading skill script: {}".format(script_path))
+        except ImportError:
+            return {"success": False, "message": "Error loading {}: {}".format(script_path, exc)}
+
+    if hasattr(mod, "__mcp_result__"):
+        return mod.__mcp_result__  # type: ignore[return-value]
+
+    main_fn = getattr(mod, "main", None)
+    if main_fn is None:
+        return {
+            "success": False,
+            "message": "Skill script has no main() entry point: {}".format(script_path),
+        }
+
+    try:
+        result = main_fn(**params)
+        return result if isinstance(result, dict) else {"success": True, "message": str(result)}
+    except SystemExit:
+        return getattr(mod, "__mcp_result__", {"success": True, "message": "Script executed"})
+    except Exception as exc:  # noqa: BLE001
+        try:
+            from dcc_mcp_core.skill import skill_exception  # noqa: PLC0415
+
+            return skill_exception(exc)
+        except ImportError:
+            return {"success": False, "message": str(exc)}
+
+
 class MayaMcpServer(DccServerBase):
     """MCP Streamable HTTP server embedded inside Maya.
 
@@ -423,91 +486,171 @@ class MayaMcpServer(DccServerBase):
         return self
 
     # ------------------------------------------------------------------
-    # In-process executor (issue #108)
+    # In-process executor (issue #108, #122)
     # ------------------------------------------------------------------
 
     def _wire_in_process_executor(self) -> None:
-        """Register the Maya in-process skill executor on the SkillCatalog.
+        """Register the Maya in-process skill executor via register_handler.
 
-        When registered, skill scripts execute inside the **current** Maya
-        Python interpreter rather than spawning a ``mayapy`` subprocess.
-        This avoids the overhead and race conditions of subprocess-based
-        execution and gives skills direct access to the live Maya session.
+        In dcc-mcp-core 0.14.x, ``McpHttpServer.catalog`` returns a plain string
+        representation — ``SkillCatalog.set_in_process_executor`` is no longer
+        accessible through the server object.  We instead use
+        ``McpHttpServer.register_handler`` to wire in-process execution for each
+        **currently loaded** action.
 
-        The executor is compatible with the ``@skill_entry`` / ``run_main``
-        contract: it sets ``__mcp_params__`` on the module before executing
-        so that ``run_main`` picks up the parameters correctly.
-
-        Falls back silently if ``SkillCatalog.set_in_process_executor`` is
-        not available (dcc-mcp-core < 0.14) so older environments keep
-        working via the subprocess path.
+        Call this after :meth:`load_skill` / :meth:`register_builtin_actions`
+        to cover skills loaded at startup.  Dynamic loads (triggered by the
+        ``load_skill`` MCP tool) are handled by the overridden
+        :meth:`load_skill` method which calls
+        :meth:`_register_inprocess_handlers` automatically.
         """
         try:
-            catalog = self._server.catalog
+            actions = self._server.registry.list_actions_enabled()
         except AttributeError:
-            logger.debug("SkillCatalog.catalog not available — skipping in-process executor wiring")
+            logger.debug("server.registry not available — skipping in-process executor wiring")
             return
 
-        if not hasattr(catalog, "set_in_process_executor"):
-            logger.debug("set_in_process_executor not available in this core version — using subprocess fallback")
-            return
+        action_names = [a["name"] for a in actions if isinstance(a, dict) and a.get("name")]
+        registered = self._register_inprocess_handlers(action_names)
+        if registered > 0:
+            logger.info("Maya in-process executor: registered %d handler(s) via register_handler", registered)
+        else:
+            logger.debug("Maya in-process executor: no new handlers registered (no loaded actions found)")
 
-        def _maya_in_process_executor(script_path: str, params: dict) -> dict:
-            """Execute a skill script in the current Maya Python process.
+    def _register_inprocess_handlers(self, action_names: List[str]) -> int:
+        """Register in-process Python handlers for the given action names.
 
-            Loads the script as a module, resolves the ``main`` entry point,
-            calls it with *params* as keyword arguments, and returns the result.
+        For each action that has a ``source_file`` and no handler registered
+        yet, wraps :meth:`_execute_in_process` as an
+        ``McpHttpServer.register_handler`` callable so that ``tools/call``
+        dispatches to the live Maya interpreter instead of spawning a
+        ``mayapy`` subprocess.
 
-            The script must expose ``main(**kwargs) -> dict`` at module level
-            (bare or decorated with ``@skill_entry``).  The standard
-            ``if __name__ == "__main__": run_main(main)`` guard is intentionally
-            **not** triggered — we call ``main()`` directly so params are
-            forwarded correctly without going through a subprocess stdout pipe.
-            """
-            import importlib.util  # noqa: PLC0415
+        Parameters
+        ----------
+        action_names:
+            List of action names returned by ``load_skill`` or discovered via
+            ``registry.list_actions_enabled()``.
 
-            spec = importlib.util.spec_from_file_location("_maya_skill_script", script_path)
-            if spec is None or spec.loader is None:
-                return {"success": False, "message": "Cannot load skill script: {}".format(script_path)}
-
-            mod = importlib.util.module_from_spec(spec)
-            try:
-                spec.loader.exec_module(mod)  # type: ignore[union-attr]
-            except SystemExit:
-                pass
-            except Exception as exc:  # noqa: BLE001
-                from dcc_mcp_core.skill import skill_exception  # noqa: PLC0415
-
-                return skill_exception(exc, message="Error loading skill script: {}".format(script_path))
-
-            # Unusual: module-level code already stored a result
-            if hasattr(mod, "__mcp_result__"):
-                return mod.__mcp_result__  # type: ignore[return-value]
-
-            # Standard path: call main(**params) directly so the skill
-            # receives the correct parameters (bypasses run_main/stdout pipe).
-            main_fn = getattr(mod, "main", None)
-            if main_fn is None:
-                return {
-                    "success": False,
-                    "message": "Skill script has no main() entry point: {}".format(script_path),
-                }
+        Returns
+        -------
+        int
+            Number of handlers newly registered.
+        """
+        registered = 0
+        for action_name in action_names:
+            if self._server.has_handler(action_name):
+                continue
 
             try:
-                result = main_fn(**params)
-                return result if isinstance(result, dict) else {"success": True, "message": str(result)}
-            except SystemExit:
-                return getattr(mod, "__mcp_result__", {"success": True, "message": "Script executed"})
-            except Exception as exc:  # noqa: BLE001
-                from dcc_mcp_core.skill import skill_exception  # noqa: PLC0415
+                action = self._server.registry.get_action(action_name)
+            except Exception:
+                continue
 
-                return skill_exception(exc)
+            if not action:
+                continue
 
+            script_path = action.get("source_file") if isinstance(action, dict) else None
+            if not script_path:
+                continue
+
+            def _make_handler(spath: str, aname: str):
+                def handler(params: dict) -> dict:
+                    return self._execute_in_process(spath, params, aname)
+
+                return handler
+
+            try:
+                self._server.register_handler(action_name, _make_handler(script_path, action_name))
+                registered += 1
+            except Exception as exc:
+                logger.warning("Failed to register in-process handler for %r: %s", action_name, exc)
+
+        return registered
+
+    def _execute_in_process(self, script_path: str, params: dict, action_name: str) -> dict:
+        """Execute a skill script inside the current Maya Python process.
+
+        Routes through the attached :class:`~dcc_mcp_maya.dispatcher.MayaUiDispatcher`
+        (if present) so the script runs on Maya's UI thread, which is required
+        for any ``maya.cmds`` or ``maya.api`` calls.  Falls back to running
+        directly on the calling thread when no dispatcher is attached (standalone
+        / ``mayapy`` mode).
+
+        The script must expose ``main(**kwargs) -> dict`` at module level.
+        The ``if __name__ == "__main__": run_main(main)`` guard is intentionally
+        **not** triggered — we call ``main()`` directly so parameters are
+        forwarded without going through a subprocess stdout pipe.
+
+        Parameters
+        ----------
+        script_path:
+            Absolute (or cwd-relative) path to the skill Python script.
+        params:
+            Keyword arguments to pass to ``main(**params)``.
+        action_name:
+            Logical action name used as the dispatcher request id and for
+            logging.
+
+        Returns
+        -------
+        dict
+            The ``{"success": ..., "message": ..., ...}`` result dict from
+            the skill's ``main()`` function.
+        """
+        dispatcher = self._maya_dispatcher
+        if dispatcher is not None and hasattr(dispatcher, "submit_callable"):
+            # Route to Maya's UI thread — required for maya.cmds / maya.api.
+            result = dispatcher.submit_callable(
+                action_name,
+                lambda: _run_skill_script(script_path, params),
+                affinity="main",
+            )
+            if isinstance(result, dict):
+                output = result.get("output")
+                if isinstance(output, dict):
+                    return output
+                if not result.get("success", True):
+                    return {
+                        "success": False,
+                        "message": result.get("error") or "Dispatcher returned failure for {}".format(action_name),
+                    }
+                if output is not None:
+                    return {"success": True, "message": str(output)}
+            return {"success": False, "message": "Dispatcher returned unexpected result for {}".format(action_name)}
+
+        # Standalone / mayapy mode — run directly on the calling thread.
+        return _run_skill_script(script_path, params)
+
+    def load_skill(self, skill_name: str) -> bool:
+        """Load *skill_name* and register in-process handlers for its actions.
+
+        Extends the base-class implementation so that skills loaded
+        dynamically (via the ``load_skill`` MCP tool at runtime) also get
+        in-process Python handlers, not just skills loaded during startup via
+        :meth:`register_builtin_actions`.
+
+        Returns
+        -------
+        bool
+            ``True`` on success (matches :class:`DccServerBase` return type).
+        """
         try:
-            catalog.set_in_process_executor(_maya_in_process_executor)
-            logger.info("Maya in-process skill executor registered (subprocess spawning disabled)")
+            action_names: List[str] = self._server.load_skill(skill_name) or []
         except Exception as exc:
-            logger.warning("Failed to register in-process executor: %s — falling back to subprocess", exc)
+            logger.debug("[%s] load_skill(%r) failed: %s", self._dcc_name, skill_name, exc)
+            return False
+
+        if action_names:
+            newly_registered = self._register_inprocess_handlers(action_names)
+            if newly_registered:
+                logger.debug(
+                    "[%s] load_skill(%r): registered %d in-process handler(s)",
+                    self._dcc_name,
+                    skill_name,
+                    newly_registered,
+                )
+        return True
 
     def _load_all_discovered_skills(self) -> None:
         """Load every discovered skill (legacy full-load behaviour)."""

--- a/tests/test_skills_round46.py
+++ b/tests/test_skills_round46.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_skills_round46.py
+++ b/tests/test_skills_round46.py
@@ -1,27 +1,29 @@
-"""Round 46 tests: in-process skill executor correctness (issue #108).
+"""Round 46 tests: in-process skill executor correctness (issue #108, #122).
 
-Verifies that _wire_in_process_executor produces an executor that:
+Verifies that the register_handler-based in-process executor:
 1. Loads skill scripts via importlib without spawning subprocesses.
 2. Calls main(**params) directly so kwargs reach the skill function.
 3. Returns the dict returned by main(), not a fake placeholder.
 4. Handles missing main(), loader errors, and skill_exception paths.
-5. Is registered on the SkillCatalog via set_in_process_executor.
+5. Registers handlers via McpHttpServer.register_handler (core 0.14.x API).
+6. Handles dynamic load_skill calls by registering handlers automatically.
 """
 
 from __future__ import annotations
 
 import textwrap
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_server():
+def _make_server(with_dispatcher=False):
     """Construct a bare MayaMcpServer without starting it."""
     from dcc_mcp_maya.server import MayaMcpServer
 
@@ -29,20 +31,36 @@ def _make_server():
     server._dcc_name = "maya"
     server._config = MagicMock()
     server._handle = None
-    server._server = MagicMock()
+    server._maya_dispatcher = None
+
+    # Mock the inner McpHttpServer with a registry and handler tracking
+    mock_inner = MagicMock()
+    mock_inner.has_handler.return_value = False
+    mock_inner.registry = MagicMock()
+    mock_inner.registry.list_actions_enabled.return_value = []
+    mock_inner.registry.get_action.return_value = None
+    server._server = mock_inner
+
+    if with_dispatcher:
+        dispatcher = MagicMock()
+        dispatcher.submit_callable.side_effect = lambda rid, fn, affinity="main": {
+            "success": True,
+            "output": fn(),
+            "error": None,
+        }
+        server._maya_dispatcher = dispatcher
+
     return server
 
 
-def _extract_executor(server):
-    """Call _wire_in_process_executor and capture the registered callable."""
-    captured = {}
-
-    def fake_set_in_process_executor(fn):
-        captured["fn"] = fn
-
-    server._server.catalog.set_in_process_executor = fake_set_in_process_executor
-    server._wire_in_process_executor()
-    return captured.get("fn")
+def _make_server_with_actions(actions):
+    """Construct a server whose registry reports the given action dicts."""
+    server = _make_server()
+    server._server.registry.list_actions_enabled.return_value = actions
+    server._server.registry.get_action.side_effect = lambda name: next(
+        (a for a in actions if a.get("name") == name), None
+    )
+    return server
 
 
 # ---------------------------------------------------------------------------
@@ -63,42 +81,83 @@ def tmp_skill(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# 1. Executor is registered on catalog
+# 1. _wire_in_process_executor uses register_handler (new core 0.14.x API)
 # ---------------------------------------------------------------------------
 
 
 class TestExecutorRegistration:
-    def test_registers_on_catalog(self):
+    def test_no_op_when_no_actions(self):
+        """_wire_in_process_executor must not raise when no actions are loaded."""
         server = _make_server()
-        executor = _extract_executor(server)
-        assert callable(executor), "executor must be callable"
-
-    def test_skips_when_catalog_missing(self):
-        server = _make_server()
-        del server._server.catalog
         server._wire_in_process_executor()  # must not raise
 
-    def test_skips_when_method_missing(self):
+    def test_skips_when_registry_missing(self):
+        """Gracefully skips when server.registry raises AttributeError."""
         server = _make_server()
-        del server._server.catalog.set_in_process_executor
+        del server._server.registry
         server._wire_in_process_executor()  # must not raise
+
+    def test_registers_handler_for_action_with_source_file(self, tmp_skill):
+        """A handler is registered for every action that has a source_file."""
+        script = tmp_skill("def main(**kwargs):\n    return {'success': True, 'message': 'ok'}\n")
+        actions = [{"name": "test__skill", "source_file": str(script), "enabled": True}]
+        server = _make_server_with_actions(actions)
+        server._wire_in_process_executor()
+        server._server.register_handler.assert_called_once()
+        name_arg = server._server.register_handler.call_args[0][0]
+        assert name_arg == "test__skill"
+
+    def test_skips_action_without_source_file(self):
+        """Actions with no source_file must be silently skipped."""
+        actions = [{"name": "test__skill", "source_file": None, "enabled": True}]
+        server = _make_server_with_actions(actions)
+        server._wire_in_process_executor()
+        server._server.register_handler.assert_not_called()
+
+    def test_skips_action_with_existing_handler(self, tmp_skill):
+        """Actions that already have a handler must not be double-registered."""
+        script = tmp_skill("def main(**kwargs):\n    return {'success': True}\n")
+        actions = [{"name": "test__skill", "source_file": str(script), "enabled": True}]
+        server = _make_server_with_actions(actions)
+        server._server.has_handler.return_value = True
+        server._wire_in_process_executor()
+        server._server.register_handler.assert_not_called()
+
+    def test_registers_multiple_actions(self, tmp_path):
+        """All actions with source_file get individual handlers."""
+        scripts = []
+        for i in range(3):
+            p = tmp_path / f"skill_{i}.py"
+            p.write_text("def main(**kwargs):\n    return {'success': True}\n")
+            scripts.append(p)
+
+        actions = [{"name": f"skill__{i}", "source_file": str(scripts[i]), "enabled": True} for i in range(3)]
+        server = _make_server_with_actions(actions)
+        server._wire_in_process_executor()
+        assert server._server.register_handler.call_count == 3
 
 
 # ---------------------------------------------------------------------------
-# 2. Executor calls main(**params) — the critical correctness test
+# 2. _run_skill_script — the core script-execution helper
 # ---------------------------------------------------------------------------
 
 
-class TestExecutorCallsMain:
+class TestRunSkillScript:
+    """Tests for the module-level _run_skill_script helper (replaces the old
+    inline _maya_in_process_executor closure)."""
+
+    def _run(self, script_path, params):
+        from dcc_mcp_maya.server import _run_skill_script
+
+        return _run_skill_script(str(script_path), params)
+
     def test_params_forwarded_to_main(self, tmp_skill):
         """main() must receive the params dict as kwargs."""
         script = tmp_skill("""\
             def main(**kwargs):
                 return {"success": True, "message": "ok", "got": kwargs}
         """)
-        server = _make_server()
-        executor = _extract_executor(server)
-        result = executor(str(script), {"radius": 2.0, "name": "test"})
+        result = self._run(script, {"radius": 2.0, "name": "test"})
         assert result["success"] is True
         assert result["got"] == {"radius": 2.0, "name": "test"}
 
@@ -107,9 +166,7 @@ class TestExecutorCallsMain:
             def main(**kwargs):
                 return {"success": True, "message": "no params", "kwargs": kwargs}
         """)
-        server = _make_server()
-        executor = _extract_executor(server)
-        result = executor(str(script), {})
+        result = self._run(script, {})
         assert result["success"] is True
         assert result["kwargs"] == {}
 
@@ -118,9 +175,7 @@ class TestExecutorCallsMain:
             def main(**kwargs):
                 return {"success": True, "message": "sphere created", "context": {"name": "pSphere1"}}
         """)
-        server = _make_server()
-        executor = _extract_executor(server)
-        result = executor(str(script), {})
+        result = self._run(script, {})
         assert result["message"] == "sphere created"
         assert result["context"]["name"] == "pSphere1"
 
@@ -133,9 +188,7 @@ class TestExecutorCallsMain:
             def main(radius: float = 1.0, **kwargs):
                 return skill_success("Created", radius=radius)
         """)
-        server = _make_server()
-        executor = _extract_executor(server)
-        result = executor(str(script), {"radius": 3.0})
+        result = self._run(script, {"radius": 3.0})
         assert result["success"] is True
         assert result["context"]["radius"] == 3.0
 
@@ -147,30 +200,17 @@ class TestExecutorCallsMain:
             def main(**kwargs):
                 return {"success": True, "message": "works", "val": _computed}
         """)
-        server = _make_server()
-        executor = _extract_executor(server)
-        result = executor(str(script), {})
+        result = self._run(script, {})
         assert result["val"] == 42
 
-
-# ---------------------------------------------------------------------------
-# 3. Error handling
-# ---------------------------------------------------------------------------
-
-
-class TestExecutorErrorHandling:
     def test_missing_main_returns_error(self, tmp_skill):
         script = tmp_skill("x = 1  # no main() defined\n")
-        server = _make_server()
-        executor = _extract_executor(server)
-        result = executor(str(script), {})
+        result = self._run(script, {})
         assert result["success"] is False
         assert "main()" in result["message"]
 
     def test_nonexistent_script_returns_error(self):
-        server = _make_server()
-        executor = _extract_executor(server)
-        result = executor("/nonexistent/path/skill.py", {})
+        result = self._run("/nonexistent/path/skill.py", {})
         assert result["success"] is False
 
     def test_main_raises_exception_returns_error(self, tmp_skill):
@@ -178,18 +218,14 @@ class TestExecutorErrorHandling:
             def main(**kwargs):
                 raise ValueError("boom")
         """)
-        server = _make_server()
-        executor = _extract_executor(server)
-        result = executor(str(script), {})
+        result = self._run(script, {})
         assert result["success"] is False
         assert "boom" in str(result.get("error", "") or result.get("message", ""))
 
     def test_loader_error_returns_error(self, tmp_skill):
         """SyntaxError in script body must return error, not raise."""
         script = tmp_skill("def main(**kwargs\n    pass\n")  # syntax error
-        server = _make_server()
-        executor = _extract_executor(server)
-        result = executor(str(script), {})
+        result = self._run(script, {})
         assert result["success"] is False
 
     def test_systemexit_in_main_is_handled(self, tmp_skill):
@@ -199,10 +235,7 @@ class TestExecutorErrorHandling:
             def main(**kwargs):
                 sys.exit(0)
         """)
-        server = _make_server()
-        executor = _extract_executor(server)
-        result = executor(str(script), {})
-        # Returns a safe fallback, does NOT raise SystemExit
+        result = self._run(script, {})
         assert isinstance(result, dict)
 
     def test_mcp_result_attribute_honoured(self, tmp_skill):
@@ -210,7 +243,83 @@ class TestExecutorErrorHandling:
         script = tmp_skill("""\
             __mcp_result__ = {"success": True, "message": "pre-computed"}
         """)
-        server = _make_server()
-        executor = _extract_executor(server)
-        result = executor(str(script), {})
+        result = self._run(script, {})
         assert result["message"] == "pre-computed"
+
+
+# ---------------------------------------------------------------------------
+# 3. _execute_in_process — dispatcher routing integration
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteInProcess:
+    def test_runs_directly_without_dispatcher(self, tmp_skill):
+        """Without a dispatcher, scripts run on the calling thread directly."""
+        script = tmp_skill("def main(**kwargs):\n    return {'success': True, 'message': 'direct'}\n")
+        server = _make_server()
+        result = server._execute_in_process(str(script), {}, "test__action")
+        assert result["success"] is True
+        assert result["message"] == "direct"
+
+    def test_routes_through_dispatcher_when_attached(self, tmp_skill):
+        """With a MayaUiDispatcher attached, submit_callable must be called."""
+        script = tmp_skill("def main(**kwargs):\n    return {'success': True, 'message': 'dispatched'}\n")
+        server = _make_server(with_dispatcher=True)
+        result = server._execute_in_process(str(script), {}, "test__action")
+        # Dispatcher was consulted
+        server._maya_dispatcher.submit_callable.assert_called_once()
+        assert result["success"] is True
+
+    def test_dispatcher_failure_returns_error(self, tmp_skill):
+        """If the dispatcher returns success=False, _execute_in_process wraps it."""
+        script = tmp_skill("def main(**kwargs):\n    return {}\n")
+        server = _make_server()
+        dispatcher = MagicMock()
+        dispatcher.submit_callable.return_value = {
+            "success": False,
+            "output": None,
+            "error": "Interrupted",
+        }
+        server._maya_dispatcher = dispatcher
+        result = server._execute_in_process(str(script), {}, "test__action")
+        assert result["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# 4. Dynamic load_skill auto-registers handlers (issue #122 regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicLoadSkill:
+    def test_load_skill_registers_handlers(self, tmp_skill):
+        """load_skill() must register in-process handlers after inner load returns actions."""
+        script = tmp_skill("def main(**kwargs):\n    return {'success': True}\n")
+        server = _make_server()
+
+        # Simulate inner server.load_skill() returning action names
+        action_names = ["my_skill__action"]
+        server._server.load_skill = MagicMock(return_value=action_names)
+        server._server.registry.get_action.return_value = {
+            "name": "my_skill__action",
+            "source_file": str(script),
+            "enabled": True,
+        }
+
+        result = server.load_skill("my-skill")
+        assert result is True  # DccServerBase returns bool
+        server._server.register_handler.assert_called_once()
+
+    def test_load_skill_empty_result_no_handlers(self):
+        """load_skill() with no actions returned must not call register_handler."""
+        server = _make_server()
+        server._server.load_skill = MagicMock(return_value=[])
+        result = server.load_skill("empty-skill")
+        assert result is True
+        server._server.register_handler.assert_not_called()
+
+    def test_load_skill_exception_returns_false(self):
+        """load_skill() must return False and not raise when inner load fails."""
+        server = _make_server()
+        server._server.load_skill = MagicMock(side_effect=ValueError("not found"))
+        result = server.load_skill("missing-skill")
+        assert result is False


### PR DESCRIPTION
## Summary

- **Root cause**: `McpHttpServer.catalog` now returns a plain string in dcc-mcp-core 0.14.x — `SkillCatalog.set_in_process_executor` is no longer accessible, so the in-process executor silently fell through to subprocess execution. Maya skills launched as subprocesses have no access to the live Maya session, breaking all `maya.cmds` calls.
- **Fix**: Replace `catalog.set_in_process_executor` with `McpHttpServer.register_handler(action_name, handler)` (the correct 0.14.x API), registering an in-process Python callable for each loaded skill action.
- **Dynamic skills**: Override `load_skill()` so skills activated at runtime (via the `load_skill` MCP tool) also get in-process handlers, not just startup skills.
- **Core dispatcher integration**: Re-export `PyPumpedDispatcher` / `PyStandaloneDispatcher` from dcc-mcp-core 0.14.14; add `create_pumped_dispatcher()` + `_CorePump` for IPC-style string-payload dispatch alongside the existing `MayaUiDispatcher`.

## Key changes

| File | What changed |
|------|-------------|
| `server.py` | `_wire_in_process_executor` → `register_handler`-based; new `_register_inprocess_handlers`, `_execute_in_process`, `_run_skill_script`; override `load_skill` |
| `dispatcher.py` | Re-export `PyPumpedDispatcher` / `PyStandaloneDispatcher`; add `create_pumped_dispatcher()` + `_CorePump` |
| `__init__.py` | Export new dispatcher symbols |
| `pyproject.toml` | Bump `dcc-mcp-core>=0.14.14` |
| `tests/test_skills_round46.py` | Rewrite to cover new register_handler API, `_run_skill_script`, dispatcher routing, dynamic `load_skill` |

## Test plan

- [x] All 451 existing tests pass (`python -m pytest tests/`)
- [x] `test_skills_round46.py` fully rewritten: 23 tests covering registration, script execution, dispatcher routing, and dynamic load
- [x] `ruff check` passes with no issues

Closes #122
