### PR TITLE
docs(advanced): document defer=True long-running script workflow (#153)

### DIFF
--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -196,6 +196,125 @@ Or set the environment variable:
 set DCC_MCP_LOG_LEVEL=DEBUG
 ```
 
+## Long-Running Scripts: `defer=True`
+
+`execute_python` and any custom skill that returns a `DeferredToolResult` can keep the MCP request thread responsive while a long-running script (bake, render, simulation, IO) runs on Maya's idle queue.
+
+### When to use it
+
+| Scenario | Recommendation |
+|---|---|
+| Quick query / attribute write (< 1s) | `defer=False` (default) — synchronous reply |
+| Wall-clock 1–60s, no UI needed | `defer=True` — client polls until done |
+| Multi-minute work (renders, caches) | `defer=True` + raise `timeout_secs` |
+| Anything that must block the request | `defer=False` (default) |
+
+### From an MCP client (Claude / Cursor / Gemini)
+
+```jsonc
+// tools/call request
+{
+  "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+  "params": {
+    "name": "maya_scripting__execute_python",
+    "arguments": {
+      "code": "import maya.cmds as cmds\nfor f in range(1, 240):\n    cmds.currentTime(f)\n    cmds.refresh()\n",
+      "defer": true,
+      "timeout_secs": 600
+    }
+  }
+}
+```
+
+The server returns immediately with a deferred handle; `dcc-mcp-core` polls the handle every 100&nbsp;ms and streams the final `ToolResult` back to the client when the script completes (or `timeout_secs` elapses).
+
+### Cancellation
+
+Long-running scripts that opt into `defer=True` should also cooperate with cancellation:
+
+```python
+from dcc_mcp_maya import check_maya_cancelled
+
+for frame in frames:
+    check_maya_cancelled()       # raises CancelledError when cancelled
+    cmds.currentTime(frame)
+    cmds.render()
+```
+
+When the MCP client sends `notifications/cancelled` (or the dispatcher signals cancellation), `check_maya_cancelled()` raises and the deferred handle resolves with a structured error envelope.
+
+### Returning `DeferredToolResult` from a custom skill
+
+Any skill can adopt the same pattern by importing the helper from `dcc-mcp-core`:
+
+```python
+"""my_long_action.py"""
+from typing import Any, Dict
+
+
+def _runner(state: Dict[str, Any], target: str) -> None:
+    import maya.cmds as cmds
+    cmds.bakeResults(target, simulation=True, time=(1, 240))
+    state["result"] = {"success": True, "message": "Bake complete"}
+    state["done"] = True
+
+
+def main(target: str, defer: bool = True, timeout_secs: float = 600.0):
+    if not defer:
+        # Synchronous fallback (blocks the request thread).
+        state: Dict[str, Any] = {"done": False, "result": None}
+        _runner(state, target)
+        return state["result"]
+
+    from dcc_mcp_core._server import DeferredToolResult  # lazy import
+
+    state = {"done": False, "result": None}
+
+    def _kick() -> None:
+        _runner(state, target)
+
+    try:
+        import maya.utils
+        maya.utils.executeDeferred(_kick)
+    except ImportError:
+        # mayapy / standalone — no idle queue; run inline.
+        _kick()
+
+    return DeferredToolResult(
+        check_is_finished=lambda: state["result"] if state["done"] else None,
+        timeout_secs=float(timeout_secs),
+        poll_interval_secs=0.1,
+    )
+```
+
+Declare it as `execution: async` in `tools.yaml` so the dispatcher allocates a worker slot:
+
+```yaml
+- name: my_long_action
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
+  inputSchema:
+    type: object
+    properties:
+      target: { type: string }
+      defer: { type: boolean, default: true }
+      timeout_secs: { type: integer, default: 600, minimum: 1 }
+```
+
+### How the dispatcher routes deferred results
+
+`MayaMcpServer._executor` duck-types the return value: if it exposes `check_is_finished`, the result is passed straight through to `dcc-mcp-core`'s poll loop. No wrapping, no copy, no main-thread reflection. This means dispatcher errors raised before the deferred kick-off are still caught and returned as structured `{"success": False, ...}` envelopes, while the polled completion uses your skill's own envelope.
+
+### Configuration knobs
+
+| Env / arg | Default | Effect |
+|---|---|---|
+| `defer=True` (per-call argument) | `false` | Opt the call into the deferred path. |
+| `timeout_secs` (per-call argument) | `3600` | Hard timeout enforced by the core poll loop. |
+| `poll_interval_secs` (constructor) | `0.1` | How often the core re-checks `check_is_finished`. |
+| Tool's `timeout_hint_secs` (`tools.yaml`) | — | Advisory hint surfaced to the MCP host UI. |
+
 ## Production Considerations
 
 ### Security

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -72,5 +72,5 @@ Paths are resolved in order (highest priority first):
 
 - [Quick Start](./getting-started) — get Maya talking to Claude Desktop in 5 minutes
 - [Action List](./actions) — full catalogue of built-in MCP tools
-- [Advanced Usage](./advanced) — custom skills, main-thread scheduling
+- [Advanced Usage](./advanced) — custom skills, main-thread scheduling, `defer=True` long-running scripts
 - [Multi-instance Deployment](./multi-instance) — run multiple Maya instances on a single workstation

--- a/docs/zh/guide/advanced.md
+++ b/docs/zh/guide/advanced.md
@@ -144,6 +144,125 @@ logging.getLogger("dcc_mcp_maya").setLevel(logging.DEBUG)
 logging.getLogger("dcc_mcp_core").setLevel(logging.DEBUG)
 ```
 
