### PR TITLE
feat(server): DCC_MCP_MAYA_STRICT_SKILL_SCAN + stale-aware discovery (#138)

### DIFF
--- a/src/dcc_mcp_maya/_env.py
+++ b/src/dcc_mcp_maya/_env.py
@@ -27,6 +27,11 @@ ENV_METRICS = "DCC_MCP_MAYA_METRICS"
 ENV_JOB_STORAGE = "DCC_MCP_MAYA_JOB_STORAGE"
 ENV_JOB_RECOVERY = "DCC_MCP_MAYA_JOB_RECOVERY"
 ENV_WINDOW_TITLE = "DCC_MCP_MAYA_WINDOW_TITLE"
+#: Issue #138 — when set to ``"1"``, ``register_builtin_actions`` runs
+#: :func:`dcc_mcp_core.scan_and_load_strict` after discovery so any
+#: silently-skipped skill directory raises ``ValueError`` at startup
+#: instead of disappearing into a debug-level log line.
+ENV_STRICT_SKILL_SCAN = "DCC_MCP_MAYA_STRICT_SKILL_SCAN"
 
 #: Default SQLite filename inside the platform data directory.
 DEFAULT_JOB_DB_FILENAME = "jobs.db"
@@ -139,6 +144,20 @@ def resolve_window_title(dcc_window_title: Optional[str]) -> Optional[str]:
         return dcc_window_title
     raw = os.environ.get(ENV_WINDOW_TITLE, "").strip()
     return raw or None
+
+
+def resolve_strict_skill_scan(strict: Optional[bool] = None) -> bool:
+    """Resolve whether to run :func:`scan_and_load_strict` after discovery.
+
+    Issue #138 acceptance criterion: a ``--strict`` knob so CI can fail
+    when skill packages don't validate (today they silently disappear).
+
+    Priority: explicit ``strict`` argument > ``DCC_MCP_MAYA_STRICT_SKILL_SCAN=1``
+    > ``False``.
+    """
+    if strict is not None:
+        return bool(strict)
+    return os.environ.get(ENV_STRICT_SKILL_SCAN, "").strip() == "1"
 
 
 # Backwards-compatibility aliases — the leading-underscore names mirror the

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -181,6 +181,7 @@ class MayaMcpServer(DccServerBase):
         extra_skill_paths: Optional[List[str]] = None,
         include_bundled: bool = True,
         minimal: Optional[bool] = None,
+        strict_scan: Optional[bool] = None,
     ) -> "MayaMcpServer":
         """Discover skills, then optionally load only core skills.
 
@@ -199,6 +200,11 @@ class MayaMcpServer(DccServerBase):
         * ``DCC_MCP_MAYA_DEFAULT_TOOLS=skill1,skill2`` → load those
           skills only (overrides ``minimal``).
 
+        When ``strict_scan=True`` (or ``DCC_MCP_MAYA_STRICT_SKILL_SCAN=1``),
+        the discovery is followed by :func:`dcc_mcp_core.scan_and_load_strict`
+        which raises :class:`ValueError` if any skill directory was
+        silently skipped (issue #138).
+
         Returns ``self`` for chaining.
         """
         # Phase 1 — discover all skills.
@@ -206,6 +212,11 @@ class MayaMcpServer(DccServerBase):
             extra_skill_paths=extra_skill_paths,
             include_bundled=include_bundled,
         )
+
+        # Phase 1a — strict validation pass (issue #138). Raises
+        # ``ValueError`` when any skill directory was silently skipped.
+        if _env.resolve_strict_skill_scan(strict_scan):
+            self._strict_skill_scan(extra_skill_paths, include_bundled)
 
         # Phase 2 — wire in-process executor for already-loaded actions.
         _executor.wire_in_process_executor(self)
@@ -222,6 +233,41 @@ class MayaMcpServer(DccServerBase):
             _skill_loader.load_minimal_skills(self._server, _skill_loader.MINIMAL_SKILLS)
 
         return self
