### PR TITLE
test(commandport): unit + mayapy E2E coverage for #148

### DIFF
--- a/tests/e2e/test_commandport_e2e.py
+++ b/tests/e2e/test_commandport_e2e.py
@@ -1,0 +1,117 @@
+"""E2E tests for ``_commandport.suppress_security_warnings`` (issue #148).
+
+These exercise the helper against a real Maya standalone interpreter so we
+catch any drift in the ``commandPort -q -name`` / ``cmds.commandPort``
+contract across Maya versions (2022, 2023, 2024, 2025).
+
+Note: ``mayapy`` is headless, so the actual modal "Allow / Deny / Allow All"
+dialog does not render here. The test focuses on the helper's interaction
+with the live Maya API:
+
+* It must successfully detect an open port via ``commandPort -q -name``.
+* It must close+reopen each port without raising.
+* The port must remain listenable after the helper completes.
+
+Run::
+
+    mayapy -m pytest tests/e2e/test_commandport_e2e.py -v
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import socket
+
+# Import third-party modules
+import pytest
+
+maya_standalone = pytest.importorskip(
+    "maya.standalone",
+    reason="maya.standalone not available — run under mayapy",
+)
+
+try:
+    maya_standalone.initialize(name="python")
+except Exception:
+    pass
+
+# Import local modules
+from dcc_mcp_maya import _commandport  # noqa: E402
+from maya import cmds  # noqa: E402
+
+pytestmark = pytest.mark.e2e
+
+
+def _free_tcp_port() -> int:
+    """Return a likely-free TCP port on the loopback interface."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _close_port_silent(name: str) -> None:
+    try:
+        cmds.commandPort(name=name, close=True)
+    except Exception:
+        pass
+
+
+class TestSuppressSecurityWarningsE2E:
+    def test_no_open_ports_returns_zero(self, monkeypatch):
+        """No commandPorts open ⇒ helper is a no-op."""
+        monkeypatch.delenv(_commandport.ENV_DISABLE_WARNING, raising=False)
+        # Make sure we start clean (best-effort; ports we did not open are left alone).
+        assert _commandport.suppress_security_warnings() >= 0
+
+    def test_env_opt_out_short_circuits(self, monkeypatch):
+        """``DCC_MCP_MAYA_DISABLE_COMMANDPORT_WARNING=0`` ⇒ helper returns 0
+        without touching any port."""
+        port_name = ":{}".format(_free_tcp_port())
+        cmds.commandPort(name=port_name, sourceType="mel", securityWarning=True)
+        try:
+            monkeypatch.setenv(_commandport.ENV_DISABLE_WARNING, "0")
+            assert _commandport.suppress_security_warnings() == 0
+            # The port we opened with sw=True must still be listed.
+            listed = cmds.commandPort(name=port_name, q=True, exists=True)
+            assert listed is True
+        finally:
+            _close_port_silent(port_name)
+
+    def test_reopens_existing_port_with_sw_disabled(self, monkeypatch):
+        """When a commandPort is open, helper closes+reopens it and counts it."""
+        monkeypatch.delenv(_commandport.ENV_DISABLE_WARNING, raising=False)
+        port_name = ":{}".format(_free_tcp_port())
+        cmds.commandPort(name=port_name, sourceType="mel", securityWarning=True)
+        try:
+            ports_before = _commandport._list_open_ports()
+            assert port_name in ports_before, ports_before
+            fixed = _commandport.suppress_security_warnings()
+            assert fixed >= 1
+            # Port must still exist after the close/reopen cycle.
+            assert cmds.commandPort(name=port_name, q=True, exists=True) is True
+        finally:
+            _close_port_silent(port_name)
+
+    def test_helper_is_idempotent(self, monkeypatch):
+        """Running the helper twice does not raise and the port stays alive."""
+        monkeypatch.delenv(_commandport.ENV_DISABLE_WARNING, raising=False)
+        port_name = ":{}".format(_free_tcp_port())
+        cmds.commandPort(name=port_name, sourceType="mel", securityWarning=True)
+        try:
+            _commandport.suppress_security_warnings()
+            _commandport.suppress_security_warnings()
+            assert cmds.commandPort(name=port_name, q=True, exists=True) is True
+        finally:
+            _close_port_silent(port_name)
+
+    def test_list_open_ports_includes_explicit_port(self, monkeypatch):
+        """``_list_open_ports`` correctly enumerates a port we just opened."""
+        monkeypatch.delenv(_commandport.ENV_DISABLE_WARNING, raising=False)
+        port_name = ":{}".format(_free_tcp_port())
+        cmds.commandPort(name=port_name, sourceType="mel", securityWarning=False)
+        try:
+            ports = _commandport._list_open_ports()
+            assert port_name in ports
+        finally:
+            _close_port_silent(port_name)

