### PR TITLE
fix(plugin): robust cleanup in uninitializePlugin + stale instance warning

### DIFF
--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -171,21 +171,43 @@ def initializePlugin(plugin):
         if _is_interactive():
             _add_menu()
         _start()
+        # Issue #126 — surface a single warning when the FileRegistry has
+        # accumulated stale entries from previous Maya crashes.  Best-effort,
+        # never blocks startup.
+        try:
+            from dcc_mcp_maya._stale_cleanup import warn_if_too_many_stale  # noqa: PLC0415
+
+            warn_if_too_many_stale(
+                registry_dir=os.environ.get("DCC_MCP_REGISTRY_DIR") or None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("stale-instance scan skipped: %s", exc)
     except Exception as exc:
         logger.error("dcc-mcp-maya plugin failed to initialize: %s", exc)
         raise RuntimeError(f"dcc-mcp-maya init failed: {exc}") from exc
 
 
 def uninitializePlugin(plugin):
-    """Called by Maya when the plugin is unloaded."""
+    """Called by Maya when the plugin is unloaded.
+
+    Issue #126 — every cleanup step runs even when an earlier one raises so
+    the FileRegistry entry is always released.  ``_stop_blocking()`` is
+    invoked from a ``finally`` block so a menu-removal failure (e.g. partial
+    UI shutdown) cannot leak the running server.
+    """
     om.MFnPlugin(plugin)
     try:
-        _stop_blocking()
         if _is_interactive():
-            _remove_menu()
+            try:
+                _remove_menu()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("dcc-mcp-maya menu removal error: %s", exc)
+    finally:
+        try:
+            _stop_blocking()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("dcc-mcp-maya server stop error: %s", exc)
         logger.info("dcc-mcp-maya plugin unloaded")
-    except Exception as exc:
-        logger.warning("dcc-mcp-maya cleanup error: %s", exc)
 
 
 # ── server helpers ────────────────────────────────────────────────────────────

--- a/src/dcc_mcp_maya/_pyexec.py
+++ b/src/dcc_mcp_maya/_pyexec.py
@@ -12,6 +12,7 @@ that is safe to call repeatedly (idempotent) and on any platform — when the
 helpers are unavailable (older core), it falls back to the previous behaviour
 of leaving the env var untouched.
 """
+
 # Import future modules
 from __future__ import annotations
 

--- a/src/dcc_mcp_maya/_stale_cleanup.py
+++ b/src/dcc_mcp_maya/_stale_cleanup.py
@@ -1,0 +1,152 @@
+"""Stale-instance detection and best-effort cleanup helpers.
+
+Issue #126: when Maya crashes (or is killed via Task Manager), the
+``FileRegistry`` entry for the MCP server instance is not removed.  Over
+time this accumulates "stale" instances that show up in gateway logs
+(``Gateway: evicted 43 stale instance(s)``).
+
+``dcc-mcp-core`` 0.14.17 added Rust-side auto-eviction
+(``FileRegistry::read_alive``); this module adds a Python-side complement
+that runs at plugin start-up so users see a single clear warning instead
+of a slow accumulation.
+
+The helpers here are intentionally side-effect-free: they only **read**
+the on-disk registry and emit log messages.  Removal of stale entries is
+left to the Rust core (which handles atomic file locking) so two
+host-side helpers cannot race each other.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+REGISTRY_SUBDIR = "dcc-mcp-registry"
+REGISTRY_FILE = "services.json"
+DEFAULT_STALE_THRESHOLD = 10
+
+
+def registry_path(registry_dir: Optional[str] = None) -> Path:
+    """Return the absolute path of the FileRegistry ``services.json``.
+
+    Resolution order matches the Rust core:
+
+    1. Explicit ``registry_dir`` argument (treated as the parent of
+       ``dcc-mcp-registry/``).
+    2. ``DCC_MCP_REGISTRY_DIR`` environment variable.
+    3. The OS temp directory (``tempfile.gettempdir()``).
+    """
+    base = registry_dir or os.environ.get("DCC_MCP_REGISTRY_DIR") or tempfile.gettempdir()
+    return Path(base) / REGISTRY_SUBDIR / REGISTRY_FILE
+
+
+def _pid_alive(pid: int) -> bool:
+    """Cross-platform liveness check for a process id.
+
+    Returns ``True`` when the process is currently running, ``False``
+    when it has exited.  Uses :func:`os.kill` with signal ``0`` on POSIX
+    and ``OpenProcess`` on Windows; both are non-destructive.
+    """
+    if pid <= 0:
+        return False
+    if sys.platform == "win32":
+        try:
+            import ctypes
+            from ctypes import wintypes
+
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            STILL_ACTIVE = 259
+            kernel32 = ctypes.windll.kernel32
+            handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+            if not handle:
+                return False
+            try:
+                exit_code = wintypes.DWORD()
+                if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                    return False
+                return exit_code.value == STILL_ACTIVE
+            finally:
+                kernel32.CloseHandle(handle)
+        except Exception:
+            return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # The process exists; we just can't signal it.
+        return True
+    except OSError:
+        return False
+
+
+def count_stale_entries(registry_dir: Optional[str] = None) -> Tuple[int, int]:
+    """Return ``(alive_count, stale_count)`` for the on-disk registry.
+
+    A "stale" entry is one whose ``pid`` no longer corresponds to a
+    running process.  When the registry file is missing or unparseable
+    the function returns ``(0, 0)`` — callers treat absence as the same
+    as "no stale entries".
+    """
+    path = registry_path(registry_dir)
+    if not path.is_file():
+        return 0, 0
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return 0, 0
+    if not isinstance(data, list):
+        return 0, 0
+
+    alive = 0
+    stale = 0
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        pid = entry.get("pid")
+        if not isinstance(pid, int):
+            continue
+        if _pid_alive(pid):
+            alive += 1
+        else:
+            stale += 1
+    return alive, stale
+
+
+def warn_if_too_many_stale(
+    threshold: int = DEFAULT_STALE_THRESHOLD,
+    registry_dir: Optional[str] = None,
+) -> int:
+    """Log a single ``WARNING`` when ``stale_count > threshold``; return ``stale_count``.
+
+    Returns ``0`` and logs nothing when the registry is missing,
+    unparseable, or below the threshold.  Always best-effort — never
+    raises so it is safe to call from plugin start-up code paths.
+    """
+    try:
+        alive, stale = count_stale_entries(registry_dir)
+    except Exception as exc:  # noqa: BLE001 — never block plugin startup
+        logger.debug("stale-instance scan skipped: %s", exc)
+        return 0
+    if stale > threshold:
+        logger.warning(
+            "FileRegistry contains %d stale Maya instance(s) (alive=%d, threshold=%d). "
+            "These will be auto-evicted by dcc-mcp-core 0.14.17+ on the next gateway "
+            "scan; if the count keeps growing, check for crashed Maya processes or "
+            "remove the registry manually: %s",
+            stale,
+            alive,
+            threshold,
+            registry_path(registry_dir),
+        )
+    return stale

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -862,6 +862,7 @@ def start_server(
 
     # Issue #125 — fix DCC_MCP_PYTHON_EXECUTABLE if it points at a GUI binary.
     from dcc_mcp_maya._pyexec import auto_correct as _auto_correct_pyexec  # noqa: PLC0415
+
     _auto_correct_pyexec()
 
     if register_builtins:

--- a/tests/test_plugin_uninit_cleanup.py
+++ b/tests/test_plugin_uninit_cleanup.py
@@ -1,0 +1,114 @@
+"""Tests for ``uninitializePlugin`` cleanup robustness (issue #126).
+
+Verifies that ``_stop_blocking()`` is always invoked from the ``finally``
+block — even when an earlier cleanup step raises — so the FileRegistry
+entry is never leaked on partial shutdowns.
+
+See: https://github.com/loonghao/dcc-mcp-maya/issues/126
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Import third-party modules
+import pytest
+
+
+def _load_plugin_module():
+    """Load the Maya plugin file as a module with ``maya.*`` mocked."""
+    plugin_path = Path(__file__).resolve().parents[1] / "maya" / "plugin" / "dcc_mcp_maya_plugin.py"
+    assert plugin_path.is_file(), plugin_path
+
+    fake_maya = MagicMock(name="maya")
+    fake_cmds = MagicMock(name="maya.cmds")
+    fake_om = MagicMock(name="maya.api.OpenMaya")
+    fake_om.MFnPlugin = MagicMock(return_value=MagicMock())
+    modules = {
+        "maya": fake_maya,
+        "maya.cmds": fake_cmds,
+        "maya.api": MagicMock(),
+        "maya.api.OpenMaya": fake_om,
+        "maya.utils": MagicMock(),
+    }
+    with patch.dict(sys.modules, modules):
+        spec = importlib.util.spec_from_file_location("_dcc_mcp_maya_plugin_under_test", plugin_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module, fake_om
+
+
+@pytest.fixture()
+def plugin_module():
+    module, fake_om = _load_plugin_module()
+    yield module, fake_om
+    sys.modules.pop("_dcc_mcp_maya_plugin_under_test", None)
+
+
+class TestUninitializePluginCleanup:
+    """Cleanup must always release the server, even on partial failures."""
+
+    def test_stop_called_even_when_menu_removal_raises(self, plugin_module):
+        module, _ = plugin_module
+        with patch.object(module, "_is_interactive", return_value=True), patch.object(
+            module, "_remove_menu", side_effect=RuntimeError("ui kaboom")
+        ) as remove_menu, patch.object(module, "_stop_blocking") as stop_blocking:
+            module.uninitializePlugin(plugin=MagicMock())
+        remove_menu.assert_called_once()
+        stop_blocking.assert_called_once()
+
+    def test_stop_called_when_menu_removal_succeeds(self, plugin_module):
+        module, _ = plugin_module
+        with patch.object(module, "_is_interactive", return_value=True), patch.object(
+            module, "_remove_menu"
+        ) as remove_menu, patch.object(module, "_stop_blocking") as stop_blocking:
+            module.uninitializePlugin(plugin=MagicMock())
+        remove_menu.assert_called_once()
+        stop_blocking.assert_called_once()
+
+    def test_stop_called_in_batch_mode(self, plugin_module):
+        """Non-interactive (mayapy / batch) → no menu, but still stop the server."""
+        module, _ = plugin_module
+        with patch.object(module, "_is_interactive", return_value=False), patch.object(
+            module, "_remove_menu"
+        ) as remove_menu, patch.object(module, "_stop_blocking") as stop_blocking:
+            module.uninitializePlugin(plugin=MagicMock())
+        remove_menu.assert_not_called()
+        stop_blocking.assert_called_once()
+
+    def test_stop_failure_is_swallowed(self, plugin_module):
+        """A stop_blocking failure must not bubble out of uninitializePlugin."""
+        module, _ = plugin_module
+        with patch.object(module, "_is_interactive", return_value=False), patch.object(
+            module, "_stop_blocking", side_effect=RuntimeError("server kaboom")
+        ) as stop_blocking:
+            # Must not raise.
+            module.uninitializePlugin(plugin=MagicMock())
+        stop_blocking.assert_called_once()
+
+
+class TestInitializePluginStaleScan:
+    """At startup, plugin best-effort warns about pre-existing stale entries."""
+
+    def test_stale_scan_invoked_after_start(self, plugin_module):
+        module, _ = plugin_module
+        with patch.object(module, "_is_interactive", return_value=False), patch.object(module, "_start") as start:
+            with patch("dcc_mcp_maya._stale_cleanup.warn_if_too_many_stale") as warn:
+                module.initializePlugin(plugin=MagicMock())
+        start.assert_called_once()
+        warn.assert_called_once()
+
+    def test_stale_scan_failure_does_not_break_init(self, plugin_module):
+        module, _ = plugin_module
+        with patch.object(module, "_is_interactive", return_value=False), patch.object(module, "_start"):
+            with patch(
+                "dcc_mcp_maya._stale_cleanup.warn_if_too_many_stale",
+                side_effect=RuntimeError("scan boom"),
+            ):
+                # Must not raise.
+                module.initializePlugin(plugin=MagicMock())

--- a/tests/test_pyexec_autocorrect.py
+++ b/tests/test_pyexec_autocorrect.py
@@ -5,6 +5,7 @@ sets it to a DCC GUI binary instead of the headless Python sibling.
 
 See: https://github.com/loonghao/dcc-mcp-maya/issues/125
 """
+
 # Import future modules
 from __future__ import annotations
 

--- a/tests/test_stale_cleanup.py
+++ b/tests/test_stale_cleanup.py
@@ -1,0 +1,142 @@
+"""Tests for ``dcc_mcp_maya._stale_cleanup`` (issue #126).
+
+Validates the host-side stale FileRegistry detection and warning helper.
+
+See: https://github.com/loonghao/dcc-mcp-maya/issues/126
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import logging
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_maya import _stale_cleanup
+
+
+@pytest.fixture()
+def registry(tmp_path: Path) -> Path:
+    """Return a writable registry path inside ``tmp_path``."""
+    target = tmp_path / _stale_cleanup.REGISTRY_SUBDIR / _stale_cleanup.REGISTRY_FILE
+    target.parent.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def _write_entries(path: Path, entries):
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+
+class TestRegistryPath:
+    """``registry_path`` resolution."""
+
+    def test_explicit_dir_takes_precedence(self, tmp_path):
+        result = _stale_cleanup.registry_path(str(tmp_path))
+        assert result == tmp_path / _stale_cleanup.REGISTRY_SUBDIR / _stale_cleanup.REGISTRY_FILE
+
+    def test_env_var_used_when_no_arg(self, tmp_path):
+        with patch.dict(os.environ, {"DCC_MCP_REGISTRY_DIR": str(tmp_path)}):
+            result = _stale_cleanup.registry_path()
+            assert result.parent.parent == tmp_path
+
+    def test_falls_back_to_tempdir(self):
+        env = os.environ.copy()
+        env.pop("DCC_MCP_REGISTRY_DIR", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = _stale_cleanup.registry_path()
+            assert result.name == _stale_cleanup.REGISTRY_FILE
+            assert result.parent.name == _stale_cleanup.REGISTRY_SUBDIR
+
+
+class TestPidAlive:
+    """``_pid_alive`` cross-platform liveness check."""
+
+    def test_current_pid_is_alive(self):
+        assert _stale_cleanup._pid_alive(os.getpid()) is True
+
+    def test_invalid_pid_is_dead(self):
+        assert _stale_cleanup._pid_alive(0) is False
+        assert _stale_cleanup._pid_alive(-1) is False
+
+    def test_definitely_dead_pid(self):
+        # 2**31 - 2 — far above any realistic PID; must report dead.
+        assert _stale_cleanup._pid_alive(2**31 - 2) is False
+
+
+class TestCountStaleEntries:
+    """``count_stale_entries`` reads JSON registry without mutating it."""
+
+    def test_missing_file_returns_zero(self, tmp_path):
+        alive, stale = _stale_cleanup.count_stale_entries(str(tmp_path))
+        assert (alive, stale) == (0, 0)
+
+    def test_unparseable_file_returns_zero(self, registry):
+        registry.write_text("{not-json", encoding="utf-8")
+        alive, stale = _stale_cleanup.count_stale_entries(str(registry.parent.parent))
+        assert (alive, stale) == (0, 0)
+
+    def test_non_list_payload_returns_zero(self, registry):
+        registry.write_text(json.dumps({"oops": True}), encoding="utf-8")
+        alive, stale = _stale_cleanup.count_stale_entries(str(registry.parent.parent))
+        assert (alive, stale) == (0, 0)
+
+    def test_mixed_alive_and_stale(self, registry):
+        _write_entries(
+            registry,
+            [
+                {"pid": os.getpid()},  # alive
+                {"pid": 2**31 - 2},  # stale
+                {"pid": 2**31 - 3},  # stale
+                {"pid": "not-an-int"},  # ignored
+                {"no_pid_at_all": True},  # ignored
+                "not a dict",  # ignored
+            ],
+        )
+        with patch.object(_stale_cleanup, "_pid_alive", side_effect=lambda p: p == os.getpid()):
+            alive, stale = _stale_cleanup.count_stale_entries(str(registry.parent.parent))
+        assert alive == 1
+        assert stale == 2
+
+    def test_empty_list(self, registry):
+        _write_entries(registry, [])
+        alive, stale = _stale_cleanup.count_stale_entries(str(registry.parent.parent))
+        assert (alive, stale) == (0, 0)
+
+
+class TestWarnIfTooManyStale:
+    """``warn_if_too_many_stale`` only warns above the threshold."""
+
+    def test_no_warning_below_threshold(self, registry, caplog):
+        _write_entries(registry, [{"pid": 2**31 - 2}] * 5)
+        with patch.object(_stale_cleanup, "_pid_alive", return_value=False):
+            with caplog.at_level(logging.WARNING, logger=_stale_cleanup.__name__):
+                stale = _stale_cleanup.warn_if_too_many_stale(threshold=10, registry_dir=str(registry.parent.parent))
+        assert stale == 5
+        assert caplog.messages == []
+
+    def test_warning_above_threshold(self, registry, caplog):
+        _write_entries(registry, [{"pid": 2**31 - 2 - i} for i in range(15)])
+        with patch.object(_stale_cleanup, "_pid_alive", return_value=False):
+            with caplog.at_level(logging.WARNING, logger=_stale_cleanup.__name__):
+                stale = _stale_cleanup.warn_if_too_many_stale(threshold=10, registry_dir=str(registry.parent.parent))
+        assert stale == 15
+        assert any("stale Maya instance" in m for m in caplog.messages)
+
+    def test_never_raises(self, tmp_path, caplog):
+        # Force count_stale_entries to raise; helper must swallow it.
+        with patch.object(_stale_cleanup, "count_stale_entries", side_effect=RuntimeError("boom")):
+            assert _stale_cleanup.warn_if_too_many_stale(registry_dir=str(tmp_path)) == 0
+
+    def test_real_pid_check_with_self(self, registry):
+        """Smoke test: own PID counts as alive, large PID as stale."""
+        _write_entries(registry, [{"pid": os.getpid()}, {"pid": 2**31 - 2}])
+        alive, stale = _stale_cleanup.count_stale_entries(str(registry.parent.parent))
+        assert alive == 1
+        assert stale == 1


### PR DESCRIPTION
Closes #126.

## Summary

Maya crashes (or kills via Task Manager) leak a `FileRegistry` entry because `uninitializePlugin()` is never reached. The previous implementation also wrapped *all* cleanup steps in a single `try/except` so a menu-removal failure could prevent the server stop, leaking the running server until the next gateway scan.

## Changes

- **`uninitializePlugin()`** is now structured as `try: remove_menu finally: stop_blocking` so the server is *always* released. Each step has its own narrow `except` that logs and swallows so partial failures never bubble out.
- **New private helper `dcc_mcp_maya._stale_cleanup`** provides `count_stale_entries()` and `warn_if_too_many_stale()` which read the `FileRegistry` `services.json` (without mutation) and emit a single WARNING when more than `threshold` entries (default 10) belong to dead PIDs. Liveness is checked cross-platform via `OpenProcess` on Windows and `os.kill(pid, 0)` on POSIX.
- **`initializePlugin()`** invokes `warn_if_too_many_stale()` after the server starts so users see one clear message instead of slow accumulation in gateway logs. Stale entries are removed by the Rust core's atomic `FileRegistry::read_alive` path (added in dcc-mcp-core 0.14.17, [#523](https://github.com/loonghao/dcc-mcp-core/issues/523)) — the host side stays read-only to avoid races with the gateway.
- Tests cover the full matrix: missing/unparseable registry, alive+stale mix, threshold gating, never-raises invariant, plus unit tests for the new `uninitializePlugin` ordering (menu removal failure must still trigger `_stop_blocking`).

## Acceptance Criteria (from #126)

- [x] `uninitializePlugin()` cleanup is robust against partial failures (try/finally)
- [x] Gateway PID-liveness check (handled in `dcc-mcp-core` 0.14.17 `FileRegistry::read_alive`)
- [x] Warning when stale instance count > threshold (default 10)
- [ ] CLI command for manual cleanup (out of scope here — belongs to `dcc-mcp-gateway`)

## Verification

```
$ pytest tests/test_stale_cleanup.py tests/test_plugin_uninit_cleanup.py tests/test_plugin_env_vars.py -q
26 passed in 0.10s
$ ruff check src/dcc_mcp_maya/_stale_cleanup.py tests/test_stale_cleanup.py tests/test_plugin_uninit_cleanup.py maya/plugin/dcc_mcp_maya_plugin.py
All checks passed!
```

## Note

This branch is based on `main` before #129 lands. After #129 merges, this PR will be rebased on the updated `main`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author