### PR TITLE
chore(release-please): auto-update all hardcoded version strings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 `dcc-mcp-maya` embeds a standards-compliant MCP Streamable HTTP server directly inside Autodesk Maya. It exposes 73+ Maya operations as MCP tools that any AI agent (Claude, Cursor, Gemini, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
-**Current version:** 0.2.20
+**Current version:** 0.2.21 <!-- x-release-please-version -->
 **Core dependency:** `dcc-mcp-core>=0.14.17,<1.0.0`
 **Python:** 3.7+
 **Maya:** 2020+

--- a/docs/api/adapter.md
+++ b/docs/api/adapter.md
@@ -14,7 +14,7 @@ from dcc_mcp_maya.server import MayaMcpServer
 MayaMcpServer(
     port: int = 8765,
     server_name: str = "maya-mcp",
-    server_version: str = "0.2.15",
+    server_version: str = "0.2.21",  # x-release-please-version
     gateway_port: Optional[int] = None,
     registry_dir: Optional[str] = None,
     dcc_version: Optional[str] = None,
@@ -30,7 +30,7 @@ MayaMcpServer(
 |-----------|------|---------|-------------|
 | `port` | int | `8765` | TCP port. Use `0` for a random available port. |
 | `server_name` | str | `"maya-mcp"` | Name shown in MCP `initialize` response |
-| `server_version` | str | `"0.2.15"` | Version shown in MCP `initialize` response |
+| `server_version` | str | `"0.2.21"` | Version shown in MCP `initialize` response | <!-- x-release-please-version -->
 | `gateway_port` | int \| None | `None` | Gateway election port for multi-instance discovery |
 | `registry_dir` | str \| None | `None` | Shared registry directory for discovery metadata |
 | `dcc_version` | str \| None | `None` | Maya version reported to the registry |

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -85,7 +85,7 @@ from dcc_mcp_maya.server import MayaMcpServer
 MayaMcpServer(
     port: int = 8765,
     server_name: str = "maya-mcp",
-    server_version: str = "0.2.15",
+    server_version: str = "0.2.21",  # x-release-please-version
     gateway_port: Optional[int] = None,
     registry_dir: Optional[str] = None,
     dcc_version: Optional[str] = None,

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@
 **dcc-mcp-maya** — Maya plugin for the DCC Model Context Protocol (MCP) ecosystem.  
 Embeds a standards-compliant MCP Streamable HTTP server (2025-03-26 spec) directly inside Maya.
 
-- **Version:** 0.2.20
+- **Version:** 0.2.21 <!-- x-release-please-version -->
 - **License:** MIT
 - **Repository:** https://github.com/loonghao/dcc-mcp-maya
 - **Python:** >=3.7
@@ -50,7 +50,7 @@ The server starts automatically when the plugin loads. In interactive mode a "DC
 MayaMcpServer(
     port: int = 8765,
     server_name: str = "maya-mcp",
-    server_version: str = "0.2.20",
+    server_version: str = "0.2.21",  # x-release-please-version
     gateway_port: Optional[int] = None,
     registry_dir: Optional[str] = None,
     dcc_version: Optional[str] = None,
@@ -68,7 +68,7 @@ MayaMcpServer(
 |-----------|------|---------|-------------|
 | `port` | `int` | `8765` | TCP port. Use `0` for OS-assigned. |
 | `server_name` | `str` | `"maya-mcp"` | Name in MCP `initialize` response. |
-| `server_version` | `str` | `"0.2.15"` | Version reported in `initialize`. |
+| `server_version` | `str` | `"0.2.21"` | Version reported in `initialize`. | <!-- x-release-please-version -->
 | `gateway_port` | `int \| None` | `None` | First-wins gateway election port. `None` reads `DCC_MCP_GATEWAY_PORT`; `0` disables. |
 | `registry_dir` | `str \| None` | `None` | Shared `FileRegistry` directory for service discovery. |
 | `dcc_version` | `str \| None` | `None` | Maya version string advertised to the registry. |

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@
 ## Project
 
 **dcc-mcp-maya** — Embed a standards-compliant MCP Streamable HTTP server directly inside Autodesk Maya.
-**Version:** 0.2.20
+**Version:** 0.2.21 <!-- x-release-please-version -->
 **License:** MIT
 **Repo:** https://github.com/loonghao/dcc-mcp-maya
 **Python:** >=3.7
@@ -57,7 +57,7 @@ stop_server() -> None
 MayaMcpServer(
     port: int = 8765,
     server_name: str = "maya-mcp",
-    server_version: str = "0.2.20",
+    server_version: str = "0.2.21",  # x-release-please-version
     gateway_port: Optional[int] = None,
     registry_dir: Optional[str] = None,
     dcc_version: Optional[str] = None,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,12 @@
           "path": "pyproject.toml",
           "jsonpath": "$.project.version"
         },
-        "src/dcc_mcp_maya/__version__.py"
+        {"type": "generic", "path": "src/dcc_mcp_maya/__version__.py"},
+        {"type": "generic", "path": "AGENTS.md"},
+        {"type": "generic", "path": "llms.txt"},
+        {"type": "generic", "path": "llms-full.txt"},
+        {"type": "generic", "path": "docs/api/adapter.md"},
+        {"type": "generic", "path": "docs/api/server.md"}
       ]
     }
   },

--- a/src/dcc_mcp_maya/__version__.py
+++ b/src/dcc_mcp_maya/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0"
+__version__ = "0.2.21"  # x-release-please-version


### PR DESCRIPTION
## Summary

Extend `release-please-config.json` to keep **every** hardcoded version string in the repo in sync, not just `pyproject.toml`. Uses release-please's `generic` updater + `x-release-please-version` annotations.

## Why

Before this PR only `pyproject.toml` was reliably updated. Side effects:

- `src/dcc_mcp_maya/__version__.py` had silently drifted to `0.3.0` while `pyproject.toml` was `0.2.21` — the existing plain-string `extra-files` entry doesn't update Python files without an annotation.
- `docs/api/adapter.md` and `docs/api/server.md` were stuck at `0.2.15` (multiple releases stale).
- `AGENTS.md`, `llms.txt`, `llms-full.txt` were one release behind at `0.2.20`.

## What changed

`release-please-config.json` extra-files now lists every version-bearing file as `generic`:

```json
"extra-files": [
  { "type": "toml", "path": "pyproject.toml", "jsonpath": "$.project.version" },
  {"type": "generic", "path": "src/dcc_mcp_maya/__version__.py"},
  {"type": "generic", "path": "AGENTS.md"},
  {"type": "generic", "path": "llms.txt"},
  {"type": "generic", "path": "llms-full.txt"},
  {"type": "generic", "path": "docs/api/adapter.md"},
  {"type": "generic", "path": "docs/api/server.md"}
]
```

And each version line carries an `x-release-please-version` annotation:

| File | Locations | Annotation |
|------|-----------|------------|
| `src/dcc_mcp_maya/__version__.py` | 1 (also fixes drifted `0.3.0` → `0.2.21`) | `# x-release-please-version` |
| `AGENTS.md` | 1 (Current version line) | `<!-- x-release-please-version -->` |
| `llms.txt` | 2 (header + code-block default) | mixed |
| `llms-full.txt` | 3 (header + code-block + table) | mixed |
| `docs/api/adapter.md` | 2 (code-block + table, was 0.2.15) | mixed |
| `docs/api/server.md` | 1 (code-block default, was 0.2.15) | `# x-release-please-version` |

Intentionally **not** annotated (historical references, must not auto-bump):
- `AGENTS.md` line 182: `**New in 0.2.20:** Rust-backed dispatchers...`
- `.github/workflows/release.yml`: example tag `v0.2.4` in description string

## Verification

Directly invoked release-please's `Generic` updater (the same code path the GitHub Action runs) against each annotated file with a synthetic version `0.9.99`:

```
OK   src/dcc_mcp_maya/__version__.py  expected=1  got=1
OK   AGENTS.md                        expected=1  got=1
OK   llms.txt                         expected=2  got=2
OK   llms-full.txt                    expected=3  got=3
OK   docs/api/adapter.md              expected=2  got=2
OK   docs/api/server.md               expected=1  got=1
```

All 10 annotated lines are rewritten correctly. The next release-please PR will sync every one of them along with `pyproject.toml`.