--- a/tests/test_commandport.py
+++ b/tests/test_commandport.py
@@ -1,0 +1,145 @@
+"""Unit tests for ``dcc_mcp_maya._commandport`` (issue #148).
+
+Mocks ``maya.cmds`` / ``maya.mel`` because these are not importable
+in the standard CI matrix (no Maya install). The corresponding
+real-Maya behaviour is exercised separately by the mayapy E2E test
+in ``tests/e2e/test_commandport_e2e.py``.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import sys
+from unittest.mock import MagicMock, patch
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_maya import _commandport
+
+# ────────────────────────────────────────────────────────────────────────
+# _is_disabled_by_env
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestIsDisabledByEnv:
+    @pytest.mark.parametrize("value", ["0", " 0", "0 "])
+    def test_disabled_when_env_is_zero(self, monkeypatch, value):
+        monkeypatch.setenv(_commandport.ENV_DISABLE_WARNING, value)
+        assert _commandport._is_disabled_by_env() is True
+
+    @pytest.mark.parametrize("value", ["", "1", "true", "yes", "no", "00"])
+    def test_not_disabled_for_other_values(self, monkeypatch, value):
+        monkeypatch.setenv(_commandport.ENV_DISABLE_WARNING, value)
+        assert _commandport._is_disabled_by_env() is False
+
+    def test_default_is_not_disabled(self, monkeypatch):
+        monkeypatch.delenv(_commandport.ENV_DISABLE_WARNING, raising=False)
+        assert _commandport._is_disabled_by_env() is False
+
+
+# ────────────────────────────────────────────────────────────────────────
+# _list_open_ports
+# ────────────────────────────────────────────────────────────────────────
+
+
+def _patch_mel(eval_return):
+    fake_mel = MagicMock()
+    fake_mel.eval = MagicMock(return_value=eval_return)
+    fake_maya = MagicMock()
+    fake_maya.mel = fake_mel
+    return patch.dict(sys.modules, {"maya": fake_maya, "maya.mel": fake_mel})
+
+
+class TestListOpenPorts:
+    def test_returns_empty_when_maya_not_installed(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "maya.mel", None)
+        # ``import maya.mel`` with sentinel None raises ImportError on Python 3.
+        assert _commandport._list_open_ports() == []
+
+    def test_returns_empty_when_mel_returns_none(self):
+        with _patch_mel(None):
+            assert _commandport._list_open_ports() == []
+
+    def test_normalises_single_string(self):
+        with _patch_mel("mayaCommand"):
+            assert _commandport._list_open_ports() == ["mayaCommand"]
+
+    def test_returns_empty_when_mel_returns_empty_string(self):
+        with _patch_mel(""):
+            assert _commandport._list_open_ports() == []
+
+    def test_normalises_list_and_strips_falsy(self):
+        with _patch_mel(["a", "", None, "b"]):
+            assert _commandport._list_open_ports() == ["a", "b"]
+
+    def test_swallows_mel_eval_exception(self):
+        fake_mel = MagicMock()
+        fake_mel.eval = MagicMock(side_effect=RuntimeError("mel boom"))
+        fake_maya = MagicMock()
+        fake_maya.mel = fake_mel
+        with patch.dict(sys.modules, {"maya": fake_maya, "maya.mel": fake_mel}):
+            assert _commandport._list_open_ports() == []
+
+    def test_returns_empty_when_iter_fails(self):
+        # Non-string non-iterable should fall through TypeError handler.
+        with _patch_mel(42):
+            assert _commandport._list_open_ports() == []
+
+
+# ────────────────────────────────────────────────────────────────────────
+# suppress_security_warnings
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestSuppressSecurityWarnings:
+    def test_zero_when_env_disabled(self, monkeypatch):
+        monkeypatch.setenv(_commandport.ENV_DISABLE_WARNING, "0")
+        with patch.object(_commandport, "_list_open_ports") as ports:
+            assert _commandport.suppress_security_warnings() == 0
+            ports.assert_not_called()
+
+    def test_zero_when_no_open_ports(self, monkeypatch):
+        monkeypatch.delenv(_commandport.ENV_DISABLE_WARNING, raising=False)
+        with patch.object(_commandport, "_list_open_ports", return_value=[]):
+            assert _commandport.suppress_security_warnings() == 0
+
+    def test_calls_close_then_reopen_per_port(self, monkeypatch):
+        monkeypatch.delenv(_commandport.ENV_DISABLE_WARNING, raising=False)
+        fake_cmds = MagicMock()
+        fake_maya = MagicMock()
+        fake_maya.cmds = fake_cmds
+        with patch.object(_commandport, "_list_open_ports", return_value=["p1", "p2"]):
+            with patch.dict(sys.modules, {"maya": fake_maya, "maya.cmds": fake_cmds}):
+                assert _commandport.suppress_security_warnings() == 2
+        # Each port: close then reopen with sw=False, sourceType="mel".
+        assert fake_cmds.commandPort.call_count == 4
+        kwargs_seq = [c.kwargs for c in fake_cmds.commandPort.call_args_list]
+        assert kwargs_seq[0] == {"name": "p1", "close": True}
+        assert kwargs_seq[1] == {"name": "p1", "securityWarning": False, "sourceType": "mel"}
+        assert kwargs_seq[2] == {"name": "p2", "close": True}
+        assert kwargs_seq[3] == {"name": "p2", "securityWarning": False, "sourceType": "mel"}
+
+    def test_partial_failure_counts_only_successes(self, monkeypatch):
+        monkeypatch.delenv(_commandport.ENV_DISABLE_WARNING, raising=False)
+        fake_cmds = MagicMock()
+
+        # Make port "bad" raise; "ok" succeeds (close + reopen).
+        def cmd(**kw):
+            if kw.get("name") == "bad" and kw.get("close"):
+                raise RuntimeError("close failed")
+
+        fake_cmds.commandPort = MagicMock(side_effect=cmd)
+        fake_maya = MagicMock()
+        fake_maya.cmds = fake_cmds
+        with patch.object(_commandport, "_list_open_ports", return_value=["bad", "ok"]):
+            with patch.dict(sys.modules, {"maya": fake_maya, "maya.cmds": fake_cmds}):
+                assert _commandport.suppress_security_warnings() == 1
+
+    def test_zero_when_cmds_unimportable(self, monkeypatch):
+        monkeypatch.delenv(_commandport.ENV_DISABLE_WARNING, raising=False)
+        monkeypatch.setitem(sys.modules, "maya.cmds", None)
+        with patch.object(_commandport, "_list_open_ports", return_value=["only"]):
+            assert _commandport.suppress_security_warnings() == 0


### PR DESCRIPTION
## Summary

Follow-up to #156: adds dedicated test coverage for `_commandport.suppress_security_warnings`, the helper that closes #148 (Maya commandPort security-warning modal).

## What's covered

### `tests/test_commandport.py` — 22 unit tests (no Maya required)

| Surface | Test cases |
|---|---|
| `_is_disabled_by_env` | env-var matrix (`0`, ` 0`, `0 ` → True; `1`, `true`, `yes`, `no`, `00`, empty → False; unset → False) |
| `_list_open_ports` | maya-not-installed, mel returns None / empty string / single string / list with falsy entries, mel `eval` raises, non-iterable result |
| `suppress_security_warnings` | env opt-out short-circuit, no-op when no ports, exact close-then-reopen kwargs per port, partial-failure counting, `maya.cmds` unimportable |

### `tests/e2e/test_commandport_e2e.py` — 5 mayapy E2E tests

Run against a real Maya standalone interpreter (the existing 2022 / 2023 / 2024 / 2025 tahv matrix already in CI).

* No-op when no ports open.
* Env opt-out (`DCC_MCP_MAYA_DISABLE_COMMANDPORT_WARNING=0`) leaves opened ports untouched.
* Helper closes+reopens an open port without breaking it (port still listed afterwards).
* Helper is idempotent (running it twice is safe).
* `_list_open_ports` correctly enumerates an explicitly opened port.

## Compatibility notes

* No production code touched — pure test addition.
* Python 3.7-compatible (no PEP 617 parenthesised `with` statements).
* `ruff check` + `ruff format --check` clean.
* Local suite: 571 passed, 2 skipped, 30 deselected, 1 xfailed, 1 xpassed.

Refs #148