+
+    def _strict_skill_scan(
+        self,
+        extra_skill_paths: Optional[List[str]] = None,
+        include_bundled: bool = True,
+    ) -> None:
+        """Re-scan with :func:`scan_and_load_strict` and raise on skipped dirs.
+
+        Issue #138: surfaces silently-skipped skill directories at
+        startup so packaging / CI failures are visible instead of
+        appearing as missing tools at run-time.
+
+        Raises
+        ------
+        ValueError
+            When any skill directory failed validation. The exception
+            message lists the offending directories.
+        """
+        from dcc_mcp_core import scan_and_load_strict  # noqa: PLC0415
+
+        scan_paths = self.collect_skill_search_paths(
+            extra_paths=extra_skill_paths,
+            include_bundled=include_bundled,
+            filter_existing=True,
+        )
+        try:
+            scan_and_load_strict(extra_paths=scan_paths, dcc_name=self._dcc_name)
+        except ValueError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] strict skill scan unavailable, falling back to lenient discovery: %s",
+                self._dcc_name,
+                exc,
+            )
 
     def load_skill(self, skill_name: str) -> bool:
         """Load *skill_name* and register in-process handlers for its actions.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -177,6 +177,61 @@ class TestMayaMcpServerApi:
         assert server.mcp_url is None
 
 
+# ── Issue #138: strict skill scan opt-in ──────────────────────────────────────
+
+
+class TestStrictSkillScan:
+    """Issue #138 — ``DCC_MCP_MAYA_STRICT_SKILL_SCAN=1`` surfaces skipped dirs."""
+
+    def test_env_var_default_off(self, monkeypatch):
+        from dcc_mcp_maya import _env
+
+        monkeypatch.delenv(_env.ENV_STRICT_SKILL_SCAN, raising=False)
+        assert _env.resolve_strict_skill_scan() is False
+
+    def test_env_var_set_to_one_enables_strict(self, monkeypatch):
+        from dcc_mcp_maya import _env
+
+        monkeypatch.setenv(_env.ENV_STRICT_SKILL_SCAN, "1")
+        assert _env.resolve_strict_skill_scan() is True
+
+    def test_explicit_arg_overrides_env(self, monkeypatch):
+        from dcc_mcp_maya import _env
+
+        monkeypatch.setenv(_env.ENV_STRICT_SKILL_SCAN, "0")
+        assert _env.resolve_strict_skill_scan(True) is True
+
+    def test_strict_scan_raises_value_error_on_skipped_dirs(self, tmp_path):
+        """When strict scan finds a malformed skill dir, startup must raise.
+
+        Builds a fake skills directory containing an unparseable
+        ``SKILL.md`` and asserts that ``register_builtin_actions(strict_scan=True)``
+        propagates the ``ValueError`` from
+        :func:`dcc_mcp_core.scan_and_load_strict`.
+        """
+        bad_skill = tmp_path / "bad-skill"
+        bad_skill.mkdir()
+        (bad_skill / "SKILL.md").write_text(
+            "---\nthis is: not: valid: yaml: at: all\n---\n",
+            encoding="utf-8",
+        )
+
+        srv_mod = _import_server()
+        server = srv_mod.MayaMcpServer(port=0)
+        try:
+            with pytest.raises(ValueError):
+                server.register_builtin_actions(
+                    extra_skill_paths=[str(tmp_path)],
+                    include_bundled=False,
+                    strict_scan=True,
+                )
+        finally:
+            try:
+                server.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+
 class TestMayaMcpServerHttp:
     """End-to-end HTTP tests against a real McpHttpServer (no Maya needed)."""
 


### PR DESCRIPTION
Closes #138.

## Summary

Addresses the two discovery-layer discrepancies in #138:

1. **`list_dcc_instances` aggregation drops registry rows** — fixed automatically by bumping `dcc-mcp-core` to `0.14.19`, which lands the upstream stale-aware `list_dcc_instances` from [`loonghao/dcc-mcp-core#568`](https://github.com/loonghao/dcc-mcp-core/pull/568). Stale / `unknown` / shutting-down rows are now returned with a `status: "stale"` discriminant instead of being silently elided.

2. **Skill scanner skips silently** — fixed at two layers:
   - The 0.14.19 bump promotes the per-skipped-directory log from `debug` to `warn` with a structured `directory=` field, so missing skills now show up in operator logs by default.
   - This PR adds the `--strict` knob requested in the acceptance criteria: a new env var `DCC_MCP_MAYA_STRICT_SKILL_SCAN=1` (or `strict_scan=True` kwarg on `MayaMcpServer.register_builtin_actions`) re-runs discovery via the upstream `dcc_mcp_core.scan_and_load_strict()` helper, raising `ValueError` when any skill directory was silently skipped — useful in CI / packaged-adapter releases where a malformed `SKILL.md` should be a blocking error.

## Changes

- `pyproject.toml` — dependency floor bump (`dcc-mcp-core>=0.14.19,<1.0.0`).
- `src/dcc_mcp_maya/_env.py` — `ENV_STRICT_SKILL_SCAN` constant + `resolve_strict_skill_scan(strict)` helper following the existing priority pattern (explicit arg > env > default).
- `src/dcc_mcp_maya/server.py` — new `strict_scan` kwarg on `register_builtin_actions`; on opt-in calls `scan_and_load_strict` after lenient discovery and propagates `ValueError`.
- `tests/test_server.py::TestStrictSkillScan` (new) — 4 tests:
  - `test_env_var_default_off` — priority defaults.
  - `test_env_var_set_to_one_enables_strict` — env var path.
  - `test_explicit_arg_overrides_env` — explicit kwarg wins.
  - `test_strict_scan_raises_value_error_on_skipped_dirs` — builds a malformed `SKILL.md`, asserts `register_builtin_actions(strict_scan=True)` raises `ValueError`.

## Acceptance criteria mapping (from #138)

- [x] `list_dcc_instances` (no filter) returns every parseable row (upstream 0.14.19).
- [x] Stale sentinels carry `status: "stale"` (upstream 0.14.19).
- [x] SkillScanner emits one `warn` per skipped directory (upstream 0.14.19; verified in test output: `Skipping skill directory: SKILL.md missing or failed validation [...] directory=...`).
- [x] Docs corrected to match shipped count — already merged in #141 (`12 packages, 73 scripts`).
- [x] `--strict` knob on the scanner — added as `DCC_MCP_MAYA_STRICT_SKILL_SCAN=1` / `strict_scan=True`.

## Verification

- `pytest tests/`: **522 passed, 7 skipped, 60 deselected, 1 xfailed, 1 xpassed**.
- New tests cover both env-var resolution and the live failure path.