### PR TITLE
fix(scripting): wire minimal skill handlers after load

### DIFF
--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -276,6 +276,12 @@ class MayaMcpServer(DccServerBase):
         else:
             _skill_loader.load_minimal_skills(self._server, _skill_loader.MINIMAL_SKILLS)
 
+        # Phase 4 — wire handlers for actions registered by Phase 3.
+        # Phase 2 only sees actions that were already loaded during discovery;
+        # minimal/default skill loading happens afterwards, so those new
+        # actions need a second pass or they fall back to subprocess execution.
+        _executor.wire_in_process_executor(self)
+
         return self
 
     def _strict_skill_scan(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -603,6 +603,25 @@ class TestMinimalMode:
         assert not server._server.is_loaded("maya-render-farm")
         server.stop()
 
+    def test_minimal_default_registers_core_skill_handlers(self):
+        """Minimal startup must wire newly-loaded core tools in-process.
+
+        Regression for issue #136: without the post-load wiring pass,
+        ``maya_scripting__execute_python`` is visible but has no Python handler,
+        so the core falls back to subprocess execution (mayapy).
+        """
+        srv_mod = _import_server()
+        server = srv_mod.MayaMcpServer(port=0)
+        try:
+            server.register_builtin_actions(
+                extra_skill_paths=[_builtin_skills_dir()],
+                minimal=True,
+            )
+
+            assert server._server.has_handler("maya_scripting__execute_python")
+        finally:
+            server.stop()
+
     def test_minimal_false_loads_all_skills(self):
         """With minimal=False, all discovered skills are loaded (legacy behaviour)."""
         srv_mod = _import_server()


### PR DESCRIPTION
## Summary
- Wire in-process handlers again after minimal/default skill loading so newly registered core tools do not fall back to mayapy subprocess execution.
- Add a regression test asserting `maya_scripting__execute_python` has an in-process handler after minimal startup.

## Test plan
- `python -m pytest tests/test_server.py -k "minimal_default_registers_core_skill_handlers or minimal_default_loads_only_core_skills" -q`