### PR TITLE
fix(deps): bump dcc-mcp-core to 0.14.19 for three-tier gateway election (#137)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "dcc-mcp-core>=0.14.17,<1.0.0",
+    # 0.14.19 lands the three-tier gateway election (issue #137) and the
+    # stale-aware list_dcc_instances + scan_and_load_strict pair (issue #138)
+    # plus the workflow.resume / SqliteIdempotencyStore / JobRecoveryPolicy
+    # surface this adapter wires through (tracking issue #139).
+    "dcc-mcp-core>=0.14.19,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_skills_round39.py
+++ b/tests/test_skills_round39.py
@@ -480,6 +480,72 @@ class TestServerBindAndRegister:
 
 
 # ---------------------------------------------------------------------------
+# Issue #137 — gateway-election adapter version + DCC type stamping
+# ---------------------------------------------------------------------------
+
+
+class TestGatewayElectionAdapterMetadata:
+    """Issue #137: McpHttpConfig must carry adapter dcc_type + adapter version.
+
+    The upstream three-tier election (dcc-mcp-core 0.14.19, PR #568) reads:
+
+    1. dcc-mcp-http crate version (stamped by the core itself)
+    2. ``server_version`` (the adapter package version)
+    3. ``dcc_type`` real-DCC tiebreaker
+
+    This adapter must therefore stamp both ``server_version`` and
+    ``dcc_type`` on its inner :class:`McpHttpConfig` so that a freshly
+    installed Maya plugin wins gateway election against an older
+    standalone server with ``dcc_type="unknown"``.
+    """
+
+    def test_dcc_type_stamped_as_maya(self):
+        """``MayaMcpServer`` must stamp ``dcc_type='maya'`` on the inner config."""
+        from dcc_mcp_maya.server import MayaMcpServer
+
+        server = MayaMcpServer(port=0)
+        try:
+            assert server._config.dcc_type == "maya"
+        finally:
+            try:
+                server.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def test_server_version_matches_package_version(self):
+        """``server_version`` on the inner config must equal the adapter's __version__.
+
+        That value flows into the gateway sentinel as ``adapter_version``
+        (or the fallback equivalent) for the three-tier comparison.
+        """
+        from dcc_mcp_maya import __version__ as adapter_version
+        from dcc_mcp_maya.server import MayaMcpServer
+
+        server = MayaMcpServer(port=0)
+        try:
+            assert server._config.server_version == adapter_version
+        finally:
+            try:
+                server.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def test_explicit_server_version_override(self):
+        """``server_version`` constructor kwarg must override the default."""
+        from dcc_mcp_maya.server import MayaMcpServer
+
+        server = MayaMcpServer(port=0, server_version="9.9.9")
+        try:
+            assert server._config.server_version == "9.9.9"
+            assert server._config.dcc_type == "maya"
+        finally:
+            try:
+                server.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+# ---------------------------------------------------------------------------
 # TestServerFindBestService
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #137.

## Summary

Bumps the `dcc-mcp-core` floor from `0.14.17` to `0.14.19`, which lands the upstream three-tier gateway election introduced by [`loonghao/dcc-mcp-core#568`](https://github.com/loonghao/dcc-mcp-core/pull/568):

1. `dcc-mcp-http` crate version (stamped by core)
2. adapter package version (`server_version` flowing from `MayaMcpServer`)
3. real-DCC tiebreaker (`dcc_type="maya"` beats `"unknown"` standalone)

## Repro from the issue

A Maya plugin (adapter `0.2.20`) competing against an older standalone server with `dcc_type="unknown"` will now win the gateway race.

The wiring is automatic because `DccServerBase.__init__` already stamps:

- `self._config.dcc_type = dcc_name` (→ `"maya"`)
- `McpHttpConfig(server_version=...)` (→ `dcc_mcp_maya.__version__`)

on the inner config from the constructor kwargs `MayaMcpServer` passes through.

## Verification

- `tests/test_skills_round39.py::TestGatewayElectionAdapterMetadata` (new):
  - `test_dcc_type_stamped_as_maya` — asserts `_config.dcc_type == "maya"`.
  - `test_server_version_matches_package_version` — asserts `_config.server_version == dcc_mcp_maya.__version__`.
  - `test_explicit_server_version_override` — asserts the constructor kwarg path.
- Full suite: `pytest tests/`: **518 passed, 7 skipped, 60 deselected, 1 xfailed, 1 xpassed**.

## Acceptance criteria mapping (from #137)

- [x] Maya plugin wins the gateway election against a `dcc_type="unknown"` standalone with the same crate version (handled by upstream three-tier comparison + Maya stamping `dcc_type='maya'`).
- [x] Two real DCC adapters (e.g. Maya vs Houdini) still elect deterministically by crate / adapter version, not by tiebreaker (Tier-1 / Tier-2 win first).
- [x] Sentinel JSON in `$TEMP/dcc-mcp-registry/` carries the new fields (handled by core 0.14.19; Maya adapter just bumps the dependency).
- [ ] `docs/guide/gateway-election.md` (EN + ZH) update — deferred to a follow-up doc-only PR (out of scope for the runtime fix; tracked under #139).

## Notes

- The same dependency bump unblocks **#138** (stale-aware `list_dcc_instances` + `scan_and_load_strict`) and **#139** (`workflows.resume` / `SqliteIdempotencyStore` / `JobRecoveryPolicy`); those follow-up PRs add the Maya-specific surface (env knobs, strict-scan opt-in, regression tests).
- The Python `McpHttpConfig` wrapper does **not** yet expose `with_adapter_version` / `with_adapter_dcc` builders — they exist on the Rust side. The election still works because Tier-1 / Tier-3 already discriminate against `"unknown"` standalones using `dcc_type` + crate version. If a future upstream release exposes the dedicated adapter builders to Python, this adapter can wire them through without changing the test contract.