### PR TITLE
fix(pyexec): auto-correct DCC_MCP_PYTHON_EXECUTABLE when set to a GUI binary

### DIFF
--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -243,6 +243,15 @@ def _export_worker_env() -> None:
         "DCC_MCP_PYTHON_INIT_SNIPPET",
         "import maya.standalone; maya.standalone.initialize(name='python')",
     )
+    # Issue #125 — auto-correct DCC_MCP_PYTHON_EXECUTABLE if it points at maya.exe
+    # (GUI) instead of mayapy.exe (headless).  Idempotent; no-op when the env
+    # var already points at a Python interpreter or when core < 0.14.17.
+    try:
+        from dcc_mcp_maya._pyexec import auto_correct as _auto_correct_pyexec  # noqa: PLC0415
+
+        _auto_correct_pyexec()
+    except Exception as exc:  # noqa: BLE001 — never block plugin load
+        logger.debug("DCC_MCP_PYTHON_EXECUTABLE auto-correct skipped: %s", exc)
     logger.debug(
         "Subprocess fallback env set: DCC_MCP_PYTHON_EXECUTABLE=%s",
         os.environ["DCC_MCP_PYTHON_EXECUTABLE"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "dcc-mcp-core>=0.14.14,<1.0.0",
+    "dcc-mcp-core>=0.14.17,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_maya/_pyexec.py
+++ b/src/dcc_mcp_maya/_pyexec.py
@@ -1,0 +1,97 @@
+"""Auto-correct ``DCC_MCP_PYTHON_EXECUTABLE`` when it points at a DCC GUI binary.
+
+Issue #125: when a user sets ``DCC_MCP_PYTHON_EXECUTABLE=/path/to/maya.exe``
+(a reasonable first guess), the core subprocess executor correctly refuses to
+spawn a GUI process — but the failure mode is a hard error rather than a quiet
+fix.  ``dcc-mcp-core`` 0.14.17 added :func:`correct_python_executable` and
+:func:`is_gui_executable` exactly to support this kind of host-side
+auto-correction.
+
+This module wraps both helpers behind a single ``auto_correct()`` entry point
+that is safe to call repeatedly (idempotent) and on any platform — when the
+helpers are unavailable (older core), it falls back to the previous behaviour
+of leaving the env var untouched.
+"""
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+ENV_VAR = "DCC_MCP_PYTHON_EXECUTABLE"
+
+
+def _try_import_helpers():
+    """Lazy-import the core helpers; return ``(is_gui, correct)`` or ``(None, None)``.
+
+    Both helpers were added in ``dcc-mcp-core`` 0.14.17.  Older versions raise
+    :class:`ImportError`; we degrade silently in that case so the plugin keeps
+    working with the previous (manual) behaviour.
+    """
+    try:
+        from dcc_mcp_core import correct_python_executable, is_gui_executable  # noqa: PLC0415
+    except ImportError:
+        return None, None
+    return is_gui_executable, correct_python_executable
+
+
+def auto_correct(env_var: str = ENV_VAR) -> Optional[str]:
+    """Auto-correct ``env_var`` in :data:`os.environ` and return the new value.
+
+    Behaviour:
+
+    * If ``env_var`` is unset or empty → returns ``None`` (nothing to do).
+    * If the value points to a known DCC GUI binary (``maya.exe``, ``houdinifx``,
+      ``UnrealEditor`` …) **and** a headless-Python sibling is found on disk
+      → the env var is rewritten to that sibling path and the new value is
+      returned.
+    * If the value already points to a Python interpreter (``mayapy``, ``python``,
+      ``hython`` …) → returns the unchanged value.
+    * If the core helpers are unavailable (older core) → returns the unchanged
+      value untouched.
+
+    Always idempotent: a second call after a successful correction is a no-op.
+    """
+    raw = os.environ.get(env_var, "").strip()
+    if not raw:
+        return None
+
+    is_gui, correct = _try_import_helpers()
+    if correct is None or is_gui is None:
+        return raw
+
+    # Only rewrite when the value is **actually** a known DCC GUI binary; that
+    # way arbitrary user-supplied Python paths (with non-canonical slashes,
+    # spaces, etc.) are preserved verbatim.
+    if not is_gui(raw):
+        return raw
+
+    # Core may return a ``pathlib.Path``; coerce to plain ``str`` for the env.
+    fixed_raw = correct(raw)
+    fixed = str(fixed_raw) if fixed_raw is not None else ""
+    if fixed and fixed != raw:
+        os.environ[env_var] = fixed
+        logger.warning(
+            "%s pointed at a GUI executable (%s); auto-corrected to %s. "
+            "Set the env var to the headless Python interpreter to silence this warning.",
+            env_var,
+            raw,
+            fixed,
+        )
+        return fixed
+
+    # GUI binary with no headless sibling found — surface a warning so the user
+    # understands the upcoming subprocess-executor failure.
+    logger.warning(
+        "%s=%s is a DCC GUI executable and no headless Python sibling was "
+        "found.  The skill subprocess executor will refuse to spawn it; "
+        "set %s to the matching headless interpreter (e.g. mayapy.exe).",
+        env_var,
+        raw,
+        env_var,
+    )
+    return raw

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -860,6 +860,10 @@ def start_server(
         if w:
             dcc_window_title = w
 
+    # Issue #125 — fix DCC_MCP_PYTHON_EXECUTABLE if it points at a GUI binary.
+    from dcc_mcp_maya._pyexec import auto_correct as _auto_correct_pyexec  # noqa: PLC0415
+    _auto_correct_pyexec()
+
     if register_builtins:
         # Create server instance and call register_builtin_actions with minimal
         with _server_lock:

--- a/tests/test_pyexec_autocorrect.py
+++ b/tests/test_pyexec_autocorrect.py
@@ -1,0 +1,138 @@
+"""Tests for ``dcc_mcp_maya._pyexec.auto_correct`` (issue #125).
+
+Validates that ``DCC_MCP_PYTHON_EXECUTABLE`` is auto-corrected when the user
+sets it to a DCC GUI binary instead of the headless Python sibling.
+
+See: https://github.com/loonghao/dcc-mcp-maya/issues/125
+"""
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+import os
+import sys
+from unittest.mock import patch
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_maya import _pyexec
+
+
+class TestAutoCorrect:
+    """Tests for the ``auto_correct`` helper."""
+
+    def test_returns_none_when_unset(self):
+        """No env var → no work to do, returns None."""
+        env = os.environ.copy()
+        env.pop(_pyexec.ENV_VAR, None)
+        with patch.dict(os.environ, env, clear=True):
+            assert _pyexec.auto_correct() is None
+            assert _pyexec.ENV_VAR not in os.environ
+
+    def test_returns_none_when_blank(self):
+        """Blank env var is treated as unset."""
+        with patch.dict(os.environ, {_pyexec.ENV_VAR: "   "}, clear=False):
+            assert _pyexec.auto_correct() is None
+
+    def test_python_interpreter_unchanged(self):
+        """A real Python interpreter must be left untouched."""
+        with patch.dict(os.environ, {_pyexec.ENV_VAR: sys.executable}, clear=False):
+            assert _pyexec.auto_correct() == sys.executable
+            assert os.environ[_pyexec.ENV_VAR] == sys.executable
+
+    def test_corrects_when_helper_returns_sibling(self):
+        """When the core helper finds a sibling, env var is rewritten and returned."""
+        original = "C:/Program Files/Autodesk/Maya2025/bin/maya.exe"
+        sibling = "C:/Program Files/Autodesk/Maya2025/bin/mayapy.exe"
+
+        def fake_correct(p):
+            return sibling if p == original else p
+
+        def fake_is_gui(p):
+            return p == original
+
+        with patch.object(_pyexec, "_try_import_helpers", return_value=(fake_is_gui, fake_correct)):
+            with patch.dict(os.environ, {_pyexec.ENV_VAR: original}, clear=False):
+                assert _pyexec.auto_correct() == sibling
+                assert os.environ[_pyexec.ENV_VAR] == sibling
+
+    def test_idempotent(self):
+        """A second call after correction is a no-op."""
+        sibling = "C:/Program Files/Autodesk/Maya2025/bin/mayapy.exe"
+
+        def fake_correct(p):
+            return p  # already a python interpreter
+
+        def fake_is_gui(p):
+            return False
+
+        with patch.object(_pyexec, "_try_import_helpers", return_value=(fake_is_gui, fake_correct)):
+            with patch.dict(os.environ, {_pyexec.ENV_VAR: sibling}, clear=False):
+                first = _pyexec.auto_correct()
+                second = _pyexec.auto_correct()
+                assert first == second == sibling
+                assert os.environ[_pyexec.ENV_VAR] == sibling
+
+    def test_warns_when_gui_with_no_sibling(self, caplog):
+        """If the helper returns the value unchanged but flags it as a GUI binary,
+        a warning is emitted so the user understands the upcoming subprocess
+        failure."""
+        gui = "C:/some/orphan/maya.exe"
+
+        def fake_correct(p):
+            return p
+
+        def fake_is_gui(p):
+            return True
+
+        with patch.object(_pyexec, "_try_import_helpers", return_value=(fake_is_gui, fake_correct)):
+            with patch.dict(os.environ, {_pyexec.ENV_VAR: gui}, clear=False):
+                with caplog.at_level(logging.WARNING, logger=_pyexec.__name__):
+                    assert _pyexec.auto_correct() == gui
+                # Match either a true correction warning or the no-sibling warning.
+                assert any("GUI executable" in m or "headless" in m for m in caplog.messages)
+
+    def test_no_op_when_helpers_unavailable(self):
+        """Older core (no helpers) → leave env var untouched, return as-is."""
+        original = "anything-at-all"
+        with patch.object(_pyexec, "_try_import_helpers", return_value=(None, None)):
+            with patch.dict(os.environ, {_pyexec.ENV_VAR: original}, clear=False):
+                assert _pyexec.auto_correct() == original
+                assert os.environ[_pyexec.ENV_VAR] == original
+
+    def test_non_gui_path_preserved_verbatim(self):
+        """Arbitrary user-supplied paths must not be normalised or rewritten."""
+        original = "/custom/mayapy"  # forward slashes, no GUI binary
+
+        def fake_correct(p):
+            return "\\custom\\mayapy"  # core normalises slashes — must be ignored
+
+        def fake_is_gui(p):
+            return False
+
+        with patch.object(_pyexec, "_try_import_helpers", return_value=(fake_is_gui, fake_correct)):
+            with patch.dict(os.environ, {_pyexec.ENV_VAR: original}, clear=False):
+                assert _pyexec.auto_correct() == original
+                assert os.environ[_pyexec.ENV_VAR] == original
+
+    def test_real_helpers_importable(self):
+        """Smoke test against the actual core helpers (requires core>=0.14.17)."""
+        is_gui, correct = _pyexec._try_import_helpers()
+        # If core is too old, both are None — that's still acceptable.
+        if correct is None:
+            pytest.skip("dcc-mcp-core < 0.14.17 — helpers unavailable")
+        assert callable(is_gui)
+        assert callable(correct)
+        # A python interpreter must round-trip unchanged (allow Path return).
+        assert os.fspath(correct(sys.executable)) == sys.executable
+
+    def test_custom_env_var_name(self):
+        """The helper accepts a custom env-var name for forward compatibility."""
+        custom_name = "TEST_PYEXEC_AUTOCORRECT"
+        env = os.environ.copy()
+        env.pop(custom_name, None)
+        with patch.dict(os.environ, env, clear=True):
+            assert _pyexec.auto_correct(custom_name) is None

--- a/tests/test_skills_round33.py
+++ b/tests/test_skills_round33.py
@@ -384,39 +384,16 @@ class TestBoundingBoxFromNode:
 
 
 # ---------------------------------------------------------------------------
-# server.py line 164 — registry property when _server has no _registry attr
+# server.py — registry property forwards to the underlying skill client.
+# (DccServerBase.registry was decomposed in dcc-mcp-core 0.14.17 and now
+# delegates to ``_skill_client.registry`` instead of ``_server._registry``.)
 # ---------------------------------------------------------------------------
 
 
 class TestServerRegistryProperty:
-    """Cover the registry property fallback (server.py line 164)."""
+    """Cover the inherited ``registry`` property after the core decomposition."""
 
-    def test_registry_returns_none_when_no_internal_registry(self):
-        """When _server has no _registry attr, registry property returns None."""
-        import importlib
-
-        for mod in list(sys.modules):
-            if "dcc_mcp_maya" in mod:
-                del sys.modules[mod]
-
-        mock_maya = MagicMock()
-        modules = {
-            "maya": mock_maya,
-            "maya.cmds": MagicMock(),
-            "maya.mel": MagicMock(),
-            "maya.utils": MagicMock(),
-        }
-        with patch.dict(sys.modules, modules):
-            srv_mod2 = importlib.import_module("dcc_mcp_maya.server")
-            server = srv_mod2.MayaMcpServer(port=0)
-            # Replace the Rust McpHttpServer with a plain Python object that has no _registry
-            plain_obj = object()
-            server._server = plain_obj
-            result = server.registry
-            assert result is None
-
-    def test_registry_returns_registry_when_attr_exists(self):
-        """When _server has _registry, registry property returns it."""
+    def _import_server(self):
         import importlib
 
         for mod in list(sys.modules):
@@ -432,14 +409,22 @@ class TestServerRegistryProperty:
         }
         with patch.dict(sys.modules, modules):
             srv_mod = importlib.import_module("dcc_mcp_maya.server")
-            server = srv_mod.MayaMcpServer(port=0)
-            # Replace Rust object with a simple namespace that has _registry
-            fake_registry = MagicMock()
+            return srv_mod.MayaMcpServer(port=0)
 
-            server._server = MagicMock()
-            server._server.registry = fake_registry
-            result = server.registry
-            assert result is fake_registry
+    def test_registry_forwards_to_skill_client(self):
+        """``server.registry`` returns whatever ``_skill_client.registry`` returns."""
+        server = self._import_server()
+        fake_registry = MagicMock(name="fake_registry")
+        server._skill_client = MagicMock()
+        server._skill_client.registry = fake_registry
+        assert server.registry is fake_registry
+
+    def test_registry_returns_none_when_skill_client_has_none(self):
+        """When the skill client exposes no registry, the property returns None."""
+        server = self._import_server()
+        server._skill_client = MagicMock()
+        server._skill_client.registry = None
+        assert server.registry is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #125.

## Summary

When users set `DCC_MCP_PYTHON_EXECUTABLE=/path/to/maya.exe` (the GUI binary, a reasonable first guess), the core subprocess executor correctly refuses to spawn a GUI process — but the failure mode is a hard error rather than a quiet fix. `dcc-mcp-core` 0.14.17 added the public helpers `is_gui_executable` and `correct_python_executable` exactly to support host-side auto-correction.

## Changes

- **New private module `dcc_mcp_maya._pyexec`** exposes `auto_correct()` that wraps both helpers behind an idempotent, safe-on-old-core entry point. When the value points at a known DCC GUI binary and a headless Python sibling is found on disk, the env var is rewritten and a single warning is logged. Non-GUI paths are preserved verbatim (no slash normalisation).
- **`server.start_server()`** invokes `auto_correct()` early so the fix applies in standalone / mayapy contexts as well.
- **The Maya plugin's `_export_worker_env()`** invokes the same helper after `setdefault` so an explicit user override pointing at `maya.exe` is corrected before any subprocess is spawned.
- **`pyproject.toml`** bumps the core dependency to `>=0.14.17,<1.0.0` so the new helpers are available.
- **`tests/test_pyexec_autocorrect.py`** covers the full matrix: unset / blank, real interpreter unchanged, GUI → sibling rewrite, idempotency, no-sibling warning, helpers-unavailable fallback, and the smoke check against the real core helpers.
- **`tests/test_skills_round33.py`** updates the `registry` property test to forward to `_skill_client.registry` after the core decomposition (EPIC #495 / sub-issue #486).

## Acceptance Criteria (from #125)

- [x] `dcc-mcp-maya` auto-corrects `maya.exe` → `mayapy.exe`
- [x] Warning message suggests the correct executable name when no sibling is found
- [x] Tests for the auto-correction logic

## Verification

```
$ pytest tests/ --ignore=tests/e2e --ignore=tests/integration
423 passed, 2 skipped, 68 deselected, 1 xfailed, 1 xpassed in 2.60s
$ ruff check src/dcc_mcp_maya/_pyexec.py tests/test_pyexec_autocorrect.py
All checks passed!
```


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author