### PR TITLE
fix(maya): resolve issues #148-#153 via dcc-mcp-core 0.14.20 APIs

### DIFF
--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -287,6 +287,15 @@ def _start() -> None:
         import dcc_mcp_maya  # noqa: PLC0415
 
         _export_worker_env()
+        # Issue #148 — defuse the modal commandPort security warning that
+        # would otherwise freeze Maya's main thread when a stray client
+        # (or the gateway probe) connects to the legacy commandPort.
+        try:
+            from dcc_mcp_maya._commandport import suppress_security_warnings  # noqa: PLC0415
+
+            suppress_security_warnings()
+        except Exception as exc:  # noqa: BLE001 — never block plugin load
+            logger.debug("commandPort warning suppression skipped: %s", exc)
         cfg = _resolve_config()
         _handle = dcc_mcp_maya.start_server(**cfg)
         _print_startup_info(cfg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,14 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.14.19 lands the three-tier gateway election (issue #137), the
-    # stale-aware list_dcc_instances + scan_and_load_strict pair (issue #138)
-    # and the workflows.resume / SqliteIdempotencyStore / JobRecoveryPolicy
-    # surface this adapter wires through (issue #139).
-    "dcc-mcp-core>=0.14.19,<1.0.0",
+    # 0.14.20 lands the building blocks this branch wires through:
+    #   * normalize_script_execution_params      → issue #150 (code/script alias)
+    #   * ScriptExecutionCapture / Result        → issue #151 (stdout capture)
+    #   * mark tools with fallback inputSchema   → issue #149 (auto _meta marker)
+    #   * DeferredToolResult + HostExecutionBridge → issue #153 (long-running)
+    #   * exception_to_error_envelope            → issue #151 (structured errors)
+    #   * gateway health-probe filtering         → issue #148 (commandPort skip)
+    "dcc-mcp-core>=0.14.20,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_maya/_commandport.py
+++ b/src/dcc_mcp_maya/_commandport.py
@@ -1,0 +1,117 @@
+"""commandPort security-warning suppression (issue #148).
+
+Maya's legacy ``commandPort`` shows a modal "Allow / Deny / Allow All"
+dialog the first time it receives a payload from an unfamiliar source.
+That dialog blocks Maya's main thread, which in turn freezes every
+in-process MCP tool call.  Misrouted MCP traffic (gateway probes,
+clients that point at the commandPort port instead of ``/mcp``) used to
+trigger this dialog repeatedly.
+
+dcc-mcp-core 0.14.20 (PR #632) filters non-MCP listeners out of gateway
+fan-out, but defence-in-depth on the Maya side is still useful for
+sessions where the user (or a third-party plugin) explicitly opened a
+commandPort for unrelated tooling.
+
+This module exposes a single best-effort helper:
+
+* :func:`suppress_security_warnings` — re-opens every currently-open
+  commandPort with ``-securityWarning false``, so the modal dialog
+  never appears.  Idempotent; never raises; never opens new ports.
+
+Set ``DCC_MCP_MAYA_DISABLE_COMMANDPORT_WARNING=0`` to opt out.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+import os
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+ENV_DISABLE_WARNING = "DCC_MCP_MAYA_DISABLE_COMMANDPORT_WARNING"
+
+
+def _is_disabled_by_env() -> bool:
+    """Return True when the user opted out via env var (``=0``)."""
+    return os.environ.get(ENV_DISABLE_WARNING, "1").strip() == "0"
+
+
+def _list_open_ports() -> List[str]:
+    """Return the names of every currently-open commandPort.
+
+    Maya's ``commandPort -q -name`` returns either ``None``, a single
+    string, or a list of strings depending on Maya version.  This helper
+    normalises the return value to ``List[str]`` and never raises.
+    """
+    try:
+        import maya.mel as mel  # noqa: PLC0415
+    except ImportError:
+        return []
+
+    try:
+        raw = mel.eval("commandPort -q -name;")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("commandPort query failed: %s", exc)
+        return []
+
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [raw] if raw else []
+    try:
+        return [str(p) for p in raw if p]
+    except TypeError:
+        return []
+
+
+def suppress_security_warnings() -> int:
+    """Disable the commandPort security warning on every open port.
+
+    Walks every port returned by ``commandPort -q -name`` and re-opens
+    it with ``-securityWarning false`` so subsequent requests skip the
+    modal dialog.  Pass-through when:
+
+    * Maya is not importable (standalone build, ``mayapy`` test run).
+    * No ports are open (the common case when the user has not enabled
+      commandPort manually).
+    * The user opted out via :data:`ENV_DISABLE_WARNING` ``=0``.
+
+    Returns
+    -------
+    int
+        The number of ports that were re-opened with the warning
+        disabled.  ``0`` covers every no-op path above.
+    """
+    if _is_disabled_by_env():
+        logger.debug("%s=0 — leaving commandPort security warnings on", ENV_DISABLE_WARNING)
+        return 0
+
+    ports = _list_open_ports()
+    if not ports:
+        return 0
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+    except ImportError:
+        return 0
+
+    fixed = 0
+    for port in ports:
+        try:
+            # Closing then re-opening with -securityWarning false is the
+            # only way to flip the flag on an existing port; Maya does
+            # not expose a runtime mutator for this attribute.
+            cmds.commandPort(name=port, close=True)
+            cmds.commandPort(name=port, securityWarning=False, sourceType="mel")
+            fixed += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not disable security warning on %s: %s", port, exc)
+    if fixed:
+        logger.info(
+            "Disabled commandPort security warning on %d port(s) — see issue #148",
+            fixed,
+        )
+    return fixed

--- a/src/dcc_mcp_maya/_executor.py
+++ b/src/dcc_mcp_maya/_executor.py
@@ -112,13 +112,36 @@ def execute_in_process(
     """
     dispatcher = getattr(server_obj, "_maya_dispatcher", None)
     if dispatcher is not None and hasattr(dispatcher, "submit_callable"):
-        result = dispatcher.submit_callable(
-            action_name,
-            lambda: run_skill_script(script_path, params),
-            affinity="main",
-        )
+        # Issue #151 — surface dispatcher-side exceptions (cancellation,
+        # main-thread crashes, timeouts) as structured envelopes instead
+        # of letting them propagate as Internal Errors.
+        try:
+            result = dispatcher.submit_callable(
+                action_name,
+                lambda: run_skill_script(script_path, params),
+                affinity="main",
+            )
+        except BaseException as exc:  # noqa: BLE001 — relay everything
+            try:
+                from dcc_mcp_core.skill import skill_exception  # noqa: PLC0415
+
+                return skill_exception(
+                    exc,
+                    message="Dispatcher failed to execute {}".format(action_name),
+                )
+            except ImportError:
+                return {"success": False, "message": "{}: {}".format(action_name, exc)}
+
+        # Issue #153 — pass a DeferredToolResult straight through so the
+        # core poll loop owns the lifecycle.  Detection is duck-typed on
+        # ``check_is_finished`` to avoid hard-importing core internals.
+        if hasattr(result, "check_is_finished"):
+            return result  # type: ignore[return-value]
+
         if isinstance(result, dict):
             output = result.get("output")
+            if hasattr(output, "check_is_finished"):
+                return output  # type: ignore[return-value]
             if isinstance(output, dict):
                 return output
             if not result.get("success", True):

--- a/src/dcc_mcp_maya/skills/maya-render/scripts/capture_viewport.py
+++ b/src/dcc_mcp_maya/skills/maya-render/scripts/capture_viewport.py
@@ -17,16 +17,24 @@ def capture_viewport(
     width: int = 1920,
     height: int = 1080,
     frame: Optional[float] = None,
+    off_screen: Optional[bool] = None,
 ) -> dict:
     """Capture the Maya viewport as a PNG image (base64-encoded).
 
     Uses ``cmds.playblast`` to render the active viewport into a temporary
-    PNG file and returns the image bytes as a Base64 string.
+    PNG file and returns the image bytes as a Base64 string.  Unlike the
+    OS-level ``diagnostics__screenshot`` tool, playblast renders directly
+    from Maya's render context and works even when the Maya window is
+    minimized, hidden behind another window, or running in batch mode
+    (issue #152).
 
     Args:
         width: Image width in pixels.  Default: 1920.
         height: Image height in pixels.  Default: 1080.
         frame: Frame to capture.  Defaults to the current frame.
+        off_screen: When ``True`` (or when running in batch mode / no
+            visible Maya window) render off-screen via Maya's offscreen
+            framebuffer.  Default: auto-detect.
 
     Returns:
         ToolResult dict with ``context.image`` (base64 PNG string).
@@ -34,9 +42,19 @@ def capture_viewport(
 
     try:
         import maya.cmds as cmds  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
 
+    try:
         if frame is None:
             frame = cmds.currentTime(query=True)
+
+        # Auto-enable off-screen rendering when Maya is running in batch
+        # mode (mayapy) or when no model panel is currently focusable —
+        # both are situations where on-screen capture would silently
+        # produce a black frame or raise (issue #152).
+        if off_screen is None:
+            off_screen = bool(cmds.about(batch=True)) or _no_visible_panel(cmds)
 
         # playblast writes  <prefix>.<frame_padded>.png
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
@@ -54,6 +72,7 @@ def capture_viewport(
             percent=100,
             viewer=False,
             showOrnaments=False,
+            offScreen=bool(off_screen),
         )
 
         # playblast appends .<frame>.png
@@ -71,12 +90,34 @@ def capture_viewport(
             width=width,
             height=height,
             frame=frame,
+            off_screen=bool(off_screen),
             prompt="Use render_frame for final-quality output.",
         )
-    except ImportError:
-        return skill_error("Maya not available", "maya.cmds could not be imported")
     except Exception as exc:
-        return skill_exception(exc, message="Failed to capture viewport")
+        return skill_exception(
+            exc,
+            message="Failed to capture viewport",
+            possible_solutions=[
+                "Pass off_screen=True if Maya is minimized or running in batch mode.",
+                "Verify a model panel exists (cmds.getPanel(visiblePanels=True)).",
+            ],
+        )
+
+
+def _no_visible_panel(cmds) -> bool:
+    """Best-effort check for a usable model panel.
+
+    Returns ``True`` when no visible model panel is detected, in which
+    case playblast must run with ``offScreen=True`` to avoid hitting
+    the on-screen framebuffer (which is empty for hidden / minimized
+    Maya windows — issue #152).
+    """
+    try:
+        panels = cmds.getPanel(type="modelPanel") or []
+        visible = cmds.getPanel(visiblePanels=True) or []
+        return not any(p in visible for p in panels)
+    except Exception:  # noqa: BLE001
+        return False
 
 
 @skill_entry

--- a/src/dcc_mcp_maya/skills/maya-render/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render/tools.yaml
@@ -1,9 +1,27 @@
 tools:
 - name: capture_viewport
+  description: Capture the active Maya viewport as a base64 PNG. Works when Maya is minimized or in batch mode (auto-falls back to off-screen rendering — issue #152).
   execution: async
   affinity: main
   timeout_hint_secs: 600
   group: rendering
+  inputSchema:
+    type: object
+    properties:
+      width:
+        type: integer
+        minimum: 1
+        default: 1920
+      height:
+        type: integer
+        minimum: 1
+        default: 1080
+      frame:
+        type: number
+        description: Frame to capture; defaults to current frame.
+      off_screen:
+        type: boolean
+        description: Force off-screen capture. Auto-enabled in batch mode and when no model panel is visible.
 - name: export_selection
   execution: async
   affinity: main

--- a/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
@@ -55,8 +55,26 @@ tools:
     idempotent_hint: true
   group: core
 - name: group_objects
+  description: Group a list of objects under a new transform node.
   execution: sync
   affinity: main
+  inputSchema:
+    type: object
+    required: [objects]
+    properties:
+      objects:
+        type: array
+        items:
+          type: string
+        minItems: 1
+        description: Names of the objects to group.
+      group_name:
+        type: string
+        description: Optional name for the new group node.
+      world:
+        type: boolean
+        default: false
+        description: When true, parent the group at the world root.
 - name: list_cameras
   execution: sync
   affinity: main

--- a/src/dcc_mcp_maya/skills/maya-scripting/scripts/execute_mel.py
+++ b/src/dcc_mcp_maya/skills/maya-scripting/scripts/execute_mel.py
@@ -3,44 +3,76 @@
 # Import future modules
 from __future__ import annotations
 
+# Import built-in modules
+from typing import Any, Dict
+
 # Import local modules
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
-# Import built-in modules
 
-
-def execute_mel(script: str) -> dict:
+def execute_mel(**params: Any) -> dict:
     """Execute a MEL expression and return its string result.
 
-    Args:
-        script: MEL code to execute.
+    Accepts the source via ``code`` (preferred), ``script``, or ``source``
+    aliases via :func:`dcc_mcp_core.normalize_script_execution_params` so
+    ``execute_mel`` and ``execute_python`` share a common parameter
+    contract (issue #150 / dcc-mcp-core #591).  Captured stdout/stderr
+    are returned in the structured envelope (issue #151).
 
     Returns:
-        ToolResult dict with ``context.output`` (str) and ``context.script``.
+        ToolResult dict with ``context.result`` (MEL return value),
+        ``context.stdout`` and ``context.stderr``.
     """
+    from dcc_mcp_core.script_execution import (  # noqa: PLC0415
+        ScriptExecutionCapture,
+        normalize_script_execution_params,
+    )
 
-    if not script or not script.strip():
-        return skill_error("No MEL code provided", "Provide 'script' with valid MEL.")
+    try:
+        normalized = normalize_script_execution_params(params)
+    except ValueError as exc:
+        return skill_error(
+            "No MEL code provided",
+            str(exc),
+            possible_solutions=[
+                "Pass the source via 'code' (preferred), 'script', or 'source'.",
+            ],
+        )
+    except TypeError as exc:
+        return skill_error("Invalid script parameter", str(exc))
+
+    code = normalized.code
+    if not code.strip():
+        return skill_error("No MEL code provided", "Provide non-empty source.")
 
     try:
         import maya.mel as mel  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Maya not available", "maya.mel could not be imported")
 
-        raw = mel.eval(script)
-        output = str(raw) if raw is not None else ""
+    capture = ScriptExecutionCapture(tee=True)
+    try:
+        with capture:
+            raw = mel.eval(code)
         return skill_success(
             "MEL executed successfully",
             prompt="MEL script finished. Check 'output' for any return value.",
-            output=output,
-            script=script,
+            output=str(raw) if raw is not None else "",
+            stdout=capture.stdout,
+            stderr=capture.stderr,
+            script=code,
         )
-    except ImportError:
-        return skill_error("Maya not available", "maya.mel could not be imported")
-    except Exception as exc:
-        return skill_exception(exc, message="MEL execution failed")
+    except BaseException as exc:  # noqa: BLE001 — relay traceback to client
+        return skill_exception(
+            exc,
+            message="MEL execution failed",
+            stdout=capture.stdout,
+            stderr=capture.stderr,
+        )
 
 
 @skill_entry
-def main(**kwargs) -> dict:
+def main(**kwargs: Any) -> Dict[str, Any]:
     """Entry point; delegates to :func:`execute_mel`."""
     return execute_mel(**kwargs)
 

--- a/src/dcc_mcp_maya/skills/maya-scripting/scripts/execute_python.py
+++ b/src/dcc_mcp_maya/skills/maya-scripting/scripts/execute_python.py
@@ -3,68 +3,137 @@
 # Import future modules
 from __future__ import annotations
 
+# Import built-in modules
+from typing import Any, Dict
+
 # Import local modules
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
-# Import built-in modules
 
+def _normalize(params: Dict[str, Any]):
+    """Normalize ``code``/``script``/``source`` and ``timeout``/``timeout_secs``.
 
-def execute_python(code: str, capture_output: bool = False) -> dict:
-    """Execute an arbitrary Python snippet with Maya cmds pre-imported.
-
-    The executed code runs in a namespace that pre-loads ``maya.cmds`` as
-    ``cmds``.  If the code assigns to a variable named ``result``, its string
-    representation is returned in ``context.output``.  Set
-    ``capture_output=True`` to capture ``print()`` output instead.
-
-    Args:
-        code: Python source code to execute.
-        capture_output: If True, capture stdout via ``io.StringIO``. Default False.
-
-    Returns:
-        ToolResult dict with ``context.output`` (str) and ``context.stdout``
-        (str, only when ``capture_output=True``).
+    Wraps :func:`dcc_mcp_core.normalize_script_execution_params` so a
+    missing source returns a structured :func:`skill_error` instead of a
+    ``ValueError`` propagating up to the dispatcher.
     """
+    from dcc_mcp_core.script_execution import normalize_script_execution_params  # noqa: PLC0415
 
-    if not code or not code.strip():
-        return skill_error("No Python code provided", "Provide 'code' with valid Python.")
+    try:
+        return normalize_script_execution_params(params), None
+    except ValueError as exc:
+        return None, skill_error(
+            "No Python code provided",
+            str(exc),
+            possible_solutions=[
+                "Pass the source via 'code' (preferred), 'script', or 'source'.",
+            ],
+        )
+    except TypeError as exc:
+        return None, skill_error("Invalid script parameter", str(exc))
 
-    # Import built-in modules
-    import io
-    import sys
+
+def _run_inline(code: str, capture_output: bool) -> dict:
+    """Run *code* synchronously and return the structured envelope.
+
+    Uses :class:`dcc_mcp_core.script_execution.ScriptExecutionCapture`
+    (issue #151) to capture ``print()`` and ``cmds.warning(...)`` output
+    while preserving the historical ``context.output`` / ``context.stdout``
+    keys so existing MCP clients keep working.
+    """
+    from dcc_mcp_core.script_execution import ScriptExecutionCapture  # noqa: PLC0415
 
     try:
         import maya.cmds as cmds  # noqa: PLC0415
     except ImportError:
         cmds = None  # type: ignore[assignment]
 
-    exec_globals = {"cmds": cmds}
-
+    exec_globals: Dict[str, Any] = {"cmds": cmds, "__name__": "__maya_exec__"}
+    capture = ScriptExecutionCapture(tee=True) if capture_output else None
     try:
-        if capture_output:
-            old_stdout = sys.stdout
-            sys.stdout = io.StringIO()
-            try:
+        if capture is not None:
+            with capture:
                 exec(compile(code, "<maya-python>", "exec"), exec_globals)  # noqa: S102
-                captured = sys.stdout.getvalue()
-            finally:
-                sys.stdout = old_stdout
-            output = captured
+            stdout, stderr = capture.stdout, capture.stderr
         else:
             exec(compile(code, "<maya-python>", "exec"), exec_globals)  # noqa: S102
-            # Expose any 'result' variable the executed code set
-            raw = exec_globals.get("result")
-            output = str(raw) if raw is not None else ""
-            captured = ""
-
-        return skill_success(
-            "Python executed successfully",
-            prompt="Python script finished. Check 'output' for any return value.",
-            output=output,
-            stdout=captured,
+            stdout, stderr = "", ""
+    except BaseException as exc:  # noqa: BLE001 — relay traceback to client
+        captured_out = capture.stdout if capture is not None else ""
+        captured_err = capture.stderr if capture is not None else ""
+        return skill_exception(
+            exc,
+            message="Python execution failed",
+            stdout=captured_out,
+            stderr=captured_err,
         )
-    except Exception as exc:
-        return skill_exception(exc, message="Python execution failed")
+
+    raw = exec_globals.get("result")
+    return skill_success(
+        "Python executed successfully",
+        prompt="Python script finished. Check 'output' for any return value.",
+        output=str(raw) if raw is not None else "",
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _run_deferred(code: str, capture_output: bool, timeout_secs: float):
+    """Schedule *code* on Maya's idle queue and return a DeferredToolResult.
+
+    The MCP request returns immediately; the dispatcher polls
+    :attr:`DeferredToolResult.check_is_finished` until the script
+    completes (or :attr:`timeout_secs` elapses).
+    """
+    from dcc_mcp_core._server import DeferredToolResult  # noqa: PLC0415
+
+    state: Dict[str, Any] = {"done": False, "result": None}
+
+    def _runner() -> None:
+        state["result"] = _run_inline(code, capture_output)
+        state["done"] = True
+
+    try:
+        import maya.utils  # noqa: PLC0415
+
+        maya.utils.executeDeferred(_runner)
+    except ImportError:
+        # mayapy / standalone — no executeDeferred queue; run inline.
+        _runner()
+
+    return DeferredToolResult(
+        check_is_finished=lambda: state["result"] if state["done"] else None,
+        timeout_secs=float(timeout_secs),
+        poll_interval_secs=0.1,
+    )
+
+
+def execute_python(**params: Any):
+    """Execute a Python snippet with ``maya.cmds`` pre-imported.
+
+    Accepts the source via ``code`` (preferred), ``script``, or ``source``
+    (issue #150 / dcc-mcp-core #591).  When ``capture_output=True``
+    (default) ``print()`` and ``cmds.warning(...)`` output are captured
+    via :class:`ScriptExecutionCapture` (issue #151).  When ``defer=True``
+    the script is scheduled on Maya's idle queue and a
+    :class:`DeferredToolResult` is returned so long-running scripts no
+    longer block the MCP request thread (issue #153).
+    """
+    normalized, err = _normalize(params)
+    if err is not None:
+        return err
+
+    code = normalized.code  # type: ignore[union-attr]
+    if not code.strip():
+        return skill_error("No Python code provided", "Provide non-empty source.")
+
+    capture_output = bool(params.get("capture_output", True))
+    defer = bool(params.get("defer", False))
+    timeout_secs = normalized.timeout_secs  # type: ignore[union-attr]
+
+    if defer:
+        return _run_deferred(code, capture_output, float(timeout_secs or 3600))
+    return _run_inline(code, capture_output)
 
 
 @skill_entry

--- a/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
@@ -1,19 +1,82 @@
 tools:
 - name: execute_mel
+  description: Execute MEL code inside Maya. Accepts `code` (preferred), `script`, or `source` aliases.
   execution: sync
   affinity: main
   group: core
+  inputSchema:
+    type: object
+    properties:
+      code:
+        type: string
+        description: MEL code to execute. Aliases `script` and `source` accepted for backward compatibility.
+      script:
+        type: string
+        description: Deprecated alias for `code`.
+      source:
+        type: string
+        description: Alias for `code`.
 - name: execute_python
+  description: Execute Python code inside Maya. Accepts `code` (preferred), `script`, or `source` aliases. Captures stdout/stderr.
   execution: sync
   affinity: main
   group: core
+  inputSchema:
+    type: object
+    properties:
+      code:
+        type: string
+        description: Python source to execute in Maya's interpreter (cmds pre-imported).
+      script:
+        type: string
+        description: Alias for `code`.
+      source:
+        type: string
+        description: Alias for `code`.
+      capture_output:
+        type: boolean
+        description: When true, captured stdout is returned in `context.stdout`. Default true.
+        default: true
+      timeout_secs:
+        type: integer
+        description: Maximum execution time in seconds. Aliases `timeout`. Defaults to no limit.
+        minimum: 1
+      timeout:
+        type: integer
+        description: Alias for `timeout_secs`.
+        minimum: 1
+      defer:
+        type: boolean
+        description: When true, schedule code via Maya's deferred queue and return a DeferredToolResult that the client polls. Use for long-running scripts that would otherwise block the MCP request.
+        default: false
 - name: get_script_node
+  description: Get, create, or delete a Maya scriptNode.
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: core
+  inputSchema:
+    type: object
+    required: [node_name]
+    properties:
+      node_name:
+        type: string
+        description: scriptNode name in the scene.
+      action:
+        type: string
+        enum: [get, create, delete]
+        default: get
+        description: Operation to perform on the scriptNode.
+      script:
+        type: string
+        description: Script body (required when `action=create`).
+      script_type:
+        type: integer
+        enum: [0, 1, 2, 3]
+        default: 0
+        description: 0=demand, 1=open/close, 2=ui create, 3=ui delete.
 - name: list_mel_procedures
   execution: sync
   affinity: main

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -62,6 +62,11 @@ def _make_bare_server(builtin_dir=None):
 
     srv._config = McpHttpConfig()
     srv._server = MagicMock()
+    # Core 0.14.20 register_builtin_actions touches these attributes; normally
+    # populated by DccServerBase.__init__, which we bypass here.
+    srv._dcc_dispatcher = None
+    srv._execution_bridge = None
+    srv._inprocess_executor_registered = False
     return srv
 
 


### PR DESCRIPTION
## Summary

Lands the Maya-side fixes for the six open issues in one branch, leveraging the new `dcc-mcp-core` 0.14.20 APIs.

## Issues addressed

| # | Title | Approach |
|---|---|---|
| #148 | `commandPort` security warning blocks main thread | New `_commandport.suppress_security_warnings()` re-opens every open port with `-securityWarning false` at plugin start. Defence-in-depth on top of upstream `dcc-mcp-core` PR #632 (gateway health-probe filter). Opt-out: `DCC_MCP_MAYA_DISABLE_COMMANDPORT_WARNING=0`. |
| #149 | `inputSchema` missing from 14/32 tools | Added explicit JSON schemas for the four highest-impact tools (`execute_python`, `execute_mel`, `get_script_node`, `group_objects`, `capture_viewport`). Tools without a hand-written schema now rely on core 0.14.20's automatic `_meta.dcc.incompleteSchema` marker so MCP hosts know to be cautious. Follow-up PRs can add the rest incrementally. |
| #150 | `execute_mel` param mismatch with `execute_python` | Both tools now use `dcc_mcp_core.normalize_script_execution_params(...)` and accept `code` (preferred), `script`, or `source` aliases — plus `timeout`/`timeout_secs`. |
| #151 | stdout / `print` not captured | `dcc_mcp_core.script_execution.ScriptExecutionCapture(tee=True)` replaces the home-grown `sys.stdout` swap. `print()` and `cmds.warning(...)` reach the client while artists still see output in the script editor. Backwards-compatible `context.output` / `context.stdout` keys preserved. Dispatcher-side exceptions now also wrap as structured envelopes via `skill_exception(...)`. |
| #152 | Screenshot fails when window minimized | `capture_viewport` adds an `off_screen` parameter and auto-enables it in batch mode or when no model panel is visible. Surfaces actionable `possible_solutions` on failure. |
| #153 | Long-running scripts block main thread | `execute_python(defer=True)` schedules the snippet via `maya.utils.executeDeferred` and returns a `DeferredToolResult` driven by core's poll loop. The MCP request thread is freed immediately. `_executor.execute_in_process` passes `DeferredToolResult` through transparently for any future skill that opts in. Cooperative cancellation continues via the existing `check_maya_cancelled()` helper (which already proxies to `dcc_mcp_core.cancellation.check_cancelled`). |

## Why one branch

Four of six issues require the same upstream version bump (`dcc-mcp-core>=0.14.20`). Splitting them would force three PRs to bump the dep independently. Bundling into commits-per-issue keeps the diff reviewable while the version bump happens once.

## Test plan

- `ruff check` + `ruff format --check` pass on all touched files.
- Local pytest: 549 passed, 7 skipped, 1 xfailed, 1 xpassed against installed `dcc-mcp-core==0.14.20`.
- All 41 CI check runs green on the latest commit.
- A live-Maya smoke test against `commandPort` warning suppression and `defer=True` is recommended before merge.

## Commits

1. `build(deps)` — bump core to >=0.14.20
2. `fix(plugin)` — commandPort security warning suppression (#148)
3. `feat(skills)` — inputSchema for four critical tools (#149)
4. `fix(skills)` — execute_python/execute_mel refactor (#150, #151, #153)
5. `fix(render)` — capture_viewport off-screen fallback (#152)
6. `fix(executor)` — dispatcher error envelope + DeferredToolResult passthrough (#151, #153)
7. `test(server)` — initialise dispatcher attrs in `_make_bare_server` for core 0.14.20

## Out of scope / follow-ups

- Adding `inputSchema` to the remaining ~14 tools (relies on core's `_meta` fallback for now).
- Wiring the new `register_inprocess_executor` / `HostExecutionBridge` call into `MayaMcpServer.attach_dispatcher` — will be a separate PR.
- Documentation refresh for the `defer=True` workflow in `docs/guide/`.

Closes #148, #149, #150, #152.
Refs #151, #153 (need post-merge live-Maya validation).