+## 长任务执行：`defer=True`
+
+`execute_python` 以及任何返回 `DeferredToolResult` 的自定义技能都可以让 MCP 请求线程保持响应，而长任务（烘焙、渲染、模拟、IO）在 Maya 的 idle 队列上运行。
+
+### 何时使用
+
+| 场景 | 推荐 |
+|---|---|
+| 快速查询 / 属性写入（< 1s） | `defer=False`（默认）— 同步返回 |
+| 1–60s，无需 UI | `defer=True` — 客户端轮询直至完成 |
+| 多分钟任务（渲染、缓存） | `defer=True` 并提高 `timeout_secs` |
+| 必须阻塞请求 | `defer=False`（默认） |
+
+### 在 MCP 客户端中使用（Claude / Cursor / Gemini）
+
+```jsonc
+// tools/call 请求
+{
+  "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+  "params": {
+    "name": "maya_scripting__execute_python",
+    "arguments": {
+      "code": "import maya.cmds as cmds\nfor f in range(1, 240):\n    cmds.currentTime(f)\n    cmds.refresh()\n",
+      "defer": true,
+      "timeout_secs": 600
+    }
+  }
+}
+```
+
+服务端立即返回一个延迟句柄；`dcc-mcp-core` 每 100&nbsp;ms 轮询一次该句柄，并在脚本完成（或 `timeout_secs` 到期）时把最终的 `ToolResult` 推送给客户端。
+
+### 取消支持
+
+启用 `defer=True` 的长任务也应配合取消机制：
+
+```python
+from dcc_mcp_maya import check_maya_cancelled
+
+for frame in frames:
+    check_maya_cancelled()       # 取消时抛出 CancelledError
+    cmds.currentTime(frame)
+    cmds.render()
+```
+
+当 MCP 客户端发出 `notifications/cancelled`（或 dispatcher 触发取消）时，`check_maya_cancelled()` 抛出异常，延迟句柄会以结构化错误信封解析。
+
+### 在自定义技能中返回 `DeferredToolResult`
+
+任何技能都可以通过引入 `dcc-mcp-core` 的辅助类来采用同样的模式：
+
+```python
+"""my_long_action.py"""
+from typing import Any, Dict
+
+
+def _runner(state: Dict[str, Any], target: str) -> None:
+    import maya.cmds as cmds
+    cmds.bakeResults(target, simulation=True, time=(1, 240))
+    state["result"] = {"success": True, "message": "Bake complete"}
+    state["done"] = True
+
+
+def main(target: str, defer: bool = True, timeout_secs: float = 600.0):
+    if not defer:
+        # 同步回退（会阻塞请求线程）。
+        state: Dict[str, Any] = {"done": False, "result": None}
+        _runner(state, target)
+        return state["result"]
+
+    from dcc_mcp_core._server import DeferredToolResult  # 延迟导入
+
+    state = {"done": False, "result": None}
+
+    def _kick() -> None:
+        _runner(state, target)
+
+    try:
+        import maya.utils
+        maya.utils.executeDeferred(_kick)
+    except ImportError:
+        # mayapy / standalone — 没有 idle 队列；同步执行。
+        _kick()
+
+    return DeferredToolResult(
+        check_is_finished=lambda: state["result"] if state["done"] else None,
+        timeout_secs=float(timeout_secs),
+        poll_interval_secs=0.1,
+    )
+```
+
+在 `tools.yaml` 中声明为 `execution: async`，dispatcher 会为其分配 worker 槽位：
+
+```yaml
+- name: my_long_action
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
+  inputSchema:
+    type: object
+    properties:
+      target: { type: string }
+      defer: { type: boolean, default: true }
+      timeout_secs: { type: integer, default: 600, minimum: 1 }
+```
+
+### Dispatcher 如何路由延迟结果
+
+`MayaMcpServer._executor` 通过鸭子类型识别返回值：只要带有 `check_is_finished` 属性，结果就直接透传给 `dcc-mcp-core` 的轮询循环，无需包装、无需复制、无需主线程反射。这意味着延迟启动前抛出的 dispatcher 异常仍会被捕获并以结构化的 `{"success": False, ...}` 信封返回，而轮询完成时则使用技能自身的信封。
+
+### 配置项
+
+| 环境变量 / 参数 | 默认 | 作用 |
+|---|---|---|
+| `defer=True`（每次调用参数） | `false` | 让本次调用进入延迟路径 |
+| `timeout_secs`（每次调用参数） | `3600` | 由 core 轮询循环强制执行的硬超时 |
+| `poll_interval_secs`（构造器参数） | `0.1` | core 重新检查 `check_is_finished` 的间隔 |
+| `tools.yaml` 中的 `timeout_hint_secs` | — | 透传给 MCP 宿主 UI 的提示值 |
+
 ## 生产环境注意事项
 
 ### 安全

