### PR TITLE
docs: fix core dependency version inconsistency

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,7 +14,7 @@ Embeds a standards-compliant MCP Streamable HTTP server (2025-03-26 spec) direct
 - **Repository:** https://github.com/loonghao/dcc-mcp-maya
 - **Python:** >=3.7
 - **Maya:** 2020+
-- **Core dependency:** `dcc-mcp-core>=0.14.17,<1.0.0`
+- **Core dependency:** `dcc-mcp-core>=0.14.21,<1.0.0`
 - **Entry point:** `dcc_mcp.adapters` → `maya = "dcc_mcp_maya:MayaMcpServer"`
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 **Repo:** https://github.com/loonghao/dcc-mcp-maya
 **Python:** >=3.7
 **Maya:** 2020+
-**Core dep:** `dcc-mcp-core>=0.14.20,<1.0.0`
+**Core dep:** `dcc-mcp-core>=0.14.21,<1.0.0`
 
 ---
 


### PR DESCRIPTION
Fix core dependency version inconsistency in llms.txt and llms-full.txt.

## Changes
- Update core dependency from \>=0.14.20\ to \>=0.14.21\ in llms.txt
- Update core dependency from \>=0.14.17\ to \>=0.14.21\ in llms-full.txt

## Context
These files had outdated core dependency versions that didn't match pyproject.toml (which correctly specifies \>=0.14.21\).

## Checklist
- [x] CI will pass
- [x] Documentation is consistent across all files