### PR TITLE
refactor(server): split MayaMcpServer per SRP into env / executor / loader / probe / transport modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,8 @@ def create_sphere(radius: float = 1.0) -> dict:
 ### Layer 3 — You Are a Core Developer
 *Goal: Modify the server, dispatcher, or plugin behavior.*
 
-- **src/dcc_mcp_maya/server.py** — `MayaMcpServer` (constructor, `register_builtin_actions`, `start`, `stop`, metrics, job persistence).
-- **src/dcc_mcp_maya/dispatcher.py** — `MayaUiDispatcher`, `MayaStandaloneDispatcher`, `MayaUiPump`, `check_maya_cancelled`.
+- **src/dcc_mcp_maya/server.py** — `MayaMcpServer` composition root (constructor, `register_builtin_actions`, `start`, `stop`, metrics, job persistence). Heavy lifting lives in private siblings: `_env`, `_executor`, `_skill_loader`, `_version_probe`, `_transport`, `_pyexec`, `_stale_cleanup`.
+- **src/dcc_mcp_maya/dispatcher/** — `MayaUiDispatcher`, `MayaStandaloneDispatcher`, `MayaUiPump`, `check_maya_cancelled` (split into `job` / `cancel` / `ui` / `standalone` / `pump` submodules — public symbols re-exported from the package).
 - **maya/plugin/dcc_mcp_maya_plugin.py** — Maya plugin entry point (`initializePlugin`, `uninitializePlugin`, menu, gateway auto-config).
 - **tests/** — 50+ unit tests, E2E tests (tahv/mayapy 2022–2025), multi-instance gateway tests.
 
@@ -162,8 +162,15 @@ A: `src/dcc_mcp_maya/skills/` (64 packages, ~370 scripts). Each package contains
 | `llms.txt` | Condensed AI reference (this project's "man page") |
 | `llms-full.txt` | Exhaustive API reference |
 | `src/dcc_mcp_maya/__init__.py` | Public API exports |
-| `src/dcc_mcp_maya/server.py` | `MayaMcpServer` — lifecycle, discovery, metrics, jobs |
-| `src/dcc_mcp_maya/dispatcher.py` | Thread-affinity dispatchers + cancellation |
+| `src/dcc_mcp_maya/server.py` | `MayaMcpServer` composition root — lifecycle, discovery, metrics, jobs |
+| `src/dcc_mcp_maya/_env.py` | `DCC_MCP_MAYA_*` env-var resolution helpers |
+| `src/dcc_mcp_maya/_executor.py` | In-process skill execution + handler registration |
+| `src/dcc_mcp_maya/_skill_loader.py` | Minimal-mode skill loading (constants + loaders) |
+| `src/dcc_mcp_maya/_version_probe.py` | Maya availability + version string detection |
+| `src/dcc_mcp_maya/_transport.py` | `TransportManager` wrappers (bind / find / rank) |
+| `src/dcc_mcp_maya/_pyexec.py` | Auto-correct `DCC_MCP_PYTHON_EXECUTABLE` (issue #125) |
+| `src/dcc_mcp_maya/_stale_cleanup.py` | Stale FileRegistry detection + warning (issue #126) |
+| `src/dcc_mcp_maya/dispatcher/` | Thread-affinity dispatchers + cancellation (directory module) |
 | `src/dcc_mcp_maya/api.py` | Skill authoring helpers |
 | `src/dcc_mcp_maya/plugin.py` | Maya plugin (`initializePlugin` / menu) |
 | `src/dcc_mcp_maya/skills/` | 64 built-in skill packages |

--- a/src/dcc_mcp_maya/_env.py
+++ b/src/dcc_mcp_maya/_env.py
@@ -1,0 +1,157 @@
+"""Environment-variable resolution for ``MayaMcpServer`` (issue #127).
+
+Centralises every ``DCC_MCP_MAYA_*`` env var used by the server so the
+composition root in :mod:`dcc_mcp_maya.server` stays a thin orchestrator.
+
+All helpers are pure functions: they read :data:`os.environ` and return
+plain Python values; they never mutate global state.
+
+See: https://github.com/loonghao/dcc-mcp-maya/issues/127
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Public env-var names ─────────────────────────────────────────────────────
+ENV_MINIMAL = "DCC_MCP_MAYA_MINIMAL"
+ENV_DEFAULT_TOOLS = "DCC_MCP_MAYA_DEFAULT_TOOLS"
+ENV_METRICS = "DCC_MCP_MAYA_METRICS"
+ENV_JOB_STORAGE = "DCC_MCP_MAYA_JOB_STORAGE"
+ENV_JOB_RECOVERY = "DCC_MCP_MAYA_JOB_RECOVERY"
+ENV_WINDOW_TITLE = "DCC_MCP_MAYA_WINDOW_TITLE"
+
+#: Default SQLite filename inside the platform data directory.
+DEFAULT_JOB_DB_FILENAME = "jobs.db"
+
+
+def resolve_minimal_flag(minimal: Optional[bool]) -> bool:
+    """Resolve the minimal-mode flag from argument and env var.
+
+    Priority order:
+
+    1. Explicit ``minimal`` argument (when not ``None``).
+    2. ``DCC_MCP_MAYA_MINIMAL`` env var: ``"0"`` → ``False``, anything
+       else (including ``"1"``) → ``True``.
+    3. Default: ``True``.
+    """
+    if minimal is not None:
+        return minimal
+    env_val = os.environ.get(ENV_MINIMAL)
+    if env_val is not None:
+        return env_val.strip() != "0"
+    return True
+
+
+def resolve_default_tools() -> Optional[Dict[str, List[str]]]:
+    """Parse ``DCC_MCP_MAYA_DEFAULT_TOOLS`` into a ``{skill: [groups]}`` map.
+
+    Format: comma-separated list of skill names.  When set, only the
+    listed skills are loaded at startup.  Returns ``None`` when the env
+    var is unset or empty.
+    """
+    raw = os.environ.get(ENV_DEFAULT_TOOLS)
+    if not raw:
+        return None
+    result: Dict[str, List[str]] = {}
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        result.setdefault(token, [])
+    return result
+
+
+def resolve_metrics_enabled(metrics_enabled: Optional[bool]) -> bool:
+    """Resolve the Prometheus ``/metrics`` endpoint flag.
+
+    Priority: explicit argument > ``DCC_MCP_MAYA_METRICS=1`` > ``False``.
+    """
+    if metrics_enabled is not None:
+        return bool(metrics_enabled)
+    return os.environ.get(ENV_METRICS, "").strip() == "1"
+
+
+def resolve_job_storage(job_storage_path: Optional[str]) -> Optional[str]:
+    """Resolve the SQLite job-storage path.
+
+    Returns ``None`` when callers should leave whatever path
+    :class:`DccServerBase._init_job_persistence` selected.  Returns the
+    empty string ``""`` when the caller passed ``""`` explicitly to
+    request in-memory operation (no persistence).
+
+    Priority order:
+
+    1. Explicit ``job_storage_path`` argument (when not ``None``).  An
+       empty string preserves the empty intent.
+    2. ``DCC_MCP_MAYA_JOB_STORAGE`` env var.
+    3. ``<platform_data_dir>/dcc-mcp-maya/jobs.db`` (auto-created).
+    """
+    if job_storage_path is not None:
+        if not str(job_storage_path).strip():
+            return ""  # explicit "disable persistence"
+        return job_storage_path
+
+    env_val = os.environ.get(ENV_JOB_STORAGE)
+    if env_val is not None:
+        return env_val
+
+    try:
+        from dcc_mcp_core import get_data_dir  # noqa: PLC0415
+
+        data_dir = Path(get_data_dir()) / "dcc-mcp-maya"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        return str(data_dir / DEFAULT_JOB_DB_FILENAME)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not resolve default job storage path: %s", exc)
+        return None
+
+
+def resolve_job_recovery(job_recovery: Optional[str]) -> str:
+    """Resolve the interrupted-job recovery policy.
+
+    Returns either ``"drop"`` (default — discard interrupted jobs) or
+    ``"requeue"`` (re-submit idempotent jobs on startup).  Any other
+    value (including a malformed env var) collapses to ``"drop"`` so the
+    server never starts in an undefined state.
+
+    Priority: explicit argument > ``DCC_MCP_MAYA_JOB_RECOVERY`` > ``"drop"``.
+    """
+    raw: Optional[str]
+    if job_recovery is not None:
+        raw = job_recovery
+    else:
+        raw = os.environ.get(ENV_JOB_RECOVERY, "drop")
+    normalised = (raw or "drop").strip().lower()
+    return normalised if normalised in ("drop", "requeue") else "drop"
+
+
+def resolve_window_title(dcc_window_title: Optional[str]) -> Optional[str]:
+    """Resolve the diagnostics-screenshot window-title hint."""
+    if dcc_window_title is not None:
+        return dcc_window_title
+    raw = os.environ.get(ENV_WINDOW_TITLE, "").strip()
+    return raw or None
+
+
+# Backwards-compatibility aliases — the leading-underscore names mirror the
+# previous module-private constants in ``server.py`` so any unit test or
+# downstream patcher that reaches in still works.
+_ENV_MINIMAL = ENV_MINIMAL
+_ENV_DEFAULT_TOOLS = ENV_DEFAULT_TOOLS
+_ENV_METRICS = ENV_METRICS
+_ENV_JOB_STORAGE = ENV_JOB_STORAGE
+_ENV_JOB_RECOVERY = ENV_JOB_RECOVERY
+_DEFAULT_JOB_DB_FILENAME = DEFAULT_JOB_DB_FILENAME
+
+
+def _unused_marker(_value: Any) -> None:  # pragma: no cover
+    """Sentinel referencing :data:`Any` so the type-only import is retained."""
+    return None

--- a/src/dcc_mcp_maya/_executor.py
+++ b/src/dcc_mcp_maya/_executor.py
@@ -1,0 +1,206 @@
+"""In-process skill executor (issue #127).
+
+Extracted from the previous monolithic ``server.py``.  Provides three
+entry points consumed by :class:`MayaMcpServer`:
+
+* :func:`run_skill_script` — load a skill ``main()`` and execute it on
+  the calling thread.  No Maya / dispatcher dependencies.
+* :func:`wire_in_process_executor` — register Python in-process handlers
+  for every action currently in the registry (called once after
+  startup-time skill loading).
+* :func:`register_inprocess_handlers` — register handlers for an explicit
+  action-name list (called by :meth:`MayaMcpServer.load_skill` for
+  dynamic loads).
+
+The dispatcher routing logic also lives here in
+:func:`execute_in_process` so the composition root can stay small.
+
+See: https://github.com/loonghao/dcc-mcp-maya/issues/127
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+from typing import Any, Callable, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def run_skill_script(script_path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Load and execute a skill script in the current Python process.
+
+    Implements the ``main(**params)`` calling convention used by all
+    ``dcc-mcp-maya`` skill scripts.  The ``if __name__ == "__main__":
+    run_main(main)`` guard is intentionally **not** triggered so
+    parameters are forwarded directly without going through subprocess
+    stdout.
+
+    Parameters
+    ----------
+    script_path:
+        Path to the skill Python script.
+    params:
+        Keyword arguments forwarded to ``main(**params)``.
+
+    Returns
+    -------
+    dict
+        The ``{"success": ..., "message": ..., ...}`` result dict
+        (or whatever shape the skill's ``main`` produced).
+    """
+    import importlib.util  # noqa: PLC0415
+
+    spec = importlib.util.spec_from_file_location("_maya_skill_script", script_path)
+    if spec is None or spec.loader is None:
+        return {"success": False, "message": "Cannot load skill script: {}".format(script_path)}
+
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    except SystemExit:
+        pass
+    except Exception as exc:  # noqa: BLE001
+        try:
+            from dcc_mcp_core.skill import skill_exception  # noqa: PLC0415
+
+            return skill_exception(exc, message="Error loading skill script: {}".format(script_path))
+        except ImportError:
+            return {"success": False, "message": "Error loading {}: {}".format(script_path, exc)}
+
+    if hasattr(mod, "__mcp_result__"):
+        return mod.__mcp_result__  # type: ignore[return-value]
+
+    main_fn = getattr(mod, "main", None)
+    if main_fn is None:
+        return {
+            "success": False,
+            "message": "Skill script has no main() entry point: {}".format(script_path),
+        }
+
+    try:
+        result = main_fn(**params)
+        return result if isinstance(result, dict) else {"success": True, "message": str(result)}
+    except SystemExit:
+        return getattr(mod, "__mcp_result__", {"success": True, "message": "Script executed"})
+    except Exception as exc:  # noqa: BLE001
+        try:
+            from dcc_mcp_core.skill import skill_exception  # noqa: PLC0415
+
+            return skill_exception(exc)
+        except ImportError:
+            return {"success": False, "message": str(exc)}
+
+
+def execute_in_process(
+    server_obj: Any,
+    script_path: str,
+    params: Dict[str, Any],
+    action_name: str,
+) -> Dict[str, Any]:
+    """Execute a skill script via the attached Maya UI dispatcher.
+
+    Routes through ``server_obj._maya_dispatcher.submit_callable`` when a
+    dispatcher is attached so the script runs on Maya's UI thread.
+    Falls back to executing inline on the calling thread otherwise
+    (standalone / ``mayapy`` mode).
+
+    The ``server_obj`` argument is the :class:`MayaMcpServer` instance
+    (a ``DccServerBase``); we only access ``_maya_dispatcher`` so a
+    duck-typed object suffices for testing.
+    """
+    dispatcher = getattr(server_obj, "_maya_dispatcher", None)
+    if dispatcher is not None and hasattr(dispatcher, "submit_callable"):
+        result = dispatcher.submit_callable(
+            action_name,
+            lambda: run_skill_script(script_path, params),
+            affinity="main",
+        )
+        if isinstance(result, dict):
+            output = result.get("output")
+            if isinstance(output, dict):
+                return output
+            if not result.get("success", True):
+                return {
+                    "success": False,
+                    "message": result.get("error") or "Dispatcher returned failure for {}".format(action_name),
+                }
+            if output is not None:
+                return {"success": True, "message": str(output)}
+        return {
+            "success": False,
+            "message": "Dispatcher returned unexpected result for {}".format(action_name),
+        }
+
+    return run_skill_script(script_path, params)
+
+
+def register_inprocess_handlers(server_obj: Any, action_names: List[str]) -> int:
+    """Register in-process Python handlers for ``action_names``.
+
+    For each action that has a ``source_file`` and no handler registered
+    yet, wraps :func:`execute_in_process` as an
+    :meth:`McpHttpServer.register_handler` callable so ``tools/call``
+    dispatches to the live Maya interpreter instead of spawning a
+    ``mayapy`` subprocess.
+
+    Returns the number of handlers newly registered.
+    """
+    inner = server_obj._server
+    registered = 0
+    for action_name in action_names:
+        if inner.has_handler(action_name):
+            continue
+
+        try:
+            action = inner.registry.get_action(action_name)
+        except Exception:  # noqa: BLE001
+            continue
+
+        if not action:
+            continue
+
+        script_path = action.get("source_file") if isinstance(action, dict) else None
+        if not script_path:
+            continue
+
+        def _make_handler(spath: str, aname: str) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+            def handler(params: Dict[str, Any]) -> Dict[str, Any]:
+                return execute_in_process(server_obj, spath, params, aname)
+
+            return handler
+
+        try:
+            inner.register_handler(action_name, _make_handler(script_path, action_name))
+            registered += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to register in-process handler for %r: %s", action_name, exc)
+
+    return registered
+
+
+def wire_in_process_executor(server_obj: Any) -> None:
+    """Register in-process handlers for every loaded action.
+
+    Called once after :meth:`MayaMcpServer.register_builtin_actions`
+    (and once after any dynamic :meth:`load_skill` call) so all loaded
+    actions route through :func:`run_skill_script` instead of the
+    subprocess executor.
+    """
+    inner = server_obj._server
+    try:
+        actions = inner.registry.list_actions_enabled()
+    except AttributeError:
+        logger.debug("server.registry not available — skipping in-process executor wiring")
+        return
+
+    action_names = [a["name"] for a in actions if isinstance(a, dict) and a.get("name")]
+    registered = register_inprocess_handlers(server_obj, action_names)
+    if registered > 0:
+        logger.info(
+            "Maya in-process executor: registered %d handler(s) via register_handler",
+            registered,
+        )
+    else:
+        logger.debug("Maya in-process executor: no new handlers registered (no loaded actions found)")

--- a/src/dcc_mcp_maya/_skill_loader.py
+++ b/src/dcc_mcp_maya/_skill_loader.py
@@ -1,0 +1,102 @@
+"""Minimal-mode skill loading (issue #127).
+
+Houses the ``MINIMAL_SKILLS`` / ``MINIMAL_DEACTIVATE_GROUPS`` constants
+and the two loader entry points used by
+:meth:`MayaMcpServer.register_builtin_actions`:
+
+* :func:`load_all_discovered_skills` — legacy "load every discovered
+  skill at startup" path.
+* :func:`load_minimal_skills` — load just the listed skills and
+  deactivate the per-skill ``__group__<name>`` stubs declared in
+  :data:`MINIMAL_DEACTIVATE_GROUPS`.
+
+The functions take a ``server`` (an :class:`McpHttpServer` instance) so
+they can be tested with a mock without owning a :class:`MayaMcpServer`.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+#: Skills loaded at startup when ``minimal=True`` (the default).
+MINIMAL_SKILLS: List[str] = ["maya-scripting", "maya-scene"]
+
+#: Per-skill ``{skill_name: [group_name, ...]}`` map of tool groups to
+#: deactivate after :meth:`load_skill`.  Deactivated groups appear in
+#: ``tools/list`` as ``__group__<name>`` stubs and can be reactivated by
+#: the agent via :func:`activate_group` at runtime.
+MINIMAL_DEACTIVATE_GROUPS: Dict[str, List[str]] = {
+    "maya-scripting": ["extended"],
+    "maya-scene": ["scene-management"],
+}
+
+# Backwards-compatibility aliases — ``server.py`` and tests previously
+# referenced these as private module attributes.
+_MINIMAL_SKILLS = MINIMAL_SKILLS
+_MINIMAL_DEACTIVATE_GROUPS = MINIMAL_DEACTIVATE_GROUPS
+
+
+def load_all_discovered_skills(server: Any) -> None:
+    """Load every discovered skill (legacy ``minimal=False`` behaviour).
+
+    Parameters
+    ----------
+    server:
+        An :class:`McpHttpServer` instance — typically
+        ``MayaMcpServer._server``.
+    """
+    try:
+        skills = server.list_skills()
+        for skill in skills:
+            name = skill.name if hasattr(skill, "name") else skill["name"]
+            try:
+                server.load_skill(name)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Failed to load skill %r: %s", name, exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to list skills for full-load: %s", exc)
+
+
+def load_minimal_skills(server: Any, skill_names: List[str]) -> None:
+    """Load only ``skill_names`` and apply :data:`MINIMAL_DEACTIVATE_GROUPS`.
+
+    For each skill in ``skill_names``:
+
+    1. ``server.load_skill(name)`` — load the skill into the registry.
+    2. For each group in :data:`MINIMAL_DEACTIVATE_GROUPS`\\ ``[name]``,
+       call ``registry.set_group_enabled(group, False)`` so the tools
+       collapse into a single ``__group__<group>`` stub.
+
+    Skills not listed remain in ``Discovered`` state and appear as
+    ``__skill__<name>`` stubs.
+    """
+    registry = server.registry
+    for name in skill_names:
+        try:
+            server.load_skill(name)
+            logger.info("[minimal] Loaded skill %r", name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[minimal] Failed to load skill %r: %s", name, exc)
+            continue
+
+        for group_name in MINIMAL_DEACTIVATE_GROUPS.get(name, []):
+            try:
+                count = registry.set_group_enabled(group_name, False)
+                logger.info(
+                    "[minimal] Deactivated group %r in %r (%d tools collapsed)",
+                    group_name,
+                    name,
+                    count,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "[minimal] Failed to deactivate group %r in %r: %s",
+                    group_name,
+                    name,
+                    exc,
+                )

--- a/src/dcc_mcp_maya/_transport.py
+++ b/src/dcc_mcp_maya/_transport.py
@@ -1,0 +1,77 @@
+"""Maya-specific :class:`TransportManager` wrappers (issue #127).
+
+Three thin helpers extracted from ``server.py``:
+
+* :func:`bind_and_register` — auto-detects the Maya version and forwards
+  to ``TransportManager.bind_and_register``.
+* :func:`find_best_service` — wraps ``TransportManager.find_best_service``
+  with default ``dcc_type="maya"``.
+* :func:`rank_services` — wraps ``TransportManager.rank_services`` and
+  always returns a list (never an iterator).
+
+All three swallow the exceptions that the underlying calls can raise so
+the server can keep running even when the registry is mid-rotation.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+from typing import Any, List, Optional
+
+# Import local modules
+from dcc_mcp_maya._version_probe import get_maya_version_string
+
+logger = logging.getLogger(__name__)
+
+
+def bind_and_register(
+    transport_manager: Any,
+    version: Optional[str] = None,
+    metadata: Optional[Any] = None,
+) -> Any:
+    """Register this Maya instance via ``TransportManager.bind_and_register``.
+
+    Auto-detects the Maya version when ``version`` is not supplied.
+
+    Returns the ``(instance_id, listener)`` tuple from the underlying
+    call, or ``None`` when the call fails (logged at WARNING level).
+    """
+    if version is None:
+        version = get_maya_version_string()
+    try:
+        return transport_manager.bind_and_register(
+            "maya",
+            version=version,
+            metadata=metadata or {},
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("bind_and_register failed: %s", exc)
+        return None
+
+
+def find_best_service(transport_manager: Any, dcc_type: str = "maya") -> Any:
+    """Find the best available Maya MCP service.
+
+    Wraps ``TransportManager.find_best_service``.  Returns ``None`` when
+    no service is available or the call fails.
+    """
+    try:
+        return transport_manager.find_best_service(dcc_type)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("find_best_service failed: %s", exc)
+        return None
+
+
+def rank_services(transport_manager: Any, dcc_type: str = "maya") -> List[Any]:
+    """Rank all active Maya MCP instances.
+
+    Wraps ``TransportManager.rank_services`` and converts the result to
+    a list so callers can iterate freely.  Returns ``[]`` on failure.
+    """
+    try:
+        return list(transport_manager.rank_services(dcc_type))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("rank_services failed: %s", exc)
+        return []

--- a/src/dcc_mcp_maya/_version_probe.py
+++ b/src/dcc_mcp_maya/_version_probe.py
@@ -1,0 +1,59 @@
+"""Maya availability + version detection (issue #127).
+
+Two pure helpers extracted from the previous monolithic ``server.py``:
+
+* :func:`maya_available` returns ``True`` when ``maya.cmds`` can be
+  imported in the current Python environment.
+* :func:`get_maya_version_string` returns the result of
+  ``maya.cmds.about(version=True)`` or the literal ``"unknown"`` when
+  Maya is not running / not importable.
+
+Both helpers are safe to call from any thread and never raise: failures
+collapse to ``"unknown"`` / ``False`` so the server can still report a
+sensible value during the very first start-up tick.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Sentinel returned when Maya is not available or its version cannot be probed.
+UNKNOWN_VERSION = "unknown"
+
+
+def maya_available() -> bool:
+    """Return ``True`` if ``maya.cmds`` is importable in this Python env.
+
+    Used by skill-discovery code paths that must run *outside* a live
+    Maya session (CI, ``mayapy``-less unit tests).  The check is cheap —
+    a single :keyword:`import` attempt — and the result is **not** cached
+    so callers that mock ``sys.modules`` mid-test see the updated value.
+    """
+    try:
+        import maya.cmds  # noqa: F401, PLC0415
+
+        return True
+    except ImportError:
+        return False
+
+
+def get_maya_version_string() -> str:
+    """Return Maya's version string via ``cmds.about(version=True)``.
+
+    Returns :data:`UNKNOWN_VERSION` when Maya is not running or the
+    ``about`` call raises (mocked Maya, partially-initialised module,
+    etc.).  Never raises.
+    """
+    if not maya_available():
+        return UNKNOWN_VERSION
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        return str(cmds.about(version=True))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Failed to read Maya version: %s", exc)
+        return UNKNOWN_VERSION

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -1,32 +1,21 @@
 """MayaMcpServer — embedded MCP Streamable HTTP server for Maya.
 
-Extends :class:`dcc_mcp_core.server_base.DccServerBase` with Maya-specific
-skill path discovery and version detection.
+Composition root after the issue #127 SRP decomposition.  The heavy
+lifting lives in private sibling modules so this file stays focused on
+wiring:
 
-All generic logic (skill registration, hot-reload, gateway failover,
-tool registry, lifecycle) is provided by the base class.
+================  ===========================================================
+Module            Responsibility
+================  ===========================================================
+``_env``          ``DCC_MCP_MAYA_*`` env-var resolution
+``_executor``    In-process skill execution + handler registration
+``_skill_loader`` Minimal-mode skill loading (constants + loaders)
+``_version_probe`` Maya availability + version string detection
+``_transport``    ``TransportManager`` wrappers (bind/find/rank)
+``_pyexec``       ``DCC_MCP_PYTHON_EXECUTABLE`` auto-correction (#125)
+================  ===========================================================
 
-Flow::
-
-    server = MayaMcpServer(port=8765)
-    server.register_builtin_actions()   # discover skills; load on demand
-    handle = server.start()
-    print(handle.mcp_url())             # http://127.0.0.1:8765/mcp
-    handle.shutdown()
-
-Or via the module-level singleton helper::
-
-    import dcc_mcp_maya
-    handle = dcc_mcp_maya.start_server(port=8765)
-    print(handle.mcp_url())
-
-Search path resolution (highest → lowest priority):
-
-1. ``extra_skill_paths`` supplied by the caller
-2. Built-in skills shipped with this package  (``src/dcc_mcp_maya/skills/``)
-3. ``DCC_MCP_MAYA_SKILL_PATHS`` environment variable (Maya-specific)
-4. ``DCC_MCP_SKILL_PATHS`` environment variable (global fallback)
-5. Platform default  (``dcc_mcp_core.get_skills_dir()``)
+All public surface is preserved 1:1.
 """
 
 # Import future modules
@@ -44,186 +33,33 @@ from dcc_mcp_core.factory import create_dcc_server
 from dcc_mcp_core.server_base import DccServerBase
 
 # Import local modules
+from dcc_mcp_maya import _env, _executor, _skill_loader, _transport, _version_probe
 from dcc_mcp_maya.__version__ import __version__
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_SERVER_VERSION = __version__
 
-# Built-in skills directory shipped with this package
-_BUILTIN_SKILLS_DIR = Path(__file__).parent / "skills"
-
-# ── Minimal-mode defaults ────────────────────────────────────────────────────
-# When minimal=True (the default), only these skills are loaded at startup;
-# all others remain as ``__skill__<name>`` stubs in ``tools/list``.
-_MINIMAL_SKILLS: List[str] = ["maya-scripting", "maya-scene"]
-
-# Groups to deactivate when running in minimal mode.
-# Keys are skill names; values are lists of group names to deactivate.
-# After ``load_skill`` the server calls ``deactivate_group`` for each listed
-# group, collapsing those tools into ``__group__<name>`` stubs.
-_MINIMAL_DEACTIVATE_GROUPS: dict[str, list[str]] = {
-    "maya-scripting": ["extended"],
-    "maya-scene": ["scene-management"],
-}
-
-# Environment variable overrides:
-#   DCC_MCP_MAYA_MINIMAL=0          → pre-load all bundled skills (legacy)
-#   DCC_MCP_MAYA_DEFAULT_TOOLS="execute_python,get_scene_info,..."
-#       → customise which skills (and optionally which groups) are active
-#         at startup.
-#   DCC_MCP_MAYA_METRICS=1          → enable Prometheus /metrics endpoint
-#       (issue #87; requires wheel built with prometheus feature).
-#   DCC_MCP_MAYA_JOB_STORAGE=<path> → SQLite job-persistence file path
-#       (issue #89; default: <platform_data_dir>/dcc-mcp-maya/jobs.db).
-#   DCC_MCP_MAYA_JOB_RECOVERY=requeue
-#       → re-queue idempotent interrupted jobs on startup (issue #89;
-#         default behaviour is "drop" as documented in the issue).
-#   DCC_MCP_MAYA_WINDOW_TITLE=...
-#       → passed as ``dcc_window_title`` to :class:`MayaMcpServer` (diagnostics
-#         / screenshot routing; dcc-mcp-core 0.14+).  The Maya plugin sets this
-#         when the env var is non-empty.
-_ENV_MINIMAL = "DCC_MCP_MAYA_MINIMAL"
-_ENV_DEFAULT_TOOLS = "DCC_MCP_MAYA_DEFAULT_TOOLS"
-_ENV_METRICS = "DCC_MCP_MAYA_METRICS"
-_ENV_JOB_STORAGE = "DCC_MCP_MAYA_JOB_STORAGE"
-_ENV_JOB_RECOVERY = "DCC_MCP_MAYA_JOB_RECOVERY"
-
-# Default SQLite file for job persistence — inside the platform data directory
-# so it survives upgrades and is shared across Maya sessions on the same user
-# account (issue #89).
-_DEFAULT_JOB_DB_FILENAME = "jobs.db"
-
-
-def _resolve_minimal_flag(minimal: Optional[bool]) -> bool:
-    """Resolve the minimal-mode flag from the argument and env vars.
-
-    Priority:
-    1. Explicit ``minimal`` argument (not None)
-    2. ``DCC_MCP_MAYA_MINIMAL`` env var (``"0"`` → False, ``"1"`` → True)
-    3. Default: True
-    """
-    if minimal is not None:
-        return minimal
-    env_val = os.environ.get(_ENV_MINIMAL)
-    if env_val is not None:
-        return env_val.strip() != "0"
-    return True
-
-
-def _resolve_default_tools() -> Optional[dict[str, list[str]]]:
-    """Parse ``DCC_MCP_MAYA_DEFAULT_TOOLS`` env var into skill→groups map.
-
-    The env var format is a comma-separated list of skill names.  When
-    present, only the listed skills are loaded at startup, and groups
-    not named in the value are deactivated.
-
-    Returns None if the env var is not set.
-    """
-    raw = os.environ.get(_ENV_DEFAULT_TOOLS)
-    if not raw:
-        return None
-    result: dict[str, list[str]] = {}
-    for token in raw.split(","):
-        token = token.strip()
-        if not token:
-            continue
-        # No group-level granularity in env var for now — just skill names
-        result.setdefault(token, [])
-    return result
-
-
-def _maya_available() -> bool:
-    """Return True if Maya is importable in this Python environment."""
-    try:
-        import maya.cmds  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
-
-
-def _run_skill_script(script_path: str, params: dict) -> dict:
-    """Load and execute a skill script in the current Python process.
-
-    Implements the ``main(**params)`` calling convention used by all
-    ``dcc-mcp-maya`` skill scripts.  The ``if __name__ == "__main__":
-    run_main(main)`` guard is intentionally **not** triggered so that
-    parameters are forwarded directly without subprocess stdout.
-
-    Parameters
-    ----------
-    script_path:
-        Path to the skill Python script.
-    params:
-        Keyword arguments forwarded to ``main(**params)``.
-
-    Returns
-    -------
-    dict
-        The ``{"success": ..., "message": ..., ...}`` result dict.
-    """
-    import importlib.util  # noqa: PLC0415
-
-    spec = importlib.util.spec_from_file_location("_maya_skill_script", script_path)
-    if spec is None or spec.loader is None:
-        return {"success": False, "message": "Cannot load skill script: {}".format(script_path)}
-
-    mod = importlib.util.module_from_spec(spec)
-    try:
-        spec.loader.exec_module(mod)  # type: ignore[union-attr]
-    except SystemExit:
-        pass
-    except Exception as exc:  # noqa: BLE001
-        try:
-            from dcc_mcp_core.skill import skill_exception  # noqa: PLC0415
-
-            return skill_exception(exc, message="Error loading skill script: {}".format(script_path))
-        except ImportError:
-            return {"success": False, "message": "Error loading {}: {}".format(script_path, exc)}
-
-    if hasattr(mod, "__mcp_result__"):
-        return mod.__mcp_result__  # type: ignore[return-value]
-
-    main_fn = getattr(mod, "main", None)
-    if main_fn is None:
-        return {
-            "success": False,
-            "message": "Skill script has no main() entry point: {}".format(script_path),
-        }
-
-    try:
-        result = main_fn(**params)
-        return result if isinstance(result, dict) else {"success": True, "message": str(result)}
-    except SystemExit:
-        return getattr(mod, "__mcp_result__", {"success": True, "message": "Script executed"})
-    except Exception as exc:  # noqa: BLE001
-        try:
-            from dcc_mcp_core.skill import skill_exception  # noqa: PLC0415
-
-            return skill_exception(exc)
-        except ImportError:
-            return {"success": False, "message": str(exc)}
+#: Built-in skills directory shipped with this package.
+_BUILTIN_SKILLS_DIR = Path(__file__).resolve().parent / "skills"
 
 
 class MayaMcpServer(DccServerBase):
     """MCP Streamable HTTP server embedded inside Maya.
 
-    Thin subclass of :class:`~dcc_mcp_core.server_base.DccServerBase`.
-    All skill management, hot-reload, gateway election, and lifecycle
-    logic is inherited.  This class adds only:
+    Thin composition root that extends
+    :class:`~dcc_mcp_core.server_base.DccServerBase` with Maya-specific
+    behaviour:
 
-    - Maya builtin skills directory (``skills/``)
-    - Maya version detection via ``cmds.about(version=True)``
-    - Minimal-mode startup: only core skills are loaded, the rest
-      remain as ``__skill__`` stubs for progressive activation
-    - ``register_builtin_actions()`` (minimal / full skill loading); instance-bound
-      diagnostic IPC + MCP tools are registered in
-      :meth:`~dcc_mcp_core.server_base.DccServerBase.start` (0.14+)
-    - Maya-specific TransportManager wrappers
-      (``bind_and_register``, ``find_best_service``, ``rank_services``)
-    - Prometheus ``/metrics`` endpoint support (issue #87)
-    - SQLite job persistence and startup recovery policy (issue #89)
+    * Maya built-in skills directory (``skills/``).
+    * Maya version detection via :func:`_version_probe.get_maya_version_string`.
+    * Minimal-mode startup — only core skills are loaded; the rest
+      remain as ``__skill__`` stubs for progressive activation.
+    * In-process skill execution via :mod:`_executor`.
+    * Maya-specific :class:`TransportManager` wrappers (delegated to
+      :mod:`_transport`).
+    * Prometheus ``/metrics`` endpoint (issue #87) and SQLite job
+      persistence (issue #89) — env vars resolved by :mod:`_env`.
 
     Example::
 
@@ -232,56 +68,6 @@ class MayaMcpServer(DccServerBase):
         handle = server.start()
         print(handle.mcp_url())    # http://127.0.0.1:8765/mcp
         handle.shutdown()
-
-    Prometheus metrics (issue #87)::
-
-        # Enable via constructor flag …
-        server = MayaMcpServer(port=8765, metrics_enabled=True)
-        # … or via environment variable:
-        # DCC_MCP_MAYA_METRICS=1 python -m dcc_mcp_maya
-
-        # Then scrape:
-        # curl http://127.0.0.1:8765/metrics
-
-    Job persistence and recovery (issue #89)::
-
-        # Enable SQLite job storage — jobs survive Maya restarts
-        server = MayaMcpServer(
-            port=8765,
-            job_storage_path="/path/to/maya-jobs.db",
-            job_recovery="requeue",   # "drop" (default) or "requeue"
-        )
-
-    Args:
-        port: TCP port to listen on.  Use ``0`` for a random available port.
-        server_name: Name reported in MCP ``initialize`` response.
-        server_version: Version reported in MCP ``initialize`` response.
-        gateway_port: Port for first-wins gateway competition.  ``None``
-            reads ``DCC_MCP_GATEWAY_PORT`` env var; ``0`` disables.
-        registry_dir: Directory for the shared ``FileRegistry`` JSON file.
-        dcc_version: Maya version string reported to the registry.
-        scene: Currently open scene file path reported to the registry.
-        enable_gateway_failover: Enable automatic gateway failover election.
-        metrics_enabled: Enable the Prometheus ``/metrics`` endpoint.
-            ``None`` reads ``DCC_MCP_MAYA_METRICS`` env var
-            (``"1"`` → enabled; default disabled).
-        job_storage_path: Path to a SQLite database for job persistence.
-            ``None`` reads ``DCC_MCP_MAYA_JOB_STORAGE`` env var.  When
-            neither is set the server defaults to
-            ``<platform_data_dir>/dcc-mcp-maya/jobs.db``.  Set to ``""``
-            to disable persistence (in-memory only).
-        job_recovery: Recovery policy for interrupted jobs found in the
-            storage on startup.  ``"drop"`` (default) discards them;
-            ``"requeue"`` re-submits idempotent jobs automatically.
-            ``None`` reads ``DCC_MCP_MAYA_JOB_RECOVERY`` env var.
-        dcc_pid: Owning Maya process id for ``diagnostics__*`` tools and IPC
-            screenshot routing.  Defaults to :func:`os.getpid` (same as
-            :class:`~dcc_mcp_core.server_base.DccServerBase`).
-        dcc_window_title: Substring to locate the Maya main window (e.g. for
-            captures) when no handle is set.  Optional; PID-based lookup
-            usually suffices.
-        dcc_window_handle: Native window handle (HWND, etc.) when pre-resolved;
-            takes precedence over title/PID resolution.
     """
 
     def __init__(
@@ -317,77 +103,57 @@ class MayaMcpServer(DccServerBase):
             dcc_window_handle=dcc_window_handle,
         )
 
-        # ── Prometheus metrics (issue #87) ────────────────────────────────────
-        effective_metrics = metrics_enabled
-        if effective_metrics is None:
-            effective_metrics = os.environ.get(_ENV_METRICS, "").strip() == "1"
-        if effective_metrics:
+        # ── Prometheus metrics (issue #87) ──────────────────────────────
+        if _env.resolve_metrics_enabled(metrics_enabled):
             self._config.enable_prometheus = True
             logger.info("[%s] Prometheus /metrics endpoint enabled", "maya")
 
-        # ── Job persistence + notifications (issue #89) ───────────────────────
-        effective_job_path = job_storage_path
-        if effective_job_path is None:
-            effective_job_path = os.environ.get(_ENV_JOB_STORAGE)
-        if effective_job_path is None:
-            # Default: platform data dir so the DB persists across upgrades.
-            try:
-                from dcc_mcp_core import get_data_dir  # noqa: PLC0415
-
-                data_dir = Path(get_data_dir()) / "dcc-mcp-maya"
-                data_dir.mkdir(parents=True, exist_ok=True)
-                effective_job_path = str(data_dir / _DEFAULT_JOB_DB_FILENAME)
-            except Exception as exc:
-                logger.debug("Could not resolve default job storage path: %s", exc)
+        # ── Job persistence + notifications (issue #89) ─────────────────
+        effective_job_path = _env.resolve_job_storage(job_storage_path)
         if effective_job_path:
             self._config.job_storage_path = effective_job_path
             logger.info("[%s] Job storage: %s", "maya", effective_job_path)
-        elif job_storage_path is not None and not str(job_storage_path).strip():
-            # ``""`` means disable persistence; clear path set by :class:`DccServerBase`
-            # in ``_init_job_persistence`` (see tests/test_server_job_metrics.py).
+        elif effective_job_path == "":
+            # Explicit "disable persistence" — clear the path that
+            # ``DccServerBase._init_job_persistence`` may have set.
             self._config.job_storage_path = ""
 
-        # Job-recovery policy (issue #89).  Stored for use in
-        # :meth:`register_builtin_actions` where we can log the effective
-        # policy after the server is configured.
-        effective_recovery = job_recovery
-        if effective_recovery is None:
-            effective_recovery = os.environ.get(_ENV_JOB_RECOVERY, "drop").strip().lower()
-        self._job_recovery: str = effective_recovery if effective_recovery in ("drop", "requeue") else "drop"
+        self._job_recovery: str = _env.resolve_job_recovery(job_recovery)
         if self._job_recovery == "requeue":
             logger.info("[%s] Job recovery policy: requeue idempotent interrupted jobs", "maya")
 
         # Optional :class:`~dcc_mcp_maya.dispatcher.MayaUiDispatcher`
-        # attached by the plugin (or by tests). When set, :meth:`stop`
+        # attached by the plugin (or by tests).  When set, :meth:`stop`
         # drains it before tearing the HTTP server down so any thread
         # blocked inside ``submit_callable`` returns within the normal
         # ``event.wait()`` budget instead of hanging indefinitely
         # (issue #85 / #89).
         self._maya_dispatcher: Any = None
 
+    # ── Lifecycle additions ────────────────────────────────────────────
+
     def attach_dispatcher(self, dispatcher: Any) -> None:
-        """Register a :class:`MayaUiDispatcher` (or compatible) for lifecycle integration.
+        """Register a :class:`MayaUiDispatcher` for lifecycle integration.
 
-        The server does not create the dispatcher itself because Maya
-        needs control over when the :class:`MayaUiPump` is installed
-        (that requires a live ``scriptJob``, which only makes sense
-        inside a real interactive session). Callers that manage a
-        dispatcher should invoke :meth:`attach_dispatcher` after
-        :meth:`start` so :meth:`stop` can drain pending jobs.
+        The server does not create the dispatcher itself because Maya needs
+        control over when the :class:`MayaUiPump` is installed (that
+        requires a live ``scriptJob``, which only makes sense inside a
+        real interactive session).  Callers that manage a dispatcher
+        should invoke :meth:`attach_dispatcher` after :meth:`start` so
+        :meth:`stop` can drain pending jobs.
 
-        Passing ``None`` detaches a previously-registered dispatcher
-        and is a no-op when nothing is attached.
+        Passing ``None`` detaches a previously-registered dispatcher.
         """
         self._maya_dispatcher = dispatcher
 
     def stop(self) -> None:
         """Stop the HTTP server and drain any attached Maya dispatcher.
 
-        Order matters: we drain the dispatcher **before** the HTTP
+        Order matters: the dispatcher is drained **before** the HTTP
         server shuts down so any thread blocked inside
-        ``submit_callable`` observes the drained outcome (``Interrupted``)
-        and returns before the HTTP handler that originally enqueued
-        the job gives up and closes the response.
+        ``submit_callable`` observes the drained outcome
+        (``Interrupted``) and returns before the HTTP handler that
+        originally enqueued the job gives up and closes the response.
         """
         dispatcher = self._maya_dispatcher
         if dispatcher is not None:
@@ -400,7 +166,7 @@ class MayaMcpServer(DccServerBase):
                         self._dcc_name,
                         signalled,
                     )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "[%s] Error draining Maya dispatcher during stop(): %s",
                     self._dcc_name,
@@ -408,7 +174,7 @@ class MayaMcpServer(DccServerBase):
                 )
         super().stop()
 
-    # ── Maya-specific overrides ───────────────────────────────────────────────
+    # ── Skill loading + executor wiring ────────────────────────────────
 
     def register_builtin_actions(
         self,
@@ -418,231 +184,61 @@ class MayaMcpServer(DccServerBase):
     ) -> "MayaMcpServer":
         """Discover skills, then optionally load only core skills.
 
-        Calls the base-class implementation to scan all skill directories
-        so the ``SkillCatalog`` is fully populated (required for
-        ``list_skills`` / ``search_skills`` / ``load_skill`` to work).
-        Then, depending on the *minimal* flag, either loads a small
-        default set of skills or falls back to the legacy "load all"
-        behaviour.
+        Phase 1 calls the base-class implementation to populate the
+        :class:`SkillCatalog` (required for ``list_skills`` /
+        ``search_skills`` / ``load_skill`` to work).  Phase 2 wires the
+        in-process Python executor so loaded actions run inside the
+        live Maya interpreter (issue #108).  Phase 3 selects which
+        skills to fully load:
 
-        **Minimal mode** (``minimal=True``, the default):
+        * ``minimal=True`` (the default) → load only
+          :data:`_skill_loader.MINIMAL_SKILLS` and deactivate the
+          per-skill ``__group__`` stubs in
+          :data:`_skill_loader.MINIMAL_DEACTIVATE_GROUPS`.
+        * ``minimal=False`` → load every discovered skill (legacy).
+        * ``DCC_MCP_MAYA_DEFAULT_TOOLS=skill1,skill2`` → load those
+          skills only (overrides ``minimal``).
 
-        - Only ``maya-scripting`` and ``maya-scene`` are loaded.
-        - Within those skills, only the ``core`` tool-group is active;
-          the ``extended`` / ``scene-management`` groups are deactivated
-          and appear as ``__group__<name>`` stubs.
-        - All other skills remain in ``Discovered`` state and appear as
-          ``__skill__<name>`` stubs.
-        - The agent can call ``load_skill("maya-primitives")`` to expand
-          the surface at any time.
-
-        **Full mode** (``minimal=False``):
-
-        - All bundled skills are loaded with all groups active (legacy).
-
-        Environment variable overrides:
-
-        - ``DCC_MCP_MAYA_MINIMAL=0`` → force full mode.
-        - ``DCC_MCP_MAYA_DEFAULT_TOOLS="maya-scripting,maya-scene,..."``
-          → customise which skills are loaded at startup.
-
-        Args:
-            extra_skill_paths: Additional directories to scan.
-            include_bundled: Include dcc-mcp-core bundled skills.
-            minimal: If ``True``, only load core skills.  ``None`` reads
-                the ``DCC_MCP_MAYA_MINIMAL`` env var (default ``True``).
-
-        Returns:
-            ``self`` for chaining.
+        Returns ``self`` for chaining.
         """
-        # Phase 1: discover all skills (populates SkillCatalog)
+        # Phase 1 — discover all skills.
         super().register_builtin_actions(
             extra_skill_paths=extra_skill_paths,
             include_bundled=include_bundled,
         )
 
-        # Phase 2: wire in-process executor so skills run inside the live Maya
-        # interpreter instead of spawning a subprocess.  This is the correct
-        # execution path for any embedded DCC (issue #108).
-        self._wire_in_process_executor()
+        # Phase 2 — wire in-process executor for already-loaded actions.
+        _executor.wire_in_process_executor(self)
 
-        # Phase 3: resolve minimal mode and load skills selectively
-        is_minimal = _resolve_minimal_flag(minimal)
-        custom_tools = _resolve_default_tools()
+        # Phase 3 — load skills selectively.
+        is_minimal = _env.resolve_minimal_flag(minimal)
+        custom_tools = _env.resolve_default_tools()
 
         if not is_minimal:
-            # Legacy mode: load all discovered skills
-            self._load_all_discovered_skills()
+            _skill_loader.load_all_discovered_skills(self._server)
         elif custom_tools is not None:
-            # Custom tool list from env var
-            self._load_minimal_skills(list(custom_tools.keys()))
+            _skill_loader.load_minimal_skills(self._server, list(custom_tools.keys()))
         else:
-            # Default minimal mode
-            self._load_minimal_skills(_MINIMAL_SKILLS)
-
-        # Diagnostic IPC + ``diagnostics__*`` MCP tools are registered in
-        # :meth:`DccServerBase.start` with full instance context (pid / window).
+            _skill_loader.load_minimal_skills(self._server, _skill_loader.MINIMAL_SKILLS)
 
         return self
-
-    # ------------------------------------------------------------------
-    # In-process executor (issue #108, #122)
-    # ------------------------------------------------------------------
-
-    def _wire_in_process_executor(self) -> None:
-        """Register the Maya in-process skill executor via register_handler.
-
-        In dcc-mcp-core 0.14.x, ``McpHttpServer.catalog`` returns a plain string
-        representation — ``SkillCatalog.set_in_process_executor`` is no longer
-        accessible through the server object.  We instead use
-        ``McpHttpServer.register_handler`` to wire in-process execution for each
-        **currently loaded** action.
-
-        Call this after :meth:`load_skill` / :meth:`register_builtin_actions`
-        to cover skills loaded at startup.  Dynamic loads (triggered by the
-        ``load_skill`` MCP tool) are handled by the overridden
-        :meth:`load_skill` method which calls
-        :meth:`_register_inprocess_handlers` automatically.
-        """
-        try:
-            actions = self._server.registry.list_actions_enabled()
-        except AttributeError:
-            logger.debug("server.registry not available — skipping in-process executor wiring")
-            return
-
-        action_names = [a["name"] for a in actions if isinstance(a, dict) and a.get("name")]
-        registered = self._register_inprocess_handlers(action_names)
-        if registered > 0:
-            logger.info("Maya in-process executor: registered %d handler(s) via register_handler", registered)
-        else:
-            logger.debug("Maya in-process executor: no new handlers registered (no loaded actions found)")
-
-    def _register_inprocess_handlers(self, action_names: List[str]) -> int:
-        """Register in-process Python handlers for the given action names.
-
-        For each action that has a ``source_file`` and no handler registered
-        yet, wraps :meth:`_execute_in_process` as an
-        ``McpHttpServer.register_handler`` callable so that ``tools/call``
-        dispatches to the live Maya interpreter instead of spawning a
-        ``mayapy`` subprocess.
-
-        Parameters
-        ----------
-        action_names:
-            List of action names returned by ``load_skill`` or discovered via
-            ``registry.list_actions_enabled()``.
-
-        Returns
-        -------
-        int
-            Number of handlers newly registered.
-        """
-        registered = 0
-        for action_name in action_names:
-            if self._server.has_handler(action_name):
-                continue
-
-            try:
-                action = self._server.registry.get_action(action_name)
-            except Exception:
-                continue
-
-            if not action:
-                continue
-
-            script_path = action.get("source_file") if isinstance(action, dict) else None
-            if not script_path:
-                continue
-
-            def _make_handler(spath: str, aname: str):
-                def handler(params: dict) -> dict:
-                    return self._execute_in_process(spath, params, aname)
-
-                return handler
-
-            try:
-                self._server.register_handler(action_name, _make_handler(script_path, action_name))
-                registered += 1
-            except Exception as exc:
-                logger.warning("Failed to register in-process handler for %r: %s", action_name, exc)
-
-        return registered
-
-    def _execute_in_process(self, script_path: str, params: dict, action_name: str) -> dict:
-        """Execute a skill script inside the current Maya Python process.
-
-        Routes through the attached :class:`~dcc_mcp_maya.dispatcher.MayaUiDispatcher`
-        (if present) so the script runs on Maya's UI thread, which is required
-        for any ``maya.cmds`` or ``maya.api`` calls.  Falls back to running
-        directly on the calling thread when no dispatcher is attached (standalone
-        / ``mayapy`` mode).
-
-        The script must expose ``main(**kwargs) -> dict`` at module level.
-        The ``if __name__ == "__main__": run_main(main)`` guard is intentionally
-        **not** triggered — we call ``main()`` directly so parameters are
-        forwarded without going through a subprocess stdout pipe.
-
-        Parameters
-        ----------
-        script_path:
-            Absolute (or cwd-relative) path to the skill Python script.
-        params:
-            Keyword arguments to pass to ``main(**params)``.
-        action_name:
-            Logical action name used as the dispatcher request id and for
-            logging.
-
-        Returns
-        -------
-        dict
-            The ``{"success": ..., "message": ..., ...}`` result dict from
-            the skill's ``main()`` function.
-        """
-        dispatcher = self._maya_dispatcher
-        if dispatcher is not None and hasattr(dispatcher, "submit_callable"):
-            # Route to Maya's UI thread — required for maya.cmds / maya.api.
-            result = dispatcher.submit_callable(
-                action_name,
-                lambda: _run_skill_script(script_path, params),
-                affinity="main",
-            )
-            if isinstance(result, dict):
-                output = result.get("output")
-                if isinstance(output, dict):
-                    return output
-                if not result.get("success", True):
-                    return {
-                        "success": False,
-                        "message": result.get("error") or "Dispatcher returned failure for {}".format(action_name),
-                    }
-                if output is not None:
-                    return {"success": True, "message": str(output)}
-            return {"success": False, "message": "Dispatcher returned unexpected result for {}".format(action_name)}
-
-        # Standalone / mayapy mode — run directly on the calling thread.
-        return _run_skill_script(script_path, params)
 
     def load_skill(self, skill_name: str) -> bool:
         """Load *skill_name* and register in-process handlers for its actions.
 
-        Extends the base-class implementation so that skills loaded
-        dynamically (via the ``load_skill`` MCP tool at runtime) also get
-        in-process Python handlers, not just skills loaded during startup via
+        Extends the base implementation so dynamically-loaded skills
+        (via the ``load_skill`` MCP tool) also get in-process Python
+        handlers — not just skills loaded during startup via
         :meth:`register_builtin_actions`.
-
-        Returns
-        -------
-        bool
-            ``True`` on success (matches :class:`DccServerBase` return type).
         """
         try:
             action_names: List[str] = self._server.load_skill(skill_name) or []
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             logger.debug("[%s] load_skill(%r) failed: %s", self._dcc_name, skill_name, exc)
             return False
 
         if action_names:
-            newly_registered = self._register_inprocess_handlers(action_names)
+            newly_registered = _executor.register_inprocess_handlers(self, action_names)
             if newly_registered:
                 logger.debug(
                     "[%s] load_skill(%r): registered %d in-process handler(s)",
@@ -652,69 +248,11 @@ class MayaMcpServer(DccServerBase):
                 )
         return True
 
-    def _load_all_discovered_skills(self) -> None:
-        """Load every discovered skill (legacy full-load behaviour)."""
-        try:
-            skills = self._server.list_skills()
-            for skill in skills:
-                name = skill.name if hasattr(skill, "name") else skill["name"]
-                try:
-                    self._server.load_skill(name)
-                except Exception as exc:
-                    logger.debug("Failed to load skill %r: %s", name, exc)
-        except Exception as exc:
-            logger.warning("Failed to list skills for full-load: %s", exc)
-
-    def _load_minimal_skills(self, skill_names: List[str]) -> None:
-        """Load only the named skills and deactivate non-core groups.
-
-        For each skill in *skill_names*, calls ``load_skill`` and then
-        deactivates any groups listed in ``_MINIMAL_DEACTIVATE_GROUPS``
-        for that skill.  Other skills stay in ``Discovered`` state.
-        """
-        registry = self._server.registry
-        for name in skill_names:
-            try:
-                self._server.load_skill(name)
-                logger.info("[minimal] Loaded skill %r", name)
-            except Exception as exc:
-                logger.warning("[minimal] Failed to load skill %r: %s", name, exc)
-                continue
-
-            # Deactivate non-core groups for minimal surface
-            groups_to_deactivate = _MINIMAL_DEACTIVATE_GROUPS.get(name, [])
-            for group_name in groups_to_deactivate:
-                try:
-                    count = registry.set_group_enabled(group_name, False)
-                    logger.info(
-                        "[minimal] Deactivated group %r in %r (%d tools collapsed)",
-                        group_name,
-                        name,
-                        count,
-                    )
-                except Exception as exc:
-                    logger.debug(
-                        "[minimal] Failed to deactivate group %r in %r: %s",
-                        group_name,
-                        name,
-                        exc,
-                    )
+    # ── Maya version + transport wrappers ──────────────────────────────
 
     def _version_string(self) -> str:
-        """Return the Maya version via ``cmds.about(version=True)``.
-
-        Falls back to ``"unknown"`` when Maya is not running or importable.
-        """
-        if not _maya_available():
-            return "unknown"
-        try:
-            import maya.cmds as cmds  # noqa: PLC0415
-
-            return str(cmds.about(version=True))
-        except Exception:
-            return "unknown"
-
-    # ── TransportManager helpers (Maya-specific wrappers) ─────────────────────
+        """Return the Maya version via :func:`_version_probe.get_maya_version_string`."""
+        return _version_probe.get_maya_version_string()
 
     def bind_and_register(
         self,
@@ -724,78 +262,64 @@ class MayaMcpServer(DccServerBase):
     ) -> Any:
         """Register this Maya instance via ``TransportManager.bind_and_register``.
 
-        Auto-detects the Maya version when ``version`` is not supplied.
-
-        Args:
-            transport_manager: A :class:`dcc_mcp_core.TransportManager` instance.
-            version: Maya version string.  Auto-detected if ``None``.
-            metadata: Arbitrary dict stored with the service entry.
-
-        Returns:
-            Tuple ``(instance_id, listener)`` or ``None`` on error.
+        Auto-detects the Maya version when ``version`` is omitted.  Returns
+        the ``(instance_id, listener)`` tuple, or ``None`` when the call
+        fails.  Delegates to :func:`_transport.bind_and_register`.
         """
-        if version is None:
-            version = self._version_string()
-        try:
-            return transport_manager.bind_and_register(
-                "maya",
-                version=version,
-                metadata=metadata or {},
-            )
-        except Exception as exc:
-            logger.warning("bind_and_register failed: %s", exc)
-            return None
+        return _transport.bind_and_register(
+            transport_manager,
+            version=version,
+            metadata=metadata,
+        )
 
     @staticmethod
     def find_best_service(transport_manager: Any, dcc_type: str = "maya") -> Any:
-        """Find the best available Maya MCP service.
+        """Find the best available Maya MCP service via the transport manager.
 
-        Wraps ``TransportManager.find_best_service``.
-
-        Args:
-            transport_manager: A :class:`dcc_mcp_core.TransportManager` instance.
-            dcc_type: DCC type string to search for.
-
-        Returns:
-            Best service instance, or ``None``.
+        Static for backward-compat with callers that pass an externally-owned
+        :class:`TransportManager` (issue #71 ergonomics).  Delegates to
+        :func:`_transport.find_best_service`.
         """
-        try:
-            return transport_manager.find_best_service(dcc_type)
-        except Exception as exc:
-            logger.debug("find_best_service failed: %s", exc)
-            return None
+        return _transport.find_best_service(transport_manager, dcc_type)
 
     @staticmethod
     def rank_services(transport_manager: Any, dcc_type: str = "maya") -> List[Any]:
-        """List and rank all active Maya MCP instances.
+        """Rank all active Maya MCP instances via the transport manager.
 
-        Wraps ``TransportManager.rank_services``.
-
-        Args:
-            transport_manager: A :class:`dcc_mcp_core.TransportManager` instance.
-            dcc_type: DCC type string to filter.
-
-        Returns:
-            Ranked list of service info objects.
+        Static for backward-compat (see :meth:`find_best_service`).  Delegates
+        to :func:`_transport.rank_services`.
         """
-        try:
-            return list(transport_manager.rank_services(dcc_type))
-        except Exception as exc:
-            logger.debug("rank_services failed: %s", exc)
-            return []
+        return _transport.rank_services(transport_manager, dcc_type)
+
+    # ── Backwards-compat instance-method shims (issue #127) ────────────
+    # Pre-#127 callers reached for these private instance methods; the
+    # implementations now live in :mod:`_executor` but the names are
+    # preserved here for one release cycle so external tests / patches
+    # keep working without modification.
+
+    def _wire_in_process_executor(self) -> None:
+        """Backward-compat shim — see :func:`_executor.wire_in_process_executor`."""
+        _executor.wire_in_process_executor(self)
+
+    def _register_inprocess_handlers(self, action_names: List[str]) -> int:
+        """Backward-compat shim — see :func:`_executor.register_inprocess_handlers`."""
+        return _executor.register_inprocess_handlers(self, action_names)
+
+    def _execute_in_process(
+        self,
+        script_path: str,
+        params: dict,
+        action_name: str,
+    ) -> dict:
+        """Backward-compat shim — see :func:`_executor.execute_in_process`."""
+        return _executor.execute_in_process(self, script_path, params, action_name)
 
 
-# ── module-level singleton helpers ────────────────────────────────────────────
-#
-# Thin wrapper around :func:`dcc_mcp_core.factory.create_dcc_server`.  The
-# singleton holder and lock live at module scope so the Maya plugin
-# (``maya/plugin/dcc_mcp_maya_plugin.py``) can reach the live server for
-# UI affordances such as gateway-status display, hot-reload toggling, and
-# non-blocking restart.
+# ── Module-level singleton helpers ─────────────────────────────────────────
 
-_server_instance: Optional[MayaMcpServer] = None
 _server_lock = threading.Lock()
 _instance_holder: List[Optional[MayaMcpServer]] = [None]
+_server_instance: Optional[MayaMcpServer] = None
 
 
 def start_server(
@@ -818,47 +342,17 @@ def start_server(
     Creates a module-level :class:`MayaMcpServer` singleton, optionally
     discovers all skills, and starts the MCP Streamable HTTP server.
 
-    All keyword arguments accepted by :class:`MayaMcpServer` (``server_name``,
-    ``gateway_port``, ``registry_dir``, ``dcc_version``, ``scene``,
-    ``enable_gateway_failover``) may be passed through ``**kwargs``.
+    All keyword arguments accepted by :class:`MayaMcpServer` may be passed
+    via ``**kwargs``.
 
-    Args:
-        port: TCP port.  Use ``0`` for a random available port.
-        register_builtins: If ``True``, discovers and loads skills.
-        extra_skill_paths: Additional directories to scan.
-        include_bundled: Include dcc-mcp-core bundled skills.
-        enable_hot_reload: Enable skill hot-reload on file changes.
-            Also honours ``DCC_MCP_MAYA_HOT_RELOAD=1``.
-        minimal: If ``True``, only core skills are loaded at startup.
-            ``None`` reads ``DCC_MCP_MAYA_MINIMAL`` env var (default
-            ``True``).  Set to ``False`` for legacy full-load behaviour.
-        metrics_enabled: Enable the Prometheus ``/metrics`` endpoint.
-            Also honours ``DCC_MCP_MAYA_METRICS=1``.
-        job_storage_path: SQLite job-persistence file path.
-            Also honours ``DCC_MCP_MAYA_JOB_STORAGE``.
-        job_recovery: Recovery policy for interrupted jobs: ``"drop"``
-            (default) or ``"requeue"``.  Also honours
-            ``DCC_MCP_MAYA_JOB_RECOVERY``.
-        dcc_pid: Maya process id for diagnostics (see :class:`MayaMcpServer`).
-        dcc_window_title: Window title substring for diagnostic capture.
-        dcc_window_handle: Pre-resolved native window handle.
-        **kwargs: Forwarded to :class:`MayaMcpServer`.
-
-    Returns:
-        ``McpServerHandle`` with ``.mcp_url()``, ``.port``, ``.shutdown()``.
-
-    Example::
-
-        import dcc_mcp_maya
-        handle = dcc_mcp_maya.start_server(port=8765)
-        print(handle.mcp_url())  # http://127.0.0.1:8765/mcp
+    Returns
+    -------
+    Any
+        ``McpServerHandle`` with ``.mcp_url()`` / ``.port`` / ``.shutdown()``.
     """
     global _server_instance
 
-    if dcc_window_title is None:
-        w = os.environ.get("DCC_MCP_MAYA_WINDOW_TITLE", "").strip()
-        if w:
-            dcc_window_title = w
+    dcc_window_title = _env.resolve_window_title(dcc_window_title)
 
     # Issue #125 — fix DCC_MCP_PYTHON_EXECUTABLE if it points at a GUI binary.
     from dcc_mcp_maya._pyexec import auto_correct as _auto_correct_pyexec  # noqa: PLC0415
@@ -866,7 +360,6 @@ def start_server(
     _auto_correct_pyexec()
 
     if register_builtins:
-        # Create server instance and call register_builtin_actions with minimal
         with _server_lock:
             if _instance_holder[0] is not None and _instance_holder[0].is_running:
                 return _instance_holder[0]._handle  # type: ignore[return-value]
@@ -905,28 +398,28 @@ def start_server(
             handle = server.start()
             _server_instance = server
             return handle
-    else:
-        # No builtin registration — delegate to factory (backward compat)
-        handle = create_dcc_server(
-            instance_holder=_instance_holder,
-            lock=_server_lock,
-            server_class=MayaMcpServer,
-            port=port,
-            register_builtins=False,
-            extra_skill_paths=extra_skill_paths,
-            include_bundled=include_bundled,
-            enable_hot_reload=enable_hot_reload,
-            hot_reload_env_var="DCC_MCP_MAYA_HOT_RELOAD",
-            metrics_enabled=metrics_enabled,
-            job_storage_path=job_storage_path,
-            job_recovery=job_recovery,
-            dcc_pid=dcc_pid,
-            dcc_window_title=dcc_window_title,
-            dcc_window_handle=dcc_window_handle,
-            **kwargs,
-        )
-        _server_instance = _instance_holder[0]
-        return handle
+
+    # No builtin registration — delegate to factory (backward compat)
+    handle = create_dcc_server(
+        instance_holder=_instance_holder,
+        lock=_server_lock,
+        server_class=MayaMcpServer,
+        port=port,
+        register_builtins=False,
+        extra_skill_paths=extra_skill_paths,
+        include_bundled=include_bundled,
+        enable_hot_reload=enable_hot_reload,
+        hot_reload_env_var="DCC_MCP_MAYA_HOT_RELOAD",
+        metrics_enabled=metrics_enabled,
+        job_storage_path=job_storage_path,
+        job_recovery=job_recovery,
+        dcc_pid=dcc_pid,
+        dcc_window_title=dcc_window_title,
+        dcc_window_handle=dcc_window_handle,
+        **kwargs,
+    )
+    _server_instance = _instance_holder[0]
+    return handle
 
 
 def stop_server() -> None:
@@ -937,3 +430,37 @@ def stop_server() -> None:
             _instance_holder[0].stop()
             _instance_holder[0] = None
     _server_instance = None
+
+
+# ── Backwards-compatibility shims ──────────────────────────────────────────
+#
+# Issue #127 split this module into ``_env`` / ``_executor`` /
+# ``_skill_loader`` / ``_version_probe`` / ``_transport``.  The names below
+# are re-exported here so any existing test, downstream patcher, or skill
+# script that imports from ``dcc_mcp_maya.server`` keeps working without a
+# code change.  Each shim is a *zero-overhead* alias — same callable, same
+# behaviour.
+#
+# These names are NOT part of the public API documented in ``llms.txt``;
+# new code should import from the dedicated submodules.
+
+_run_skill_script = _executor.run_skill_script
+_execute_in_process = _executor.execute_in_process
+_register_inprocess_handlers = _executor.register_inprocess_handlers
+_wire_in_process_executor = _executor.wire_in_process_executor
+
+_load_minimal_skills = _skill_loader.load_minimal_skills
+_load_all_discovered_skills = _skill_loader.load_all_discovered_skills
+_MINIMAL_SKILLS = _skill_loader.MINIMAL_SKILLS
+_MINIMAL_DEACTIVATE_GROUPS = _skill_loader.MINIMAL_DEACTIVATE_GROUPS
+
+_resolve_minimal_flag = _env.resolve_minimal_flag
+_resolve_default_tools = _env.resolve_default_tools
+_ENV_MINIMAL = _env.ENV_MINIMAL
+_ENV_DEFAULT_TOOLS = _env.ENV_DEFAULT_TOOLS
+_ENV_METRICS = _env.ENV_METRICS
+_ENV_JOB_STORAGE = _env.ENV_JOB_STORAGE
+_ENV_JOB_RECOVERY = _env.ENV_JOB_RECOVERY
+_DEFAULT_JOB_DB_FILENAME = _env.DEFAULT_JOB_DB_FILENAME
+
+_maya_available = _version_probe.maya_available

--- a/tests/test_env_resolution.py
+++ b/tests/test_env_resolution.py
@@ -1,0 +1,152 @@
+"""Tests for ``dcc_mcp_maya._env`` env-var resolution helpers (issue #127)."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import os
+from unittest.mock import patch
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_maya import _env
+
+
+class TestResolveMinimalFlag:
+    def test_explicit_true_wins(self):
+        with patch.dict(os.environ, {_env.ENV_MINIMAL: "0"}):
+            assert _env.resolve_minimal_flag(True) is True
+
+    def test_explicit_false_wins(self):
+        with patch.dict(os.environ, {_env.ENV_MINIMAL: "1"}):
+            assert _env.resolve_minimal_flag(False) is False
+
+    def test_env_zero_disables(self):
+        env = os.environ.copy()
+        env[_env.ENV_MINIMAL] = "0"
+        with patch.dict(os.environ, env, clear=True):
+            assert _env.resolve_minimal_flag(None) is False
+
+    def test_env_one_enables(self):
+        with patch.dict(os.environ, {_env.ENV_MINIMAL: "1"}):
+            assert _env.resolve_minimal_flag(None) is True
+
+    def test_default_when_unset(self):
+        env = os.environ.copy()
+        env.pop(_env.ENV_MINIMAL, None)
+        with patch.dict(os.environ, env, clear=True):
+            assert _env.resolve_minimal_flag(None) is True
+
+
+class TestResolveDefaultTools:
+    def test_unset_returns_none(self):
+        env = os.environ.copy()
+        env.pop(_env.ENV_DEFAULT_TOOLS, None)
+        with patch.dict(os.environ, env, clear=True):
+            assert _env.resolve_default_tools() is None
+
+    def test_blank_returns_none(self):
+        with patch.dict(os.environ, {_env.ENV_DEFAULT_TOOLS: ""}):
+            assert _env.resolve_default_tools() is None
+
+    def test_single_skill(self):
+        with patch.dict(os.environ, {_env.ENV_DEFAULT_TOOLS: "maya-scene"}):
+            assert _env.resolve_default_tools() == {"maya-scene": []}
+
+    def test_csv_skills_with_whitespace(self):
+        with patch.dict(os.environ, {_env.ENV_DEFAULT_TOOLS: "  maya-scene , maya-mesh-ops "}):
+            result = _env.resolve_default_tools()
+            assert result is not None
+            assert set(result.keys()) == {"maya-scene", "maya-mesh-ops"}
+
+    def test_skips_empty_tokens(self):
+        with patch.dict(os.environ, {_env.ENV_DEFAULT_TOOLS: ",a,,b,"}):
+            result = _env.resolve_default_tools()
+            assert result is not None
+            assert set(result.keys()) == {"a", "b"}
+
+
+class TestResolveMetricsEnabled:
+    def test_explicit_true(self):
+        with patch.dict(os.environ, {_env.ENV_METRICS: "0"}):
+            assert _env.resolve_metrics_enabled(True) is True
+
+    def test_explicit_false(self):
+        with patch.dict(os.environ, {_env.ENV_METRICS: "1"}):
+            assert _env.resolve_metrics_enabled(False) is False
+
+    def test_env_one(self):
+        with patch.dict(os.environ, {_env.ENV_METRICS: "1"}):
+            assert _env.resolve_metrics_enabled(None) is True
+
+    def test_env_zero_or_unset(self):
+        env = os.environ.copy()
+        env.pop(_env.ENV_METRICS, None)
+        with patch.dict(os.environ, env, clear=True):
+            assert _env.resolve_metrics_enabled(None) is False
+        with patch.dict(os.environ, {_env.ENV_METRICS: "0"}):
+            assert _env.resolve_metrics_enabled(None) is False
+
+
+class TestResolveJobStorage:
+    def test_explicit_path_wins(self, tmp_path):
+        path = str(tmp_path / "jobs.db")
+        assert _env.resolve_job_storage(path) == path
+
+    def test_explicit_empty_disables_persistence(self):
+        assert _env.resolve_job_storage("") == ""
+
+    def test_env_var_used(self, tmp_path):
+        path = str(tmp_path / "from-env.db")
+        with patch.dict(os.environ, {_env.ENV_JOB_STORAGE: path}):
+            assert _env.resolve_job_storage(None) == path
+
+    def test_default_under_data_dir(self):
+        env = os.environ.copy()
+        env.pop(_env.ENV_JOB_STORAGE, None)
+        with patch.dict(os.environ, env, clear=True):
+            result = _env.resolve_job_storage(None)
+        # Either we got a real default path, or the data-dir helper failed
+        # gracefully (returned None) — both are acceptable.
+        assert result is None or result.endswith(_env.DEFAULT_JOB_DB_FILENAME)
+
+
+class TestResolveJobRecovery:
+    @pytest.mark.parametrize("explicit", ["drop", "DROP", " drop "])
+    def test_explicit_drop_normalised(self, explicit):
+        assert _env.resolve_job_recovery(explicit) == "drop"
+
+    @pytest.mark.parametrize("explicit", ["requeue", "REQUEUE", " requeue "])
+    def test_explicit_requeue_normalised(self, explicit):
+        assert _env.resolve_job_recovery(explicit) == "requeue"
+
+    def test_unknown_collapses_to_drop(self):
+        assert _env.resolve_job_recovery("garbage") == "drop"
+
+    def test_env_used_when_none(self):
+        with patch.dict(os.environ, {_env.ENV_JOB_RECOVERY: "requeue"}):
+            assert _env.resolve_job_recovery(None) == "requeue"
+
+    def test_default_when_unset(self):
+        env = os.environ.copy()
+        env.pop(_env.ENV_JOB_RECOVERY, None)
+        with patch.dict(os.environ, env, clear=True):
+            assert _env.resolve_job_recovery(None) == "drop"
+
+
+class TestResolveWindowTitle:
+    def test_explicit_wins(self):
+        with patch.dict(os.environ, {_env.ENV_WINDOW_TITLE: "Other"}):
+            assert _env.resolve_window_title("Custom") == "Custom"
+
+    def test_env_used_when_none(self):
+        with patch.dict(os.environ, {_env.ENV_WINDOW_TITLE: "  My Maya  "}):
+            assert _env.resolve_window_title(None) == "My Maya"
+
+    def test_blank_treated_as_none(self):
+        env = os.environ.copy()
+        env.pop(_env.ENV_WINDOW_TITLE, None)
+        with patch.dict(os.environ, env, clear=True):
+            assert _env.resolve_window_title(None) is None

--- a/tests/test_version_probe_module.py
+++ b/tests/test_version_probe_module.py
@@ -1,0 +1,58 @@
+"""Tests for ``dcc_mcp_maya._version_probe`` (issue #127)."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import sys
+from unittest.mock import MagicMock, patch
+
+# Import local modules
+from dcc_mcp_maya import _version_probe
+
+
+class TestMayaAvailable:
+    def test_returns_true_when_maya_cmds_importable(self):
+        fake_cmds = MagicMock()
+        with patch.dict(sys.modules, {"maya": MagicMock(), "maya.cmds": fake_cmds}):
+            assert _version_probe.maya_available() is True
+
+    def test_returns_false_when_maya_missing(self):
+        with patch.dict(sys.modules, {"maya": None, "maya.cmds": None}):
+            assert _version_probe.maya_available() is False
+
+
+class TestGetMayaVersionString:
+    def test_returns_unknown_when_unavailable(self):
+        with patch.object(_version_probe, "maya_available", return_value=False):
+            assert _version_probe.get_maya_version_string() == _version_probe.UNKNOWN_VERSION
+
+    def _install_fake_maya(self, about_returns=None, about_raises=None):
+        """Install a fresh ``maya``/``maya.cmds`` pair so the lazy import sees us."""
+        fake_cmds = MagicMock(name="maya.cmds")
+        if about_raises is not None:
+            fake_cmds.about.side_effect = about_raises
+        else:
+            fake_cmds.about.return_value = about_returns
+        fake_maya = MagicMock(name="maya")
+        fake_maya.cmds = fake_cmds
+        return {"maya": fake_maya, "maya.cmds": fake_cmds}, fake_cmds
+
+    def test_returns_about_value_when_available(self):
+        modules, fake_cmds = self._install_fake_maya(about_returns="2025")
+        with patch.object(_version_probe, "maya_available", return_value=True):
+            with patch.dict(sys.modules, modules):
+                assert _version_probe.get_maya_version_string() == "2025"
+                fake_cmds.about.assert_called_once_with(version=True)
+
+    def test_returns_unknown_on_exception(self):
+        modules, _ = self._install_fake_maya(about_raises=RuntimeError("kaboom"))
+        with patch.object(_version_probe, "maya_available", return_value=True):
+            with patch.dict(sys.modules, modules):
+                assert _version_probe.get_maya_version_string() == _version_probe.UNKNOWN_VERSION
+
+    def test_coerces_non_string_to_str(self):
+        modules, _ = self._install_fake_maya(about_returns=2025)
+        with patch.object(_version_probe, "maya_available", return_value=True):
+            with patch.dict(sys.modules, modules):
+                assert _version_probe.get_maya_version_string() == "2025"


### PR DESCRIPTION
Closes #127.

## Summary

The 935-line `server.py` carried seven distinct responsibilities — the same God-Object problem `dcc-mcp-core` resolved in EPIC [#495](https://github.com/loonghao/dcc-mcp-core/issues/495) / sub-issue [#486](https://github.com/loonghao/dcc-mcp-core/issues/486) (`DccServerBase` decomposition). This PR applies the same discipline to the Maya subclass.

## Layout

```
src/dcc_mcp_maya/
├── server.py            # composition root (MayaMcpServer + start/stop)
├── _env.py              # DCC_MCP_MAYA_* env-var resolution
├── _executor.py         # in-process skill execution + handler registration
├── _skill_loader.py     # minimal-mode skill loading constants + loaders
├── _version_probe.py    # maya_available + get_maya_version_string
└── _transport.py        # bind_and_register / find_best_service / rank_services
```

## Behavioural / API guarantees

- **No public-API change.** Every name previously importable from `dcc_mcp_maya.server` (including the documented privates `_run_skill_script`, `_execute_in_process`, `_MINIMAL_SKILLS`, `_resolve_minimal_flag`, `_maya_available`, …) is re-exported via zero-overhead aliases for one release cycle.
- Static methods `find_best_service` / `rank_services` keep their `@staticmethod` decorator and `transport_manager` first-argument signature so existing callers (issue [#71](https://github.com/loonghao/dcc-mcp-maya/issues/71)) are untouched.
- Instance-method shims (`_wire_in_process_executor` / `_register_inprocess_handlers` / `_execute_in_process`) preserve the previous test surface verbatim.
- Each new submodule is independently importable without touching `maya.cmds` — every `maya.*` import stays inside the function that needs it (lazy import).

## Acceptance Criteria (from #127)

- [x] Each new module is independently importable without touching `maya.cmds` (lazy-import only inside functions that need it)
- [x] No external API changes — public re-exports from `dcc_mcp_maya/__init__.py` continue to work
- [x] Each module has its own focused unit tests; existing tests still pass
- [x] Documentation (`AGENTS.md` File Index) updated to reflect the new layout
- [ ] `MayaMcpServer` ≤ 250 LOC; remaining helpers extracted to private modules — the class itself is ~270 LOC after the split, and `server.py` total is ~390 LOC including the backward-compat shim block. Stripping the shims would land both at the target, but the shims protect external test/patcher surface for one release; they will be removed in a follow-up once downstreams migrate.

## New focused unit tests

- **`tests/test_env_resolution.py`** — 30 cases covering every env-var helper (minimal flag, default tools, metrics, job-storage, job-recovery, window title).
- **`tests/test_version_probe_module.py`** — 6 cases covering availability detection and version-string fallback.

## Verification

```
$ pytest tests/ --ignore=tests/e2e --ignore=tests/integration
459 passed, 2 skipped, 68 deselected, 1 xfailed, 1 xpassed in 2.47s
$ ruff format --check src/dcc_mcp_maya/ tests/test_env_resolution.py tests/test_version_probe_module.py
All checks passed!
$ ruff check src/dcc_mcp_maya/ tests/test_env_resolution.py tests/test_version_probe_module.py
All checks passed!
```

## Follow-up worth filing

* Migrate `_skill_loader` to use `dcc_mcp_core.server_base.MinimalModeConfig` + `apply_minimal_mode` (added in core 0.14.17, [#525](https://github.com/loonghao/dcc-mcp-core/issues/525)) so the `MINIMAL_SKILLS` / `MINIMAL_DEACTIVATE_GROUPS` constants become declarative config.
* Migrate `_executor` to `build_inprocess_executor` + `BaseDccCallableDispatcher` ([#521](https://github.com/loonghao/dcc-mcp-core/issues/521)) once `MayaUiDispatcher` exposes `dispatch_callable` (a thin adapter would be enough).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author