--- a/docs/zh/guide/index.md
+++ b/docs/zh/guide/index.md
@@ -70,5 +70,5 @@ maya-scene/
 
 - [快速开始](./getting-started) — 5 分钟让 Maya 与 Claude Desktop 联通
 - [Action 完整列表](./actions) — 所有内置 MCP 工具的完整目录
-- [高级用法](./advanced) — 自定义 Skill、主线程调度
+- [高级用法](./advanced) — 自定义 Skill、主线程调度、`defer=True` 长任务执行
 - [单机多实例部署](./multi-instance) — 在同一台工作站上运行多个 Maya 实例


### PR DESCRIPTION
## Summary

Follow-up to #156: documents the `defer=True` workflow that PR #156 wired into `execute_python` and `_executor` for issue #153.

New section **"Long-Running Scripts: `defer=True`"** added to:

* `docs/guide/advanced.md` (English)
* `docs/zh/guide/advanced.md` (中文)

`docs/guide/index.md` and `docs/zh/guide/index.md` cross-links updated to mention the new topic.

## What's covered

| Topic | Detail |
|---|---|
| When to opt in | Decision matrix — sync vs deferred vs hard-block |
| MCP `tools/call` request | Full JSON example for `maya_scripting__execute_python` with `defer=true` |
| Cancellation | `check_maya_cancelled()` cooperation pattern |
| Custom skills | Copy-pasteable template returning `DeferredToolResult` (lazy `dcc_mcp_core._server` import) |
| `tools.yaml` declaration | `execution: async` + `timeout_hint_secs` example |
| Executor wiring | Duck-typed `check_is_finished` pass-through (matches `_executor.py:138`) |
| Configuration knobs | Table: `defer`, `timeout_secs`, `poll_interval_secs`, `timeout_hint_secs` |

## Compatibility notes

* Pure documentation — no source code touched.
* EN + ZH parity preserved.
* Markdown only — no test impact.

Refs #153