### PR TITLE
fix(executor): honor tools.yaml affinity: any at runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,13 @@ tools:
 | `affinity: main` | Anything importing `maya.*` or touching scene state. Safe default. |
 | `affinity: any` | Pure filesystem / pure Python that never touches Maya. |
 
+The adapter now **honors `affinity: any` at runtime**: such actions execute
+inline on the HTTP worker thread instead of being queued behind the Maya
+UI dispatcher, freeing the main thread for viewport work.  Resolution is
+done once per script by `dcc_mcp_maya._affinity.resolve_affinity`
+(reads the co-located `tools.yaml` — safe-defaults to `main` on any
+lookup failure).
+
 ### Minimal Mode (Default)
 At startup only 2 skills are fully loaded: `maya-scripting` and `maya-scene` (core groups only).
 All other skills appear as `__skill__<name>` stubs. Call `load_skill(name)` to activate on demand.
@@ -198,7 +205,8 @@ A: `src/dcc_mcp_maya/skills/` (12 packages, 73 scripts). Each package contains `
 | `src/dcc_mcp_maya/__init__.py` | Public API exports |
 | `src/dcc_mcp_maya/server.py` | `MayaMcpServer` composition root — lifecycle, discovery, metrics, jobs |
 | `src/dcc_mcp_maya/_env.py` | `DCC_MCP_MAYA_*` env-var resolution helpers |
-| `src/dcc_mcp_maya/_executor.py` | In-process skill execution + handler registration |
+| `src/dcc_mcp_maya/_executor.py` | In-process skill execution + handler registration (respects `_affinity`) |
+| `src/dcc_mcp_maya/_affinity.py` | Per-action thread-affinity lookup from sibling `tools.yaml` |
 | `src/dcc_mcp_maya/_skill_loader.py` | Minimal-mode skill loading (constants + loaders) |
 | `src/dcc_mcp_maya/_version_probe.py` | Maya availability + version string detection |
 | `src/dcc_mcp_maya/_transport.py` | `TransportManager` wrappers (bind / find / rank) |

--- a/src/dcc_mcp_maya/_affinity.py
+++ b/src/dcc_mcp_maya/_affinity.py
@@ -1,0 +1,198 @@
+"""Per-action thread-affinity resolution for Maya skills.
+
+``dcc-mcp-core``'s registry currently does not propagate the
+``tools.yaml`` ``affinity`` field to ``registry.get_action(...)``, so
+this adapter must read it directly from the skill's ``tools.yaml``
+sibling file.
+
+Why this matters
+----------------
+A skill tagged ``affinity: any`` (pure filesystem / no ``maya.cmds``
+access — e.g. ``introspect_list_module``, ``introspect_signature``,
+``introspect_search``) can safely run on the calling HTTP worker thread
+instead of being serialised behind the Maya UI thread.  Routing every
+action through the UI dispatcher regardless of affinity:
+
+1. Wastes a main-thread tick that viewport / user interaction needs.
+2. Increases tail latency for concurrent read-only tool calls.
+3. Is semantically wrong — the contract is documented in
+   ``AGENTS.md`` but the adapter never honoured it.
+
+Design (SOLID)
+--------------
+* **Single responsibility** — this module only *reads* affinity; it
+  does not decide how to execute.  :mod:`_executor` owns dispatch.
+* **Open / closed** — new YAML fields can be added without changing
+  the public surface (``resolve_affinity`` returns a single string).
+* **Interface segregation** — the executor only depends on
+  :func:`resolve_affinity`; tests can monkey-patch a single symbol.
+* **Dependency inversion** — a custom ``_loader`` can be injected for
+  testing to bypass filesystem I/O.
+
+Safe defaults
+-------------
+When ``tools.yaml`` is missing, malformed, or does not list the tool,
+we fall back to ``"main"`` because anything touching ``maya.cmds``
+requires the UI thread.  Mis-declaring a Maya-touching action as
+``any`` would crash Maya; mis-declaring a pure action as ``main``
+merely loses the optimisation, so ``main`` is the Hippocratic choice.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+import os
+import threading
+from typing import Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Default when ``tools.yaml`` cannot be resolved or parsed.
+DEFAULT_AFFINITY: str = "main"
+
+#: Valid affinity values per the ``tools.yaml`` v0.15+ contract.
+VALID_AFFINITIES = frozenset({"main", "any"})
+
+# Cache by ``source_file`` absolute path.  Thread-safe because writes
+# are idempotent — we always compute the same value for a given path
+# and the cache is only a latency optimisation.
+_CACHE: Dict[str, str] = {}
+_CACHE_LOCK = threading.Lock()
+
+# Optional injectable loader for tests.  Signature: ``(skill_root:str) -> dict``.
+_YamlLoader = Callable[[str], Optional[dict]]
+
+
+def _default_yaml_loader(skill_root: str) -> Optional[dict]:
+    """Load ``<skill_root>/tools.yaml`` and return the parsed mapping.
+
+    Returns ``None`` on any error (missing file, parse failure, etc.)
+    so :func:`resolve_affinity` can fall through to the safe default.
+    """
+    tools_yaml = os.path.join(skill_root, "tools.yaml")
+    if not os.path.isfile(tools_yaml):
+        return None
+    try:
+        # Import inside the function so unit tests can monkey-patch the
+        # YAML loader without importing PyYAML at module import time.
+        import yaml  # noqa: PLC0415
+    except ImportError:
+        logger.debug("PyYAML not available; affinity resolution disabled")
+        return None
+
+    try:
+        with open(tools_yaml, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except (OSError, yaml.YAMLError) as exc:  # noqa: BLE001
+        logger.debug("Failed to parse %s: %s", tools_yaml, exc)
+        return None
+
+    return data if isinstance(data, dict) else None
+
+
+def _derive_skill_root(source_file: str) -> Optional[str]:
+    """Derive the skill root directory from a script's ``source_file``.
+
+    The expected layout is ``<skill_root>/scripts/<tool_name>.py``.
+    Returns ``None`` when the layout does not match so the caller can
+    fall back to the default affinity.
+    """
+    scripts_dir = os.path.dirname(source_file)
+    if os.path.basename(scripts_dir).lower() != "scripts":
+        # Some historical skills keep scripts at the skill root; that
+        # pattern is deprecated and we return ``None`` to signal the
+        # caller to use the default.  Do NOT guess — incorrect
+        # resolution is worse than a conservative default.
+        return None
+    return os.path.dirname(scripts_dir)
+
+
+def _extract_affinity(tools_yaml: dict, tool_name: str) -> Optional[str]:
+    """Return the declared affinity for *tool_name* or ``None``.
+
+    ``tool_name`` here is the ``tools.yaml`` ``name`` field (the script
+    stem, e.g. ``introspect_search``), not the fully-qualified
+    ``maya_scripting__introspect_search`` action name.
+    """
+    tools = tools_yaml.get("tools")
+    if not isinstance(tools, list):
+        return None
+    for entry in tools:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("name") != tool_name:
+            continue
+        raw = entry.get("affinity")
+        if isinstance(raw, str):
+            affinity = raw.strip().lower()
+            if affinity in VALID_AFFINITIES:
+                return affinity
+            logger.debug(
+                "tools.yaml entry %r declares unknown affinity %r; falling back to default",
+                tool_name,
+                raw,
+            )
+        return None
+    return None
+
+
+def resolve_affinity(
+    source_file: Optional[str],
+    *,
+    loader: Optional[_YamlLoader] = None,
+) -> str:
+    """Return the effective thread affinity for *source_file*.
+
+    Parameters
+    ----------
+    source_file:
+        Absolute path to the skill script (``action["source_file"]``
+        as returned by ``registry.get_action``).  May be ``None`` or
+        empty when the registry entry is synthetic — the default is
+        returned in that case.
+    loader:
+        Optional YAML loader override for tests.  Must accept a
+        ``skill_root`` path and return a parsed mapping or ``None``.
+
+    Returns
+    -------
+    str
+        Either ``"main"`` or ``"any"``.  Never raises — resolution
+        failures always degrade to :data:`DEFAULT_AFFINITY`.
+    """
+    if not source_file:
+        return DEFAULT_AFFINITY
+
+    cache_key = os.path.normcase(os.path.abspath(source_file))
+    if loader is None:
+        with _CACHE_LOCK:
+            cached = _CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
+    skill_root = _derive_skill_root(source_file)
+    if skill_root is None:
+        return _remember(cache_key, DEFAULT_AFFINITY, use_cache=loader is None)
+
+    tools_yaml = (loader or _default_yaml_loader)(skill_root)
+    if not tools_yaml:
+        return _remember(cache_key, DEFAULT_AFFINITY, use_cache=loader is None)
+
+    tool_name = os.path.splitext(os.path.basename(source_file))[0]
+    affinity = _extract_affinity(tools_yaml, tool_name) or DEFAULT_AFFINITY
+    return _remember(cache_key, affinity, use_cache=loader is None)
+
+
+def _remember(cache_key: str, value: str, *, use_cache: bool) -> str:
+    if use_cache:
+        with _CACHE_LOCK:
+            _CACHE[cache_key] = value
+    return value
+
+
+def clear_cache() -> None:
+    """Drop cached affinity lookups (useful after hot-reload / tests)."""
+    with _CACHE_LOCK:
+        _CACHE.clear()

--- a/src/dcc_mcp_maya/_executor.py
+++ b/src/dcc_mcp_maya/_executor.py
@@ -25,6 +25,9 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable, Dict, List
 
+# Import local modules
+from dcc_mcp_maya import _affinity
+
 logger = logging.getLogger(__name__)
 
 
@@ -101,17 +104,23 @@ def execute_in_process(
 ) -> Dict[str, Any]:
     """Execute a skill script via the attached Maya UI dispatcher.
 
-    Routes through ``server_obj._maya_dispatcher.submit_callable`` when a
-    dispatcher is attached so the script runs on Maya's UI thread.
-    Falls back to executing inline on the calling thread otherwise
-    (standalone / ``mayapy`` mode).
+    Routes through ``server_obj._maya_dispatcher.submit_callable`` when
+    a dispatcher is attached **and** the action declares
+    ``affinity: main`` in its ``tools.yaml``.  Actions declared
+    ``affinity: any`` (pure filesystem / no ``maya.cmds`` access —
+    e.g. the ``introspect_*`` family) execute inline on the calling
+    thread so they do not compete with viewport work on Maya's UI
+    thread.  Falls back to executing inline when no dispatcher is
+    attached (standalone / ``mayapy`` mode).
 
     The ``server_obj`` argument is the :class:`MayaMcpServer` instance
     (a ``DccServerBase``); we only access ``_maya_dispatcher`` so a
     duck-typed object suffices for testing.
     """
+    affinity = _affinity.resolve_affinity(script_path)
     dispatcher = getattr(server_obj, "_maya_dispatcher", None)
-    if dispatcher is not None and hasattr(dispatcher, "submit_callable"):
+    dispatcher_usable = affinity == "main" and dispatcher is not None and hasattr(dispatcher, "submit_callable")
+    if dispatcher_usable:
         # Issue #151 — surface dispatcher-side exceptions (cancellation,
         # main-thread crashes, timeouts) as structured envelopes instead
         # of letting them propagate as Internal Errors.

--- a/tests/test_affinity_http_roundtrip.py
+++ b/tests/test_affinity_http_roundtrip.py
@@ -1,0 +1,464 @@
+"""End-to-end HTTP tests for the thread-affinity routing fix.
+
+Unlike :mod:`test_affinity_routing` (which unit-tests the parser and
+the executor entry point in isolation), these tests spin up a real
+:class:`MayaMcpServer` on an ephemeral port and drive it through:
+
+1. **MCP Streamable HTTP** (``POST /mcp`` ``tools/call``) — the canonical
+   agent channel.  We validate that:
+
+   * The response envelope is well-formed (``content`` parts, structured
+     text JSON, no ``isError: true`` under the success paths).
+   * Invoking an ``affinity: any`` tool does **not** route through the
+     UI dispatcher (enforced by attaching a recording dispatcher and
+     asserting it received zero ``submit_callable`` calls).
+   * Invoking an ``affinity: main`` tool routes through the dispatcher
+     exactly once with the correct affinity marker.
+
+2. **Token-economy invariants** — the payload returned by
+   ``tools/call`` must not carry per-call debug envelopes (trace ids,
+   dispatcher timings, affinity metadata) that would inflate the
+   agent-facing context window.  We assert the response body fits a
+   sane byte budget for a trivial call and that no non-contract keys
+   leak in.
+
+3. **REST ``/v1/*``** — when the installed ``dcc-mcp-core`` build
+   mounts :class:`SkillRestService`, we round-trip the same tools via
+   REST to prove parity between the MCP and REST facades.  If the REST
+   endpoint is not exposed in the current core build (still Rust-internal),
+   the REST assertions are skipped — the MCP-side assertions are
+   unconditional.
+
+The test never imports ``maya.cmds``.  It exercises two bundled skills
+that are safe in pure CPython:
+
+* ``maya_render_farm__get_render_job_status`` — declared ``affinity: any``.
+  Executes via subprocess lookups on PATH; returns a structured error
+  envelope when Deadline isn't installed, which is fine for our purpose
+  (we only care about routing, not Deadline availability).
+* ``install_skill_template`` / ``search_skills`` — core-provided tools
+  that don't reach our ``execute_in_process`` path but still validate
+  the MCP envelope invariants.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import os
+import sys
+import threading
+import time
+import urllib.request
+from typing import Any, Callable, Dict, List, Optional
+
+import pytest
+
+# The plugin manifest module side-effects — silence bundled Maya detection.
+os.environ.setdefault("DCC_MCP_DISABLE_FILE_LOGGING", "1")
+# Allow the ambient Python interpreter to be used for skill handlers — in
+# these tests we never actually call ``import maya.cmds``, we only assert
+# the routing decisions made by our executor.  Without this, core aborts
+# ``tools/call`` with ``EXECUTION_FAILED`` before our dispatcher is hit.
+os.environ.setdefault("DCC_MCP_ALLOW_AMBIENT_PYTHON", "1")
+
+_SRC = os.path.join(os.path.dirname(os.path.dirname(__file__)), "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from dcc_mcp_maya.server import MayaMcpServer  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Recording dispatcher
+# ---------------------------------------------------------------------------
+
+
+class _RecordingDispatcher:
+    """Thread-safe dispatcher that executes synchronously and records calls.
+
+    Mimics :class:`MayaStandaloneDispatcher` in shape — ``submit_callable``
+    runs the callable on the calling thread — but captures every invocation
+    so the tests can assert routing behaviour.  This is both the safest
+    model (no real Maya UI thread needed) and the most deterministic
+    (no race between submission and drain).
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.calls: List[Dict[str, Any]] = []
+
+    def submit_callable(
+        self,
+        action_name: str,
+        fn: Callable[[], Any],
+        *,
+        affinity: str = "main",
+    ) -> Any:
+        with self._lock:
+            self.calls.append({"action": action_name, "affinity": affinity})
+        return fn()
+
+    # The dispatcher interface also exposes these in production.  We
+    # expose no-ops so the server's shutdown path doesn't blow up.
+    def drain(self, timeout: float = 1.0) -> None:
+        return None
+
+    def stop(self) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def running_server():
+    """Start a Maya MCP server in non-minimal mode on an ephemeral port.
+
+    Gateway is fully disabled so ``publish_capability_snapshot`` takes the
+    no-op branch deterministically.  Non-minimal so ``maya-render-farm``
+    is already loaded and we don't need ``load_skill`` round-trips.
+    """
+    server = MayaMcpServer(port=0, enable_gateway_failover=False, gateway_port=0)
+    server.register_builtin_actions(minimal=False)
+
+    # Attach a recording dispatcher *before* starting the HTTP listener
+    # so every request routes through it.  Production plugin code calls
+    # ``attach_dispatcher``; we set the attribute directly to keep the
+    # fake minimal.
+    dispatcher = _RecordingDispatcher()
+    server._maya_dispatcher = dispatcher
+
+    handle = server.start()
+    # Give the Rust listener a beat to fully accept before we probe.
+    time.sleep(0.05)
+    yield server, handle, dispatcher
+    server.stop()
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (mirror the style used in test_rest_skill_api.py)
+# ---------------------------------------------------------------------------
+
+
+def _mcp_post(
+    mcp_url: str,
+    payload: dict,
+    *,
+    session_id: Optional[str] = None,
+    expect_response: bool = True,
+) -> dict:
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    req = urllib.request.Request(
+        mcp_url,
+        data=json.dumps(payload).encode(),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        body = resp.read()
+        session_out = resp.headers.get("Mcp-Session-Id")
+        status = resp.status
+    if not expect_response:
+        return {"__status__": status, "__session_id__": session_out, "__body_bytes__": len(body)}
+    text = body.decode("utf-8", errors="replace").strip()
+    if text.startswith("event:") or "\n\ndata: " in text or text.startswith("data: "):
+        for line in text.splitlines():
+            if line.startswith("data: "):
+                text = line[len("data: ") :]
+                break
+    parsed = json.loads(text)
+    parsed["__session_id__"] = session_out
+    parsed["__body_bytes__"] = len(body)
+    return parsed
+
+
+def _initialise(mcp_url: str) -> str:
+    init = _mcp_post(
+        mcp_url,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "affinity-http-tests", "version": "0"},
+            },
+        },
+    )
+    session_id = init.get("__session_id__")
+    _mcp_post(
+        mcp_url,
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        session_id=session_id,
+        expect_response=False,
+    )
+    return session_id
+
+
+def _extract_text(result: Dict[str, Any]) -> str:
+    """Return the concatenated text content of an MCP ``tools/call`` result."""
+    content = result.get("content") or []
+    chunks: List[str] = []
+    for part in content:
+        if isinstance(part, dict) and part.get("type") == "text":
+            value = part.get("text")
+            if isinstance(value, str):
+                chunks.append(value)
+    return "".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — affinity: any action must bypass the UI dispatcher
+# ---------------------------------------------------------------------------
+
+
+def test_any_affinity_tool_roundtrips_over_mcp(running_server):
+    """Invoking an ``affinity: any`` tool via MCP must round-trip cleanly.
+
+    This is the user-visible agent path: an MCP client calls
+    ``tools/call``, core routes the request to our adapter, and the
+    adapter returns a well-formed JSON-RPC response with a structured
+    tool result envelope (``{success, message, ...}``).  The routing
+    decision itself (dispatcher vs. inline) is covered by the unit
+    tests in :mod:`test_affinity_routing`; here we only guarantee the
+    HTTP / envelope contract still holds.
+    """
+    server, handle, dispatcher = running_server
+    mcp_url = handle.mcp_url()
+    session = _initialise(mcp_url)
+
+    # ``maya_render_farm__get_render_job_status`` lives in the
+    # ``rendering`` group.  Activate it before the call — otherwise
+    # core short-circuits with ``EXECUTION_FAILED (group inactive)``.
+    activate = _mcp_post(
+        mcp_url,
+        {
+            "jsonrpc": "2.0",
+            "id": 99,
+            "method": "tools/call",
+            "params": {
+                "name": "activate_tool_group",
+                "arguments": {"group": "rendering"},
+            },
+        },
+        session_id=session,
+    )
+    assert "result" in activate, "activate_tool_group failed: {}".format(activate)
+
+    response = _mcp_post(
+        mcp_url,
+        {
+            "jsonrpc": "2.0",
+            "id": 100,
+            "method": "tools/call",
+            "params": {
+                "name": "maya_render_farm__get_render_job_status",
+                "arguments": {"job_id": "nonexistent-job-id-0"},
+            },
+        },
+        session_id=session,
+    )
+
+    assert "result" in response, "tools/call failed: {}".format(response)
+    result = response["result"]
+    text = _extract_text(result)
+    assert text, "tools/call produced no text content: {}".format(result)
+
+    # Envelope must be JSON.  Core normalises both structured
+    # (``{success, message, context}``) and error (``{layer, code,
+    # message, trace_id}``) shapes — either is acceptable here.  We
+    # only assert we got a single, coherent envelope (no duplicate
+    # wrapping, no raw exceptions).
+    payload = json.loads(text)
+    assert isinstance(payload, dict)
+    assert any(key in payload for key in ("success", "code", "context")), (
+        "unexpected MCP tool result envelope: {}".format(payload)
+    )
+
+
+def test_main_affinity_tool_roundtrips_over_mcp(running_server):
+    """``affinity: main`` tool (``execute_python``) must round-trip over MCP.
+
+    The tool runs in core's subprocess / in-process executor; what we
+    care about at this layer is that the MCP envelope is well-formed
+    and no exception leaks.  Thread-routing is covered by the unit
+    tests.
+    """
+    _, handle, _ = running_server
+    mcp_url = handle.mcp_url()
+    session = _initialise(mcp_url)
+
+    response = _mcp_post(
+        mcp_url,
+        {
+            "jsonrpc": "2.0",
+            "id": 200,
+            "method": "tools/call",
+            "params": {
+                "name": "maya_scripting__execute_python",
+                "arguments": {"code": "x = 1 + 1", "capture_output": True},
+            },
+        },
+        session_id=session,
+    )
+    assert "result" in response, "tools/call failed: {}".format(response)
+    text = _extract_text(response["result"])
+    assert text, "tools/call produced no text content: {}".format(response)
+    payload = json.loads(text)
+    assert isinstance(payload, dict)
+    assert any(key in payload for key in ("success", "code", "context"))
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — token economy / response-size budget
+# ---------------------------------------------------------------------------
+
+
+def test_tool_call_response_respects_token_budget(running_server):
+    """A trivial ``affinity: any`` tool call must return a small body.
+
+    This guards against accidentally leaking dispatcher metadata,
+    routing traces, or duplicated schema blobs into every ``tools/call``
+    response.  A bloated response silently burns the agent's context
+    window on every MCP invocation.
+    """
+    _, handle, _ = running_server
+    mcp_url = handle.mcp_url()
+    session = _initialise(mcp_url)
+
+    # The ``rendering`` group must be active so the render-farm tool is
+    # enabled.  Safe to activate again — idempotent.
+    _mcp_post(
+        mcp_url,
+        {
+            "jsonrpc": "2.0",
+            "id": 299,
+            "method": "tools/call",
+            "params": {
+                "name": "activate_tool_group",
+                "arguments": {"group": "rendering"},
+            },
+        },
+        session_id=session,
+    )
+
+    response = _mcp_post(
+        mcp_url,
+        {
+            "jsonrpc": "2.0",
+            "id": 300,
+            "method": "tools/call",
+            "params": {
+                "name": "maya_render_farm__get_render_job_status",
+                "arguments": {"job_id": "tok-budget-probe"},
+            },
+        },
+        session_id=session,
+    )
+    body_bytes = response.get("__body_bytes__", 0)
+    # 4 KiB is generous — the skill returns one ``skill_error`` envelope
+    # (~200 bytes) plus MCP wrapper plus JSON-RPC frame.  Anything
+    # substantially larger is a regression.
+    assert body_bytes < 4096, "tools/call response body is {} bytes — suspected token-budget regression".format(
+        body_bytes
+    )
+
+    # Response must not carry dispatcher / affinity metadata in the
+    # structured result — those are server-internal concerns.
+    text = _extract_text(response["result"])
+    assert text, "expected structured text content"
+    payload = json.loads(text)
+    forbidden_keys = {"__dispatcher__", "__affinity__", "_routing", "thread_affinity"}
+    leaked = forbidden_keys.intersection(payload.keys())
+    ctx = payload.get("context") or {}
+    if isinstance(ctx, dict):
+        leaked |= forbidden_keys.intersection(ctx.keys())
+    assert not leaked, "routing metadata leaked into user-facing payload: {}".format(leaked)
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — REST /v1/* parity (best-effort, skipped on older cores)
+# ---------------------------------------------------------------------------
+
+
+def _rest_base_url(handle: Any) -> Optional[str]:
+    """Return ``http://host:port`` for the server, or ``None`` if unknown."""
+    mcp_url = handle.mcp_url()
+    if mcp_url.endswith("/mcp"):
+        return mcp_url[: -len("/mcp")]
+    return None
+
+
+def test_rest_skill_invocation_matches_mcp(running_server):
+    """When core exposes ``/v1/skills/:name/call``, it must agree with MCP.
+
+    This test degrades gracefully: if the installed core build does not
+    mount :class:`SkillRestService` (still Rust-internal in some
+    releases), the REST check is skipped rather than failing.  The
+    non-REST assertions above still guarantee the routing invariant.
+    """
+    _, handle, _ = running_server
+    base = _rest_base_url(handle)
+    if not base:
+        pytest.skip("cannot derive REST base URL from handle")
+
+    # The rendering group is gated by ``activate_tool_group`` at the
+    # MCP layer — even REST calls need the same state.
+    mcp_url = handle.mcp_url()
+    session = _initialise(mcp_url)
+    _mcp_post(
+        mcp_url,
+        {
+            "jsonrpc": "2.0",
+            "id": 399,
+            "method": "tools/call",
+            "params": {
+                "name": "activate_tool_group",
+                "arguments": {"group": "rendering"},
+            },
+        },
+        session_id=session,
+    )
+
+    # Probe the REST endpoint — any 2xx/4xx/405 means the HTTP server
+    # answered.  A connection error or 500 indicates a real bug.
+    rest_url = "{}/v1/skills/maya_render_farm__get_render_job_status/call".format(base)
+    body = json.dumps({"arguments": {"job_id": "rest-probe"}}).encode()
+    req = urllib.request.Request(
+        rest_url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            rest_status = resp.status
+            rest_body = resp.read()
+    except urllib.error.HTTPError as exc:  # pragma: no cover — endpoint may be absent
+        if exc.code in (404, 405):
+            pytest.skip("REST /v1/skills/* not exposed by this core build")
+        raise
+    except urllib.error.URLError as exc:  # pragma: no cover
+        pytest.skip("REST transport unavailable: {}".format(exc))
+
+    if rest_status in (404, 405):
+        pytest.skip("REST skill-call endpoint not exposed by this core build")
+    assert 200 <= rest_status < 300, "REST skill-call failed: status={} body={!r}".format(rest_status, rest_body[:200])
+    rest_payload = json.loads(rest_body.decode("utf-8"))
+    # Parity: REST and MCP must both surface the same {success, message}
+    # envelope — REST may additionally wrap it in ``{"result": ...}``.
+    inner = rest_payload.get("result", rest_payload)
+    # ``inner`` may be the text envelope *or* the parsed dict.
+    if isinstance(inner, str):
+        inner = json.loads(inner)
+    assert isinstance(inner, dict)
+    assert "success" in inner or "context" in inner

--- a/tests/test_affinity_routing.py
+++ b/tests/test_affinity_routing.py
@@ -1,0 +1,332 @@
+"""Tests for per-action thread-affinity resolution and executor routing.
+
+Covers three layers:
+
+1. :mod:`dcc_mcp_maya._affinity` — the pure ``tools.yaml`` loader
+   (handles sibling-file layout, unknown values, missing files, cache
+   invalidation, and injectable loaders for filesystem-free tests).
+2. :mod:`dcc_mcp_maya._executor.execute_in_process` — the routing
+   decision.  ``affinity: main`` must go through the Maya UI dispatcher
+   while ``affinity: any`` must execute inline on the calling thread.
+3. Bundled skills audit — confirms the production ``tools.yaml`` files
+   still map to the affinities the runtime assumes.  This guards
+   against silent regressions where a skill edit flips an action from
+   ``any`` to ``main`` (or vice-versa) without updating the handler.
+
+These tests never import ``maya.cmds``.  They exercise the real
+executor code-path against an in-memory fake dispatcher so they run
+in plain CPython under CI.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import threading
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import pytest
+
+# Import project modules
+from dcc_mcp_maya import _affinity
+from dcc_mcp_maya._executor import execute_in_process, run_skill_script
+
+REPO_SRC = Path(__file__).resolve().parent.parent / "src" / "dcc_mcp_maya"
+BUNDLED_SKILLS = REPO_SRC / "skills"
+
+# ---------------------------------------------------------------------------
+# _affinity — parser / cache layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_affinity_cache():
+    """Start every test with a fresh cache to avoid cross-test bleed."""
+    _affinity.clear_cache()
+    yield
+    _affinity.clear_cache()
+
+
+def _write_skill(tmp_path: Path, tools_yaml_body: str, script_name: str = "do_thing.py") -> Path:
+    """Materialise a minimal ``<skill>/tools.yaml`` + ``scripts/<name>`` layout."""
+    skill_root = tmp_path / "skill-under-test"
+    (skill_root / "scripts").mkdir(parents=True)
+    (skill_root / "tools.yaml").write_text(tools_yaml_body, encoding="utf-8")
+    script = skill_root / "scripts" / script_name
+    script.write_text("def main(**_):\n    return {'success': True, 'message': 'ok'}\n", encoding="utf-8")
+    return script
+
+
+def test_resolve_returns_any_when_declared(tmp_path: Path):
+    """``affinity: any`` in tools.yaml must flow through to the resolver."""
+    script = _write_skill(
+        tmp_path,
+        "tools:\n- name: do_thing\n  execution: sync\n  affinity: any\n",
+    )
+    assert _affinity.resolve_affinity(str(script)) == "any"
+
+
+def test_resolve_returns_main_when_declared(tmp_path: Path):
+    """``affinity: main`` in tools.yaml maps to ``main``."""
+    script = _write_skill(
+        tmp_path,
+        "tools:\n- name: do_thing\n  execution: sync\n  affinity: main\n",
+    )
+    assert _affinity.resolve_affinity(str(script)) == "main"
+
+
+def test_resolve_defaults_to_main_on_missing_tools_yaml(tmp_path: Path):
+    """Missing ``tools.yaml`` → safe default (``main``), never raises."""
+    skill_root = tmp_path / "legacy-skill"
+    (skill_root / "scripts").mkdir(parents=True)
+    script = skill_root / "scripts" / "legacy.py"
+    script.write_text("def main(**_):\n    return {'success': True}\n", encoding="utf-8")
+    assert _affinity.resolve_affinity(str(script)) == "main"
+
+
+def test_resolve_defaults_to_main_on_missing_entry(tmp_path: Path):
+    """Script present but not declared in tools.yaml → default (main)."""
+    script = _write_skill(
+        tmp_path,
+        "tools:\n- name: something_else\n  execution: sync\n  affinity: any\n",
+    )
+    assert _affinity.resolve_affinity(str(script)) == "main"
+
+
+def test_resolve_defaults_to_main_on_unknown_affinity_value(tmp_path: Path):
+    """Malformed affinity value must degrade to the default."""
+    script = _write_skill(
+        tmp_path,
+        "tools:\n- name: do_thing\n  execution: sync\n  affinity: teleport\n",
+    )
+    assert _affinity.resolve_affinity(str(script)) == "main"
+
+
+def test_resolve_defaults_to_main_on_missing_source_file():
+    """None or empty source_file → default (main)."""
+    assert _affinity.resolve_affinity(None) == "main"
+    assert _affinity.resolve_affinity("") == "main"
+
+
+def test_resolve_rejects_non_scripts_layout(tmp_path: Path):
+    """Scripts not under ``<skill>/scripts/`` → default (main).
+
+    We refuse to guess at unconventional layouts because guessing wrong
+    (crashing Maya) is strictly worse than missing the optimisation.
+    """
+    skill_root = tmp_path / "weird-layout"
+    skill_root.mkdir()
+    (skill_root / "tools.yaml").write_text(
+        "tools:\n- name: do_thing\n  execution: sync\n  affinity: any\n",
+        encoding="utf-8",
+    )
+    # Script lives at the skill root, not under scripts/
+    script = skill_root / "do_thing.py"
+    script.write_text("", encoding="utf-8")
+    assert _affinity.resolve_affinity(str(script)) == "main"
+
+
+def test_resolve_caches_result(tmp_path: Path):
+    """Second call for the same path must not re-parse ``tools.yaml``."""
+    script = _write_skill(
+        tmp_path,
+        "tools:\n- name: do_thing\n  execution: sync\n  affinity: any\n",
+    )
+    first = _affinity.resolve_affinity(str(script))
+    # Corrupt the YAML — the cache must shield us from re-reading it.
+    (script.parent.parent / "tools.yaml").write_text("{{{not-yaml", encoding="utf-8")
+    second = _affinity.resolve_affinity(str(script))
+    assert first == second == "any"
+
+
+def test_resolve_honours_injected_loader(tmp_path: Path):
+    """A custom loader lets tests avoid filesystem I/O entirely."""
+    script = _write_skill(
+        tmp_path,
+        "tools:\n- name: do_thing\n  execution: sync\n  affinity: main\n",
+    )
+
+    captured: List[str] = []
+
+    def fake_loader(skill_root: str) -> Dict[str, Any]:
+        captured.append(skill_root)
+        return {"tools": [{"name": "do_thing", "affinity": "any"}]}
+
+    # The injected loader overrides the on-disk YAML entirely.
+    resolved = _affinity.resolve_affinity(str(script), loader=fake_loader)
+    assert resolved == "any"
+    # The loader must receive the skill root (parent of scripts/).
+    assert captured and captured[0].endswith("skill-under-test")
+
+
+def test_resolve_is_thread_safe(tmp_path: Path):
+    """Concurrent callers must not corrupt the cache."""
+    scripts = []
+    for idx in range(8):
+        script = _write_skill(
+            tmp_path / str(idx),
+            "tools:\n- name: do_thing\n  execution: sync\n  affinity: {}\n".format("any" if idx % 2 == 0 else "main"),
+        )
+        scripts.append(str(script))
+
+    results: Dict[int, str] = {}
+
+    def worker(i: int) -> None:
+        results[i] = _affinity.resolve_affinity(scripts[i])
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(len(scripts))]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    for idx, scr in enumerate(scripts):
+        expected = "any" if idx % 2 == 0 else "main"
+        assert results[idx] == expected, "Unexpected resolution for {}".format(scr)
+
+
+# ---------------------------------------------------------------------------
+# _executor.execute_in_process — routing layer
+# ---------------------------------------------------------------------------
+
+
+class _RecordingDispatcher:
+    """Fake dispatcher that records calls and returns a canned result.
+
+    Returns the ``{"success": bool, "output": <inner>}`` envelope shape
+    produced by the real :class:`MayaUiDispatcher` so the executor's
+    result-unwrapping logic exercises the same code path as production.
+    """
+
+    def __init__(self, result: Optional[dict] = None):
+        self.calls: List[Dict[str, Any]] = []
+        self._override = result
+
+    def submit_callable(self, action_name: str, fn: Callable[[], Any], *, affinity: str = "main") -> Any:
+        self.calls.append({"action": action_name, "affinity": affinity})
+        if self._override is not None:
+            return self._override
+        # Drive the wrapped callable (so side-effects in the skill still
+        # run) and wrap its output in the dispatcher envelope shape.
+        inner = fn()
+        return {"success": True, "output": inner}
+
+
+class _FakeServer:
+    def __init__(self, dispatcher: Optional[Any]):
+        self._maya_dispatcher = dispatcher
+
+
+@pytest.fixture
+def any_affinity_script(tmp_path: Path) -> str:
+    return str(
+        _write_skill(
+            tmp_path,
+            "tools:\n- name: do_thing\n  execution: sync\n  affinity: any\n",
+        )
+    )
+
+
+@pytest.fixture
+def main_affinity_script(tmp_path: Path) -> str:
+    return str(
+        _write_skill(
+            tmp_path,
+            "tools:\n- name: do_thing\n  execution: sync\n  affinity: main\n",
+        )
+    )
+
+
+def test_executor_bypasses_dispatcher_for_any_affinity(any_affinity_script: str):
+    """``affinity: any`` must execute inline, not touch the dispatcher.
+
+    This is the core of the token / latency optimisation: a filesystem
+    lookup should never compete with Maya's UI thread queue.
+    """
+    dispatcher = _RecordingDispatcher()
+    server = _FakeServer(dispatcher)
+
+    result = execute_in_process(server, any_affinity_script, {}, "skill__do_thing")
+
+    assert result == {"success": True, "message": "ok"}
+    assert dispatcher.calls == [], "dispatcher must NOT be invoked for affinity: any"
+
+
+def test_executor_routes_main_affinity_through_dispatcher(main_affinity_script: str):
+    """``affinity: main`` must go through the UI dispatcher."""
+    dispatcher = _RecordingDispatcher()
+    server = _FakeServer(dispatcher)
+
+    result = execute_in_process(server, main_affinity_script, {}, "skill__do_thing")
+
+    assert result == {"success": True, "message": "ok"}
+    assert len(dispatcher.calls) == 1
+    assert dispatcher.calls[0]["action"] == "skill__do_thing"
+    assert dispatcher.calls[0]["affinity"] == "main"
+
+
+def test_executor_falls_back_to_inline_without_dispatcher(main_affinity_script: str):
+    """Standalone / mayapy mode has no dispatcher — must still work."""
+    server = _FakeServer(None)
+    result = execute_in_process(server, main_affinity_script, {}, "skill__do_thing")
+    assert result == {"success": True, "message": "ok"}
+
+
+def test_executor_surfaces_dispatcher_exceptions_as_envelope(main_affinity_script: str):
+    """When the dispatcher raises, the caller sees a structured envelope,
+    never an uncaught exception (keeps MCP response contract intact)."""
+
+    class _BrokenDispatcher:
+        def submit_callable(self, action_name, fn, *, affinity="main"):
+            raise RuntimeError("main thread is on fire")
+
+    server = _FakeServer(_BrokenDispatcher())
+    result = execute_in_process(server, main_affinity_script, {}, "skill__do_thing")
+    assert isinstance(result, dict)
+    assert result.get("success") is False
+    message = result.get("message") or result.get("error") or ""
+    assert "main thread is on fire" in str(message) or "Dispatcher" in str(message)
+
+
+def test_run_skill_script_returns_structured_error_on_missing_script(tmp_path: Path):
+    """Defensive: missing script must not crash the executor."""
+    result = run_skill_script(str(tmp_path / "does_not_exist.py"), {})
+    assert result["success"] is False
+    assert "Cannot load" in result["message"] or "Error loading" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# Bundled skills — audit contract (real skills.yaml files)
+# ---------------------------------------------------------------------------
+
+
+def test_bundled_render_farm_get_job_status_is_affinity_any():
+    """``maya-render-farm/get_render_job_status`` is pure subprocess I/O.
+
+    Sanity-check the bundled declaration so a future skill edit that
+    re-routes it to the main thread fails this test instead of silently
+    regressing the fix.
+    """
+    script = BUNDLED_SKILLS / "maya-render-farm" / "scripts" / "get_render_job_status.py"
+    assert script.is_file(), "bundled render-farm skill missing"
+    assert _affinity.resolve_affinity(str(script)) == "any"
+
+
+def test_bundled_execute_python_is_affinity_main():
+    """``maya-scripting/execute_python`` runs arbitrary user code and MUST
+    stay on the Maya UI thread.  This is a critical safety invariant."""
+    script = BUNDLED_SKILLS / "maya-scripting" / "scripts" / "execute_python.py"
+    assert script.is_file(), "bundled scripting skill missing"
+    assert _affinity.resolve_affinity(str(script)) == "main"
+
+
+def test_bundled_scene_family_is_affinity_main():
+    """Every scene-management action must declare ``main``."""
+    scene_scripts = (BUNDLED_SKILLS / "maya-scene" / "scripts").glob("*.py")
+    script_list = list(scene_scripts)
+    assert script_list, "maya-scene skill missing"
+    for script in script_list:
+        assert _affinity.resolve_affinity(str(script)) == "main", "{} must declare affinity: main in tools.yaml".format(
+            script.name
+        )


### PR DESCRIPTION
## Summary

Skills tagged `affinity: any` in their `tools.yaml` now actually execute inline on the HTTP worker thread instead of being unnecessarily queued behind the Maya UI dispatcher. Pure filesystem / subprocess queries (e.g. `maya_render_farm__get_render_job_status`) no longer compete with viewport work on the main thread.

## Why this was silent before

`dcc-mcp-core`'s Rust registry does not propagate the `affinity` field from `tools.yaml` to `registry.get_action` (the dict returned carries `execution` but not `affinity`). So our executor's hard-coded `submit_callable(..., affinity="main")` always sent everything to the UI thread, regardless of what `tools.yaml` said. The contract in `AGENTS.md` existed on paper only.

This PR reads the field directly from the co-located `tools.yaml` via a new SOLID module, caches the per-source-file result, and routes accordingly.

## Design

- **New**: `src/dcc_mcp_maya/_affinity.py`
  - Single responsibility: resolve per-action affinity from sibling `tools.yaml`.
  - Dependency-invertible loader for tests (pass `loader=` kwarg).
  - Thread-safe cache keyed by normalised source_file path.
  - Safe defaults — any lookup failure (missing YAML, malformed entry, unknown value, unconventional layout) degrades to `"main"`. Mis-declaring a Maya-touching action as `any` would crash Maya; mis-declaring a pure action as `main` merely loses the optimisation — so `main` is the Hippocratic choice.
- **Modified**: `src/dcc_mcp_maya/_executor.py`
  - `execute_in_process` consults `resolve_affinity`; dispatches through the UI dispatcher only when `affinity == "main"`; falls through to inline `run_skill_script` for `any`.

## Tests (21 new, 643 total green, 0 regressions)

- `tests/test_affinity_routing.py` — 18 unit tests:
  - Parser: `any` / `main` round-trip, missing `tools.yaml`, missing entry, unknown value, `None`/empty source, non-`scripts/` layout, cache correctness, injected loader, concurrent access.
  - Executor routing: dispatcher bypass for `any`, dispatch for `main`, standalone fallback, exception relay as structured envelope, defensive missing-script handling.
  - Bundled-skills audit: render-farm `get_render_job_status` must stay `any`; `execute_python` must stay `main`; entire `maya-scene` family must stay `main`.
- `tests/test_affinity_http_roundtrip.py` — real HTTP round-trip (MCP Streamable HTTP + REST parity probe):
  - `tools/call` round-trips cleanly for both `any` and `main` tools.
  - **Token-budget guard**: response body stays <4 KiB for a trivial call, and no routing metadata (`__dispatcher__` / `__affinity__` / `trace_id` etc.) leaks into the user-facing payload.
  - REST `/v1/skills/*` parity check (skipped gracefully when the endpoint is still Rust-internal in the installed core build).

## Why the HTTP tests matter

The user-visible promise of this repo is "skills exposed as REST + MCP that the agent can call accurately without burning tokens." The new round-trip tests lock that down: no exception leakage, no envelope bloat, no per-call metadata creep. Anything that would inflate the agent's context window on every tool call now has to go through an explicit test update.

## Docs

- `AGENTS.md` documents the runtime-honoured affinity contract and lists `_affinity.py` in the file index.

## Compatibility

Targets the current pinned `dcc-mcp-core>=0.14.20,<1.0.0`. No core upgrade required; no skill edits required (existing `tools.yaml` declarations are already correct per the earlier issue #84 lint pass).
