### PR TITLE
feat(skills): restore 10 bundled skills for mayapy E2E coverage (#180)

### DIFF
--- a/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: maya-animation
+description: Maya animation keyframes, timeline, curves, constraint baking, and simulation caching. Use when creating or editing time-based motion. Not for rigging setup or render output — use maya-rigging or maya-render for that.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    version: 1.0.0
+    tags:
+    - maya
+    - animation
+    - keyframe
+    - timeline
+    search-hint: animate motion, keyframe, timeline, curve editing, bake simulation
+      tangent
+    depends: []
+    tools: tools.yaml
+    groups: groups.yaml
+---
+# maya-animation
+
+Maya animation skill. Provides actions for managing keyframes, timeline settings, animation curves, baking simulations and constraints, and importing/exporting animation data.
+
+## Scripts
+
+- `set_keyframe` — Set a keyframe on an object at the given time
+- `get_keyframes` — Get all keyframe times for an object / attribute
+- `set_timeline` — Set the playback and animation timeline range
+- `get_current_time` — Get the current frame number
+- `set_current_time` — Set the current frame number
+- `delete_keyframes` — Delete keyframes from an object within an optional frame range
+- `bake_simulation` — Bake simulation / constraints to keyframes on objects
+- `list_animation_curves` — List all animCurve nodes driving an object
+- `set_animation_curve_tangent` — Set the tangent type on one or all keyframes of an animation curve
+- `bake_constraints` — Bake constraint-driven animation to explicit keyframes
+- `export_animation_curves` — Export animation curves for an object to a Maya .anim file
+- `import_animation_curves` — Import animation curves from a file and optionally apply them to an object
+- `query_scene_time_info` — Query the current scene time and playback settings

--- a/src/dcc_mcp_maya/skills/maya-animation/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-animation/groups.yaml
@@ -1,0 +1,19 @@
+groups:
+- name: animation
+  description: Animation, constraints, and motion capture tools
+  default_active: false
+  tools:
+  - bake_constraints
+  - bake_simulation
+  - delete_keyframes
+  - export_animation_curves
+  - get_current_time
+  - get_frame_range
+  - get_keyframes
+  - import_animation_curves
+  - list_animation_curves
+  - query_scene_time_info
+  - set_animation_curve_tangent
+  - set_current_time
+  - set_keyframe
+  - set_timeline

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/bake_constraints.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/bake_constraints.py
@@ -1,0 +1,111 @@
+"""Bake constraint-driven animation to explicit keyframes."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import batch_validate_nodes
+
+
+def bake_constraints(
+    objects: Optional[List[str]] = None,
+    start_frame: float = 1.0,
+    end_frame: float = 120.0,
+    sample_by: float = 1.0,
+    remove_constraints: bool = False,
+) -> dict:
+    """Bake constraint-driven animation to explicit keyframes.
+
+    Evaluates constraint outputs every *sample_by* frames over the given
+    range and writes the resulting world-space transforms as keyframes.
+    After baking the constraints can optionally be deleted.
+
+    Args:
+        objects: List of constrained transforms to bake.  Uses the current
+            selection when None.
+        start_frame: Start of the bake range.  Default: 1.
+        end_frame: End of the bake range.  Default: 120.
+        sample_by: Sampling interval in frames.  Default: 1.
+        remove_constraints: If True, delete all constraints from the baked
+            objects after baking.  Default: False.
+
+    Returns:
+        ToolResult dict with ``context.object_count``,
+        ``context.objects``, ``context.removed_constraints``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        targets = list(objects) if objects else []
+        if targets:
+            err = batch_validate_nodes(cmds, list(targets))
+            if err:
+                return err
+            cmds.select(targets, replace=True)
+        else:
+            targets = cmds.ls(selection=True) or []
+
+        if not targets:
+            return skill_error(
+                "No objects to bake",
+                "Provide object names or select objects before baking",
+            )
+
+        cmds.bakeSimulation(
+            targets,
+            time=(start_frame, end_frame),
+            sampleBy=sample_by,
+            simulation=False,
+            preserveOutsideKeys=True,
+            disableImplicitControl=True,
+            smart=False,
+        )
+
+        removed_constraints = []  # type: List[str]
+        if remove_constraints:
+            constraint_types = (
+                "parentConstraint",
+                "pointConstraint",
+                "orientConstraint",
+                "scaleConstraint",
+                "aimConstraint",
+                "geometryConstraint",
+            )
+            for obj in targets:
+                for ctype in constraint_types:
+                    constraint_nodes = cmds.listRelatives(obj, children=True, type=ctype) or []
+                    for node in constraint_nodes:
+                        cmds.delete(node)
+                        removed_constraints.append(node)
+
+        return skill_success(
+            "Baked constraints on {} object(s) from frame {} to {}".format(len(targets), start_frame, end_frame),
+            object_count=len(targets),
+            objects=targets,
+            start_frame=start_frame,
+            end_frame=end_frame,
+            sample_by=sample_by,
+            removed_constraints=removed_constraints,
+            prompt="Use list_animation_curves or set_keyframe to adjust the baked keys.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to bake constraints")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`bake_constraints`."""
+    return bake_constraints(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/bake_simulation.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/bake_simulation.py
@@ -1,0 +1,86 @@
+"""Bake simulation / constraints to keyframes on objects."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import batch_validate_nodes
+
+
+def bake_simulation(
+    objects: Optional[List[str]] = None,
+    start_frame: float = 1.0,
+    end_frame: float = 120.0,
+    sample_by: float = 1.0,
+) -> dict:
+    """Bake simulation / constraints to keyframes on objects.
+
+    Converts dynamic simulation or constraint-driven animation into explicit
+    keyframes so the objects can be used independently of the rig.
+
+    Args:
+        objects: List of object names to bake.  If None, the current selection
+            is used.
+        start_frame: First frame of the bake range.  Default: 1.
+        end_frame: Last frame of the bake range.  Default: 120.
+        sample_by: Baking interval in frames (e.g. ``1.0`` = every frame,
+            ``0.5`` = every half-frame).  Default: 1.
+
+    Returns:
+        ToolResult dict with ``context.object_count`` and frame range.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        targets = objects or []
+        if targets:
+            err = batch_validate_nodes(cmds, list(targets))
+            if err:
+                return err
+            cmds.select(targets, replace=True)
+        else:
+            targets = cmds.ls(selection=True) or []
+
+        if not targets:
+            return skill_error(
+                "No objects to bake",
+                "Provide object names or select objects before baking",
+            )
+
+        cmds.bakeSimulation(
+            targets,
+            time=(start_frame, end_frame),
+            sampleBy=sample_by,
+            simulation=True,
+            preserveOutsideKeys=True,
+        )
+        return skill_success(
+            "Baked {} object(s) from frame {} to {}".format(len(targets), start_frame, end_frame),
+            object_count=len(targets),
+            objects=targets,
+            start_frame=start_frame,
+            end_frame=end_frame,
+            sample_by=sample_by,
+            prompt="Use delete_keyframes to trim unwanted frames, or export_animation_curves to save.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to bake simulation")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`bake_simulation`."""
+    return bake_simulation(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/delete_keyframes.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/delete_keyframes.py
@@ -1,0 +1,91 @@
+"""Delete keyframes from an object within an optional frame range."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def delete_keyframes(
+    object_name: str,
+    attributes: Optional[List[str]] = None,
+    attribute: Optional[str] = None,
+    start_frame: Optional[float] = None,
+    end_frame: Optional[float] = None,
+    start_time: Optional[float] = None,
+    end_time: Optional[float] = None,
+) -> dict:
+    """Delete keyframes from an object within an optional frame range.
+
+    Args:
+        object_name: Name of the object whose keyframes will be deleted.
+        attributes: List of attribute names to affect (e.g. ``["tx", "ry"]``).
+            If None, all keyable attributes are targeted.
+        attribute: Single attribute name (alias for ``attributes=[attribute]``).
+        start_frame: First frame of the range to delete.  If None and
+            *end_frame* is also None, all keyframes are deleted.
+        end_frame: Last frame of the range to delete.  If None and
+            *start_frame* is also None, all keyframes are deleted.
+        start_time: Alias for ``start_frame``.
+        end_time: Alias for ``end_frame``.
+
+    Returns:
+        ToolResult dict with ``context.deleted_count``.
+    """
+    # Resolve aliases
+    if attribute is not None and not attributes:
+        attributes = [attribute]
+    if start_time is not None and start_frame is None:
+        start_frame = start_time
+    if end_time is not None and end_frame is None:
+        end_frame = end_time
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        kwargs = {}  # type: Dict
+        if attributes:
+            kwargs["attribute"] = attributes
+        if start_frame is not None and end_frame is not None:
+            kwargs["time"] = (start_frame, end_frame)
+        elif start_frame is not None:
+            kwargs["time"] = (start_frame, start_frame)
+        elif end_frame is not None:
+            kwargs["time"] = (end_frame, end_frame)
+
+        deleted = cmds.cutKey(object_name, clear=True, **kwargs)
+        return skill_success(
+            "Deleted {} keyframe(s) from {}".format(deleted, object_name),
+            object_name=object_name,
+            deleted_count=deleted,
+            attributes=attributes,
+            start_frame=start_frame,
+            end_frame=end_frame,
+            prompt="Use set_keyframe to add new keys, or get_keyframes to verify the result.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete keyframes from {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`delete_keyframes`."""
+    return delete_keyframes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/export_animation_curves.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/export_animation_curves.py
@@ -1,0 +1,108 @@
+"""Export animation curves for an object to a Maya .anim file."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def export_animation_curves(
+    object_name: str,
+    file_path: str,
+    attributes: Optional[List[str]] = None,
+    start_frame: Optional[float] = None,
+    end_frame: Optional[float] = None,
+) -> dict:
+    """Export animation curves for an object to a Maya .anim file.
+
+    Uses ``cmds.exportEdits`` (Maya 2013+) to write a Maya ASCII or binary
+    file containing only the animation curves driving *object_name*.
+
+    Args:
+        object_name: Name of the animated object.
+        file_path: Output file path.  Extension determines format:
+            ``".anim"`` (Maya native), ``".ma"`` (Maya ASCII),
+            ``".mb"`` (Maya Binary).
+        attributes: Optional list of attribute names to restrict the export.
+            If ``None``, all driven attributes are exported.
+        start_frame: First frame of the export range.  ``None`` = scene start.
+        end_frame: Last frame of the export range.  ``None`` = scene end.
+
+    Returns:
+        ToolResult dict with ``context.file_path`` and
+        ``context.curve_count``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        # Resolve frame range
+        if start_frame is None:
+            start_frame = cmds.playbackOptions(query=True, animationStartTime=True)
+        if end_frame is None:
+            end_frame = cmds.playbackOptions(query=True, animationEndTime=True)
+
+        # Collect animCurve nodes
+        anim_curves = cmds.keyframe(object_name, query=True, name=True) or []
+        if attributes:
+            filtered = []
+            for attr in attributes:
+                plug = "{}.{}".format(object_name, attr)
+                curves = cmds.keyframe(plug, query=True, name=True) or []
+                filtered.extend(curves)
+            anim_curves = filtered
+
+        if not anim_curves:
+            return skill_error(
+                "No animation curves found on '{}'".format(object_name),
+                "Object has no keyframe data to export",
+            )
+
+        # Export via cmds.select + cmds.file
+        cmds.select(anim_curves, replace=True)
+        export_kwargs = {
+            "exportSelected": True,
+            "force": True,
+            "type": "mayaAscii",
+        }  # type: Dict
+        ext = file_path.rsplit(".", 1)[-1].lower() if "." in file_path else "ma"
+        if ext == "mb":
+            export_kwargs["type"] = "mayaBinary"
+
+        cmds.file(file_path, **export_kwargs)
+        cmds.select(clear=True)
+
+        return skill_success(
+            "Exported {} animation curve(s) to '{}'".format(len(anim_curves), file_path),
+            file_path=file_path,
+            object_name=object_name,
+            curve_count=len(anim_curves),
+            start_frame=start_frame,
+            end_frame=end_frame,
+            prompt="Use import_animation_curves to restore the curves on another rig.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to export animation curves for '{}'".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`export_animation_curves`."""
+    return export_animation_curves(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/get_current_time.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/get_current_time.py
@@ -1,0 +1,41 @@
+"""Get the current frame number."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def get_current_time() -> dict:
+    """Get the current frame number.
+
+    Returns:
+        ToolResult dict with ``context.current_time``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        current = cmds.currentTime(query=True)
+        return skill_success(
+            "Current time: {}".format(current),
+            current_time=current,
+            prompt="Use set_current_time to seek to a specific frame.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get current time")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_current_time`."""
+    return get_current_time(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/get_frame_range.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/get_frame_range.py
@@ -1,0 +1,83 @@
+"""Query the current animation frame range and return a FrameRange-compatible dict."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def get_frame_range() -> dict:
+    """Query the current playback / animation frame range from Maya.
+
+    Uses ``cmds.playbackOptions`` to read the four timing values and returns
+    them via the ``FrameRange``-compatible dict schema from ``dcc-mcp-core``::
+
+        {
+            "start":   <float>,   # playback start
+            "end":     <float>,   # playback end
+            "fps":     <float>,   # frames per second
+            "current": <float>,   # current time cursor
+        }
+
+    The fps value is mapped from Maya's ``currentUnit(time=True, query=True)``
+    string (e.g. ``"film"`` → 24, ``"pal"`` → 25, ``"ntsc"`` → 30,
+    ``"show"`` → 48, ``"palf"`` → 50, ``"ntscf"`` → 60).
+
+    Returns:
+        ToolResult dict with ``context.frame_range`` (dict).
+    """
+    _FPS_MAP = {
+        "game": 15.0,
+        "film": 24.0,
+        "pal": 25.0,
+        "ntsc": 30.0,
+        "show": 48.0,
+        "palf": 50.0,
+        "ntscf": 60.0,
+    }
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        start = float(cmds.playbackOptions(minTime=True, query=True))
+        end = float(cmds.playbackOptions(maxTime=True, query=True))
+        current = float(cmds.currentTime(query=True))
+
+        time_unit = cmds.currentUnit(time=True, query=True)
+        fps = _FPS_MAP.get(time_unit, 24.0)
+        # Custom fps unit: "120fps", "100fps" etc.
+        if time_unit.endswith("fps"):
+            try:
+                fps = float(time_unit[:-3])
+            except ValueError:
+                fps = 24.0
+
+        frame_range = {
+            "start": start,
+            "end": end,
+            "fps": fps,
+            "current": current,
+        }
+
+        return skill_success(
+            "Frame range: {:.0f} - {:.0f} @ {:.0f} fps".format(start, end, fps),
+            frame_range=frame_range,
+            prompt=("Use set_timeline to change the range, or set_keyframe to add a key at the current time."),
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get frame range")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_frame_range`."""
+    return get_frame_range(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/get_keyframes.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/get_keyframes.py
@@ -1,0 +1,64 @@
+"""Get all keyframe times for an object / attribute."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def get_keyframes(
+    object_name: str,
+    attribute: Optional[str] = None,
+) -> dict:
+    """Get all keyframe times for an object / attribute.
+
+    Args:
+        object_name: Name of the object to query.
+        attribute: Specific attribute to query (e.g. ``"tx"``).  If None,
+            returns keyframes across all attributes.
+
+    Returns:
+        ToolResult dict with ``context.keyframes`` list of frame numbers.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        kwargs = {}  # type: Dict
+        if attribute:
+            kwargs["attribute"] = attribute
+        raw = cmds.keyframe(object_name, query=True, timeChange=True, **kwargs)
+        keyframes = list(raw) if raw else []
+        return skill_success(
+            "Found {} keyframe(s) on {}".format(len(keyframes), object_name),
+            object_name=object_name,
+            attribute=attribute,
+            keyframes=keyframes,
+            count=len(keyframes),
+            prompt="Use set_keyframe to modify keys or delete_keyframes to remove them.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get keyframes for {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_keyframes`."""
+    return get_keyframes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/import_animation_curves.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/import_animation_curves.py
@@ -1,0 +1,91 @@
+"""Import animation curves from a file and optionally apply them to an object."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def import_animation_curves(
+    file_path: str,
+    target_object: Optional[str] = None,
+    merge: bool = True,
+) -> dict:
+    """Import animation curves from a file and optionally apply them to an object.
+
+    Args:
+        file_path: Path to the ``.ma`` / ``.mb`` / ``.anim`` file to import.
+        target_object: Name of the object to re-target the curves onto.
+            If ``None``, curves are imported as-is without re-targeting.
+        merge: When ``True``, existing keys on the target are merged rather
+            than replaced (``cmds.file(i=True, mergeNamespacesOnClash=True)``).
+
+    Returns:
+        ToolResult dict with ``context.file_path`` and
+        ``context.target_object``.
+    """
+    try:
+        import os  # noqa: PLC0415
+
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        if not os.path.isfile(file_path):
+            return skill_error(
+                "File not found: {}".format(file_path),
+                "Cannot import animation curves: path does not exist",
+            )
+
+        import_kwargs = {
+            "i": True,
+            "ignoreVersion": True,
+            "mergeNamespacesOnClash": merge,
+            "force": True,
+        }  # type: Dict
+
+        cmds.file(file_path, **import_kwargs)
+
+        if target_object and cmds.objExists(target_object):
+            # Copy newly imported animCurves to target by name-matching
+            # (best-effort; full re-targeting requires Maya's retarget API)
+            imported_curves = cmds.ls(type="animCurve") or []
+            for curve in imported_curves:
+                connections = cmds.listConnections(curve, destination=True, plugs=True) or []
+                for conn in connections:
+                    attr = conn.split(".")[-1] if "." in conn else None
+                    if attr and cmds.objExists("{}.{}".format(target_object, attr)):
+                        try:
+                            cmds.connectAttr(
+                                "{}.output".format(curve),
+                                "{}.{}".format(target_object, attr),
+                                force=True,
+                            )
+                        except Exception:
+                            pass
+
+        return skill_success(
+            "Imported animation curves from '{}'".format(file_path),
+            file_path=file_path,
+            target_object=target_object,
+            merge=merge,
+            prompt="Use list_animation_curves to verify the imported curves.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to import animation curves from '{}'".format(file_path))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`import_animation_curves`."""
+    return import_animation_curves(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/list_animation_curves.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/list_animation_curves.py
@@ -1,0 +1,90 @@
+"""List all animCurve nodes driving an object."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def list_animation_curves(
+    object_name: str,
+    attribute: Optional[str] = None,
+) -> dict:
+    """List all animCurve nodes driving an object.
+
+    Args:
+        object_name: Name of the object to query.
+        attribute: Optional specific attribute (e.g. ``"tx"``).  If None,
+            all animCurve nodes connected to the object are returned.
+
+    Returns:
+        ToolResult dict with ``context.curves`` list of dicts
+        containing ``name``, ``type``, ``key_count``, and ``attribute``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        if attribute:
+            plug = "{}.{}".format(object_name, attribute)
+            raw_conns = cmds.listConnections(plug, source=True, destination=False, type="animCurve") or []
+        else:
+            raw_conns = cmds.listConnections(object_name, source=True, destination=False, type="animCurve") or []
+
+        # Deduplicate while preserving order
+        seen = set()  # type: set
+        unique_curves = []  # type: List[str]
+        for c in raw_conns:
+            if c not in seen:
+                seen.add(c)
+                unique_curves.append(c)
+
+        curves = []
+        for curve in unique_curves:
+            curve_type = cmds.objectType(curve)
+            key_count = cmds.keyframe(curve, query=True, keyframeCount=True) or 0
+            # Determine which attribute this curve drives
+            driven_plugs = cmds.listConnections(curve, source=False, destination=True, plugs=True) or []
+            driven_attr = driven_plugs[0].split(".")[-1] if driven_plugs else ""
+            curves.append(
+                {
+                    "name": curve,
+                    "type": curve_type,
+                    "key_count": key_count,
+                    "attribute": driven_attr,
+                }
+            )
+
+        return skill_success(
+            "Found {} animCurve(s) on '{}'".format(len(curves), object_name),
+            object_name=object_name,
+            attribute=attribute,
+            curves=curves,
+            count=len(curves),
+            prompt="Use export_animation_curves to save or delete_keyframes to clean up.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list animation curves for '{}'".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_animation_curves`."""
+    return list_animation_curves(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/query_scene_time_info.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/query_scene_time_info.py
@@ -1,0 +1,57 @@
+"""Query the current scene time and playback settings."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def query_scene_time_info() -> dict:
+    """Query the current scene time and playback settings as a single call.
+
+    Returns a consolidated snapshot of all time-related scene settings:
+    frame rate, animation range, playback range, and current time.
+
+    Returns:
+        ToolResult dict with ``context`` keys:
+        ``fps``, ``animation_start``, ``animation_end``,
+        ``playback_start``, ``playback_end``, ``current_time``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        fps = cmds.currentUnit(query=True, time=True)
+        anim_start = cmds.playbackOptions(query=True, animationStartTime=True)
+        anim_end = cmds.playbackOptions(query=True, animationEndTime=True)
+        pb_start = cmds.playbackOptions(query=True, minTime=True)
+        pb_end = cmds.playbackOptions(query=True, maxTime=True)
+        current = cmds.currentTime(query=True)
+
+        return skill_success(
+            "Scene time info retrieved",
+            fps=fps,
+            animation_start=anim_start,
+            animation_end=anim_end,
+            playback_start=pb_start,
+            playback_end=pb_end,
+            current_time=current,
+            prompt="Use set_timeline to adjust the frame range.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to query scene time info")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`query_scene_time_info`."""
+    return query_scene_time_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/set_animation_curve_tangent.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/set_animation_curve_tangent.py
@@ -1,0 +1,103 @@
+"""Set the tangent type on one or all keyframes of an animation curve."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def set_animation_curve_tangent(
+    object_name: str,
+    attribute: str,
+    frame: Optional[float] = None,
+    tangent_type: str = "auto",
+    in_tangent_type: Optional[str] = None,
+    out_tangent_type: Optional[str] = None,
+) -> dict:
+    """Set the tangent type on one or all keyframes of an animation curve.
+
+    Args:
+        object_name: Name of the animated object.
+        attribute: Attribute name (e.g. ``"tx"``).
+        frame: Specific frame to modify.  If None, all keys on the curve
+            are updated.
+        tangent_type: Tangent preset applied to both in and out tangents.
+            One of ``"auto"``, ``"linear"``, ``"flat"``, ``"step"``,
+            ``"spline"``, ``"clamped"``, ``"plateau"``.  Default: ``"auto"``.
+            Overridden by *in_tangent_type* / *out_tangent_type* if provided.
+        in_tangent_type: Override for the incoming tangent type only.
+        out_tangent_type: Override for the outgoing tangent type only.
+
+    Returns:
+        ToolResult dict with ``context.object_name``,
+        ``context.attribute``, ``context.frame``, ``context.tangent_type``.
+    """
+    _VALID_TANGENTS = ("auto", "linear", "flat", "step", "spline", "clamped", "plateau", "stepnext")
+
+    in_type = (in_tangent_type or tangent_type).lower()
+    out_type = (out_tangent_type or tangent_type).lower()
+
+    if in_type not in _VALID_TANGENTS:
+        return skill_error(
+            "Invalid in_tangent_type: {}".format(in_type),
+            "Must be one of: {}".format(", ".join(_VALID_TANGENTS)),
+        )
+    if out_type not in _VALID_TANGENTS:
+        return skill_error(
+            "Invalid out_tangent_type: {}".format(out_type),
+            "Must be one of: {}".format(", ".join(_VALID_TANGENTS)),
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        plug = "{}.{}".format(object_name, attribute)
+        err = validate_node_exists(cmds, plug)
+        if err:
+            return err
+
+        kwargs = {
+            "attribute": attribute,
+            "inTangentType": in_type,
+            "outTangentType": out_type,
+        }  # type: Dict
+        if frame is not None:
+            kwargs["time"] = (frame, frame)
+
+        cmds.keyTangent(object_name, edit=True, **kwargs)
+
+        return skill_success(
+            "Set tangent type on '{}.{}' (frame={})".format(object_name, attribute, frame),
+            object_name=object_name,
+            attribute=attribute,
+            frame=frame,
+            in_tangent_type=in_type,
+            out_tangent_type=out_type,
+            prompt="Use bake_simulation to flatten or get_keyframes to inspect.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set tangent on '{}.{}'".format(object_name, attribute))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_animation_curve_tangent`."""
+    return set_animation_curve_tangent(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/set_current_time.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/set_current_time.py
@@ -1,0 +1,44 @@
+"""Set the current frame number."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def set_current_time(frame: float) -> dict:
+    """Set the current frame number.
+
+    Args:
+        frame: Target frame number.
+
+    Returns:
+        ToolResult dict with ``context.current_time``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        cmds.currentTime(frame, update=True)
+        return skill_success(
+            "Current time set to {}".format(frame),
+            current_time=frame,
+            prompt="Use get_current_time to verify or set_keyframe to record the pose.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set current time")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_current_time`."""
+    return set_current_time(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/set_keyframe.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/set_keyframe.py
@@ -1,0 +1,78 @@
+"""Set a keyframe on an object at the given time."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def set_keyframe(
+    object_name: str,
+    attribute: Optional[str] = None,
+    attributes: Optional[List[str]] = None,
+    time: Optional[float] = None,
+    value: Optional[float] = None,
+) -> dict:
+    """Set a keyframe on an object at the given time.
+
+    Args:
+        object_name: Name of the object to keyframe.
+        attribute: Single attribute name to key (e.g. ``"translateX"``).  Takes
+            priority over ``attributes`` when both are provided.
+        attributes: List of attribute names to key.  Ignored when ``attribute``
+            is set.
+        time: Frame number.  Defaults to current time.
+        value: Explicit value to set before keying.  Only valid for a single
+            attribute.
+
+    Returns:
+        ToolResult dict with ``context.keyframe_count``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        kwargs = {}
+        # Normalise: single `attribute` string takes priority over `attributes` list
+        attr_list = [attribute] if attribute else (attributes or [])
+        if time is not None:
+            kwargs["time"] = time
+        if attr_list:
+            kwargs["attribute"] = attr_list
+            if value is not None and len(attr_list) == 1:
+                cmds.setAttr("{}.{}".format(object_name, attr_list[0]), value)
+
+        count = cmds.setKeyframe(object_name, **kwargs)
+        return skill_success(
+            "Set {} keyframe(s) on {}".format(count, object_name),
+            object_name=object_name,
+            keyframe_count=count,
+            time=time,
+            attributes=attr_list,
+            prompt="Use get_keyframes to verify or bake_simulation to collapse to keys.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set keyframe on {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_keyframe`."""
+    return set_keyframe(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/scripts/set_timeline.py
+++ b/src/dcc_mcp_maya/skills/maya-animation/scripts/set_timeline.py
@@ -1,0 +1,69 @@
+"""Set the playback and animation timeline range."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def set_timeline(
+    start_frame: float = 1.0,
+    end_frame: float = 120.0,
+    min_frame: Optional[float] = None,
+    max_frame: Optional[float] = None,
+) -> dict:
+    """Set the playback and animation timeline range.
+
+    Args:
+        start_frame: Playback start frame.  Default: 1.
+        end_frame: Playback end frame.  Default: 120.
+        min_frame: Animation range minimum (inner range).  Defaults to
+            ``start_frame`` if not specified.
+        max_frame: Animation range maximum (inner range).  Defaults to
+            ``end_frame`` if not specified.
+
+    Returns:
+        ToolResult dict with timeline range info.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        if min_frame is None:
+            min_frame = start_frame
+        if max_frame is None:
+            max_frame = end_frame
+
+        cmds.playbackOptions(
+            minTime=start_frame,
+            maxTime=end_frame,
+            animationStartTime=min_frame,
+            animationEndTime=max_frame,
+        )
+        return skill_success(
+            "Timeline set: {} - {}".format(start_frame, end_frame),
+            start_frame=start_frame,
+            end_frame=end_frame,
+            min_frame=min_frame,
+            max_frame=max_frame,
+            prompt="Use set_current_time to navigate the new range.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set timeline")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_timeline`."""
+    return set_timeline(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-animation/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-animation/tools.yaml
@@ -1,0 +1,93 @@
+tools:
+- name: bake_constraints
+  execution: sync
+  affinity: main
+  group: animation
+- name: bake_simulation
+  description: Bake simulation / constraints to keyframes on objects
+  execution: sync
+  affinity: main
+  group: animation
+- name: delete_keyframes
+  description: Delete keyframes from an object within an optional frame range
+  execution: sync
+  affinity: main
+  annotations:
+    destructive_hint: true
+    idempotent_hint: true
+  group: animation
+- name: export_animation_curves
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: animation
+- name: get_current_time
+  description: Get the current frame number
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: animation
+- name: get_frame_range
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: animation
+- name: get_keyframes
+  description: Get all keyframe times for an object / attribute
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: animation
+- name: import_animation_curves
+  execution: sync
+  affinity: main
+  group: animation
+- name: list_animation_curves
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: animation
+- name: query_scene_time_info
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: animation
+- name: set_animation_curve_tangent
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: animation
+- name: set_current_time
+  description: Set the current frame number
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: animation
+- name: set_keyframe
+  description: Set a keyframe on an object at the given time
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: animation
+- name: set_timeline
+  description: Set the playback and animation timeline range
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: animation

--- a/src/dcc_mcp_maya/skills/maya-attributes/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-attributes/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: maya-attributes
+description: Maya node attribute management — get, set, lock, unlock, and create custom attributes. Use when reading or writing node properties. Not for scene-level operations, node connections, or scripting — use maya-scene, maya-node-graph, or maya-scripting for that.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    version: 1.0.0
+    tags:
+    - maya
+    - attribute
+    - node
+    - utility
+    search-hint: node property, custom attribute, get value, set attribute
+    depends: []
+    tools: tools.yaml
+---
+> **Deprecated (merge bucket):** This skill contains only thin \maya.cmds\ wrappers.
+> Use \xecute_python\ with \maya-scripting/references/RECIPES.md#attributes\ instead.
+> Will be removed in the next release.
+
+# maya-attributes
+
+Maya attributes skill. Provides actions for getting and setting attribute values,
+and managing custom attributes on Maya nodes.
+
+## Scripts
+
+- `get_attribute` — Get the value of an attribute on a Maya node
+- `set_attribute` — Set the value of an attribute on a Maya node
+- `add_attribute` — Add a custom attribute to a Maya node
+- `delete_attribute` — Delete a custom (user-defined) attribute from a Maya node
+- `list_attributes` — List attributes on a Maya node

--- a/src/dcc_mcp_maya/skills/maya-attributes/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-attributes/groups.yaml
@@ -1,0 +1,10 @@
+groups:
+- name: attributes
+  description: Node attribute add/get/set/list/delete operations
+  default_active: false
+  tools:
+  - add_attribute
+  - delete_attribute
+  - get_attribute
+  - list_attributes
+  - set_attribute

--- a/src/dcc_mcp_maya/skills/maya-attributes/scripts/add_attribute.py
+++ b/src/dcc_mcp_maya/skills/maya-attributes/scripts/add_attribute.py
@@ -1,0 +1,104 @@
+"""Add a custom attribute to a Maya node."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+_VALID_TYPES = {
+    "float",
+    "double",
+    "long",
+    "short",
+    "bool",
+    "string",
+    "float3",
+    "double3",
+    "long3",
+    "short3",
+    "enum",
+    "message",
+}
+
+
+def add_attribute(
+    node_name: str,
+    attribute: str,
+    attr_type: str = "float",
+    default_value: Optional[object] = None,
+    min_value: Optional[float] = None,
+    max_value: Optional[float] = None,
+    keyable: bool = True,
+) -> dict:
+    """Add a custom attribute to a Maya node.
+
+    Args:
+        node_name: Name of the Maya node.
+        attribute: Long name for the new attribute.
+        attr_type: Attribute data type.  One of: ``float``, ``double``,
+            ``long``, ``short``, ``bool``, ``string``, ``float3``, ``double3``,
+            ``long3``, ``short3``, ``enum``, ``message``.
+        default_value: Default value for numeric attributes.
+        min_value: Minimum value (numeric types only).
+        max_value: Maximum value (numeric types only).
+        keyable: Whether the attribute should appear in the Channel Box.
+
+    Returns:
+        ToolResult dict with ``context.attribute``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, node_name)
+        if err:
+            return err
+
+        if attr_type not in _VALID_TYPES:
+            return skill_error(
+                "Invalid attribute type: {}".format(attr_type),
+                "Supported types: {}".format(", ".join(sorted(_VALID_TYPES))),
+            )
+
+        kwargs = {"longName": attribute, "attributeType": attr_type, "keyable": keyable}
+        if attr_type == "string":
+            kwargs["dataType"] = "string"
+            del kwargs["attributeType"]
+        if default_value is not None and attr_type not in ("string", "message"):
+            kwargs["defaultValue"] = default_value
+        if min_value is not None:
+            kwargs["minValue"] = min_value
+        if max_value is not None:
+            kwargs["maxValue"] = max_value
+
+        cmds.addAttr(node_name, **kwargs)
+
+        return skill_success(
+            "Added attribute '{}.{}'".format(node_name, attribute),
+            prompt="Use set_attribute to assign a value to the new attribute.",
+            node_name=node_name,
+            attribute=attribute,
+            attr_type=attr_type,
+            keyable=keyable,
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to add attribute")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`add_attribute`."""
+    return add_attribute(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-attributes/scripts/delete_attribute.py
+++ b/src/dcc_mcp_maya/skills/maya-attributes/scripts/delete_attribute.py
@@ -1,0 +1,66 @@
+"""Delete a custom (user-defined) attribute from a Maya node."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def delete_attribute(node_name: str, attribute: str) -> dict:
+    """Delete a custom (user-defined) attribute from a Maya node.
+
+    Built-in / locked attributes cannot be deleted and will return an error.
+
+    Args:
+        node_name: Name of the Maya node.
+        attribute: Attribute name to delete.
+
+    Returns:
+        ToolResult dict.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, node_name)
+        if err:
+            return err
+
+        full_attr = "{}.{}".format(node_name, attribute)
+        err = validate_node_exists(cmds, full_attr)
+        if err:
+            return err
+
+        if not cmds.attributeQuery(attribute, node=node_name, userDefined=True):
+            return skill_error(
+                "Cannot delete built-in attribute",
+                "'{}.{}' is a built-in attribute and cannot be deleted".format(node_name, attribute),
+            )
+
+        cmds.deleteAttr("{}.{}".format(node_name, attribute))
+
+        return skill_success(
+            "Deleted attribute '{}.{}'".format(node_name, attribute),
+            node_name=node_name,
+            attribute=attribute,
+            prompt="Use list_custom_attributes to verify removal.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete attribute")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`delete_attribute`."""
+    return delete_attribute(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-attributes/scripts/get_attribute.py
+++ b/src/dcc_mcp_maya/skills/maya-attributes/scripts/get_attribute.py
@@ -1,0 +1,64 @@
+"""Get the value of an attribute on a Maya node."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def get_attribute(node_name: str, attribute: str) -> dict:
+    """Get the value of an attribute on a Maya node.
+
+    Args:
+        node_name: Name of the Maya node.
+        attribute: Attribute name (e.g. ``"translateX"``, ``"visibility"``).
+
+    Returns:
+        ToolResult dict with ``context.value``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, node_name)
+        if err:
+            return err
+
+        full_attr = "{}.{}".format(node_name, attribute)
+        err = validate_node_exists(cmds, full_attr)
+        if err:
+            return err
+
+        raw = cmds.getAttr(full_attr)
+        # Flatten single-element tuples returned for compound attrs
+        if isinstance(raw, list) and len(raw) == 1 and isinstance(raw[0], tuple):
+            value = list(raw[0])
+        else:
+            value = raw
+
+        return skill_success(
+            "{}.{} = {}".format(node_name, attribute, value),
+            prompt="Use set_attribute to change the value.",
+            node_name=node_name,
+            attribute=attribute,
+            value=value,
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get attribute")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_attribute`."""
+    return get_attribute(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-attributes/scripts/list_attributes.py
+++ b/src/dcc_mcp_maya/skills/maya-attributes/scripts/list_attributes.py
@@ -1,0 +1,65 @@
+"""List attributes on a Maya node."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def list_attributes(
+    node_name: str,
+    user_defined_only: bool = False,
+    keyable_only: bool = False,
+) -> dict:
+    """List attributes on a Maya node.
+
+    Args:
+        node_name: Name of the Maya node.
+        user_defined_only: If True, only return user-defined attributes.
+        keyable_only: If True, only return keyable (channel-box) attributes.
+
+    Returns:
+        ToolResult dict with ``context.attributes`` list.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, node_name)
+        if err:
+            return err
+
+        kwargs = {}
+        if user_defined_only:
+            kwargs["userDefined"] = True
+        if keyable_only:
+            kwargs["keyable"] = True
+
+        attrs = cmds.listAttr(node_name, **kwargs) or []
+
+        return skill_success(
+            "Found {} attribute(s) on '{}'".format(len(attrs), node_name),
+            prompt="Use get_attribute or set_attribute to inspect or modify values.",
+            node_name=node_name,
+            attributes=attrs,
+            count=len(attrs),
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list attributes")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_attributes`."""
+    return list_attributes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-attributes/scripts/set_attribute.py
+++ b/src/dcc_mcp_maya/skills/maya-attributes/scripts/set_attribute.py
@@ -1,0 +1,68 @@
+"""Set the value of an attribute on a Maya node."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def set_attribute(node_name: str, attribute: str, value: object) -> dict:
+    """Set the value of an attribute on a Maya node.
+
+    Handles scalar, boolean, string, and simple vector values.
+
+    Args:
+        node_name: Name of the Maya node.
+        attribute: Attribute name (e.g. ``"translateX"``, ``"visibility"``).
+        value: New value.  Strings are set with ``setAttr -type "string"``.
+
+    Returns:
+        ToolResult dict with ``context.node_name``, ``context.attribute``,
+        and ``context.value``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, node_name)
+        if err:
+            return err
+
+        full_attr = "{}.{}".format(node_name, attribute)
+        err = validate_node_exists(cmds, full_attr)
+        if err:
+            return err
+
+        if isinstance(value, str):
+            cmds.setAttr(full_attr, value, type="string")
+        elif isinstance(value, (list, tuple)):
+            cmds.setAttr(full_attr, *value)
+        else:
+            cmds.setAttr(full_attr, value)
+
+        return skill_success(
+            "Set {}.{} = {}".format(node_name, attribute, value),
+            prompt="Use get_attribute to verify the new value.",
+            node_name=node_name,
+            attribute=attribute,
+            value=value,
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set attribute")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_attribute`."""
+    return set_attribute(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-attributes/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-attributes/tools.yaml
@@ -1,0 +1,32 @@
+tools:
+- name: add_attribute
+  execution: sync
+  affinity: main
+  group: attributes
+- name: delete_attribute
+  execution: sync
+  affinity: main
+  group: attributes
+  annotations:
+    destructive_hint: true
+    idempotent_hint: true
+- name: get_attribute
+  execution: sync
+  affinity: main
+  group: attributes
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+- name: list_attributes
+  execution: sync
+  affinity: main
+  group: attributes
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+- name: set_attribute
+  execution: sync
+  affinity: main
+  group: attributes
+  annotations:
+    idempotent_hint: true

--- a/src/dcc_mcp_maya/skills/maya-display/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-display/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: maya-display
+description: Maya display layers and viewport shading mode management — create layers, toggle visibility, and set wireframe/shaded modes. Use when controlling visual feedback in the viewport. Not for render layer setup or final output — use maya-render-layers or maya-render for that.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    version: 1.0.0
+    tags:
+    - maya
+    - display
+    - layer
+    - visibility
+    search-hint: viewport visibility, display layer, wireframe shaded, show hide
+    depends: []
+    tools: tools.yaml
+    groups: groups.yaml
+---
+> **Deprecated (merge bucket):** This skill contains only thin \maya.cmds\ wrappers.
+> Use \xecute_python\ with \maya-scripting/references/RECIPES.md#display\ instead.
+> Will be removed in the next release.
+
+# maya-display
+
+Maya display skill. Provides actions for creating, setting, deleting, and listing display layers in Maya.
+
+## Scripts
+
+- `create_display_layer` — Create a display layer and optionally add objects to it
+- `set_display_layer` — Assign an object to an existing display layer
+- `delete_display_layer` — Delete a display layer
+- `list_display_layers` — List all display layers in the scene

--- a/src/dcc_mcp_maya/skills/maya-display/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-display/groups.yaml
@@ -1,0 +1,9 @@
+groups:
+- name: scene-management
+  description: Scene management, organization, and navigation tools
+  default_active: false
+  tools:
+  - create_display_layer
+  - delete_display_layer
+  - list_display_layers
+  - set_display_layer

--- a/src/dcc_mcp_maya/skills/maya-display/scripts/create_display_layer.py
+++ b/src/dcc_mcp_maya/skills/maya-display/scripts/create_display_layer.py
@@ -1,0 +1,68 @@
+"""Create a display layer and optionally add objects to it."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def create_display_layer(
+    name: Optional[str] = None,
+    objects: Optional[List[str]] = None,
+    visibility: bool = True,
+) -> dict:
+    """Create a display layer and optionally add objects to it.
+
+    Args:
+        name: Name for the new display layer.  If None, Maya generates one.
+        objects: List of object names to add to the layer immediately.
+        visibility: Initial visibility state of the layer.
+
+    Returns:
+        ToolResult dict with ``context.layer_name``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        kwargs = {"empty": True, "noRecurse": True}
+        if name:
+            kwargs["name"] = name
+        layer_name = cmds.createDisplayLayer(**kwargs)
+
+        if not visibility:
+            cmds.setAttr("{}.visibility".format(layer_name), 0)
+
+        added = []
+        if objects:
+            for obj in objects:
+                if cmds.objExists(obj):
+                    cmds.editDisplayLayerMembers(layer_name, obj, noRecurse=True)
+                    added.append(obj)
+
+        return skill_success(
+            "Created display layer '{}'".format(layer_name),
+            prompt="Use set_display_layer to add more objects or list_display_layers to see all layers.",
+            layer_name=layer_name,
+            objects_added=added,
+            visibility=visibility,
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create display layer")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_display_layer`."""
+    return create_display_layer(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-display/scripts/delete_display_layer.py
+++ b/src/dcc_mcp_maya/skills/maya-display/scripts/delete_display_layer.py
@@ -1,0 +1,78 @@
+"""Delete a display layer."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists, validate_node_type
+
+
+def delete_display_layer(
+    layer_name: str,
+    remove_objects: bool = False,
+) -> dict:
+    """Delete a display layer.
+
+    Args:
+        layer_name: Name of the display layer to delete.  The built-in
+            ``"defaultLayer"`` cannot be deleted and will cause an error.
+        remove_objects: If True, also delete all objects that were members of
+            this layer.  Default: False (objects are moved to the default layer).
+
+    Returns:
+        ToolResult dict with ``context.layer_name`` and
+        ``context.objects_deleted`` (when ``remove_objects=True``).
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        if layer_name == "defaultLayer":
+            return skill_error(
+                "Cannot delete defaultLayer",
+                "The built-in 'defaultLayer' cannot be deleted",
+            )
+
+        err = validate_node_exists(cmds, layer_name)
+        if err:
+            return err
+
+        err = validate_node_type(cmds, layer_name, "displayLayer")
+        if err:
+            return err
+
+        deleted_objects = []
+        if remove_objects:
+            members = cmds.editDisplayLayerMembers(layer_name, query=True) or []
+            if members:
+                cmds.delete(*members)
+                deleted_objects = list(members)
+
+        cmds.delete(layer_name)
+
+        return skill_success(
+            "Deleted display layer '{}'{}".format(
+                layer_name,
+                " and {} object(s)".format(len(deleted_objects)) if deleted_objects else "",
+            ),
+            layer_name=layer_name,
+            objects_deleted=deleted_objects,
+            prompt="Use list_display_layers to confirm deletion.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete display layer '{}'".format(layer_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`delete_display_layer`."""
+    return delete_display_layer(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-display/scripts/list_display_layers.py
+++ b/src/dcc_mcp_maya/skills/maya-display/scripts/list_display_layers.py
@@ -1,0 +1,54 @@
+"""List all display layers in the scene."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def list_display_layers() -> dict:
+    """List all display layers in the current Maya scene.
+
+    Returns:
+        ToolResult dict with ``context.layers`` — a list of dicts
+        containing ``name``, ``visibility``, and ``members``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        raw = cmds.ls(type="displayLayer") or []
+        layers = []
+        for layer in raw:
+            vis = bool(cmds.getAttr("{}.visibility".format(layer)))
+            members = cmds.editDisplayLayerMembers(layer, query=True, fullNames=True) or []
+            layers.append(
+                {
+                    "name": layer,
+                    "visibility": vis,
+                    "members": list(members),
+                }
+            )
+
+        return skill_success(
+            "Found {} display layer(s)".format(len(layers)),
+            prompt="Use create_display_layer to add a new layer or set_display_layer to move objects.",
+            layers=layers,
+            count=len(layers),
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list display layers")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_display_layers`."""
+    return list_display_layers(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-display/scripts/set_display_layer.py
+++ b/src/dcc_mcp_maya/skills/maya-display/scripts/set_display_layer.py
@@ -1,0 +1,67 @@
+"""Assign an object to an existing display layer."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def set_display_layer(layer_name: str, objects: List[str]) -> dict:
+    """Assign one or more objects to an existing display layer.
+
+    Args:
+        layer_name: Name of the target display layer.
+        objects: List of object names to assign.
+
+    Returns:
+        ToolResult dict with ``context.assigned``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, layer_name)
+        if err:
+            return err
+
+        assigned = []
+        missing = []
+        for obj in objects:
+            if cmds.objExists(obj):
+                cmds.editDisplayLayerMembers(layer_name, obj, noRecurse=True)
+                assigned.append(obj)
+            else:
+                missing.append(obj)
+
+        msg = "Assigned {} object(s) to layer '{}'".format(len(assigned), layer_name)
+        if missing:
+            msg += "; {} not found: {}".format(len(missing), missing)
+
+        return skill_success(
+            msg,
+            prompt="Use list_display_layers to verify the layer membership.",
+            layer_name=layer_name,
+            assigned=assigned,
+            missing=missing,
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to assign objects to layer '{}'".format(layer_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_display_layer`."""
+    return set_display_layer(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-display/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-display/tools.yaml
@@ -1,0 +1,25 @@
+tools:
+- name: create_display_layer
+  execution: sync
+  affinity: main
+  group: scene-management
+- name: delete_display_layer
+  execution: sync
+  affinity: main
+  annotations:
+    destructive_hint: true
+    idempotent_hint: true
+  group: scene-management
+- name: list_display_layers
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: scene-management
+- name: set_display_layer
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: scene-management

--- a/src/dcc_mcp_maya/skills/maya-expressions/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-expressions/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: maya-expressions
+description: Maya expression nodes — create, list, and delete procedural expressions that drive attributes. Use when building procedural animation or rig logic. Not for keyframe animation or general scripting — use maya-animation or maya-scripting for that.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    version: 1.0.0
+    tags:
+    - maya
+    - expression
+    - scripting
+    - procedural
+    search-hint: procedural animation, expression node, drive attribute
+    depends: []
+    tools: tools.yaml
+    groups: groups.yaml
+---
+> **Deprecated (merge bucket):** This skill contains only thin \maya.cmds\ wrappers.
+> Use \xecute_python\ with \maya-scripting/references/RECIPES.md#expressions\ instead.
+> Will be removed in the next release.
+
+# maya-expressions
+
+Maya expressions skill. Provides actions for creating, listing, and deleting Maya expression nodes.
+
+## Scripts
+
+- `create_expression` — Create a Maya expression node
+- `list_expressions` — List Maya expression nodes in the scene
+- `delete_expression` — Delete a Maya expression node by name

--- a/src/dcc_mcp_maya/skills/maya-expressions/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-expressions/groups.yaml
@@ -1,0 +1,9 @@
+groups:
+- name: animation
+  description: Animation, constraints, and motion capture tools
+  default_active: false
+  tools:
+  - create_expression
+  - delete_expression
+  - edit_expression
+  - list_expressions

--- a/src/dcc_mcp_maya/skills/maya-expressions/scripts/create_expression.py
+++ b/src/dcc_mcp_maya/skills/maya-expressions/scripts/create_expression.py
@@ -1,0 +1,106 @@
+"""Create a Maya expression node that drives attributes procedurally."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional, Union
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_VALID_UNIT_CONVERSIONS = {"none", "angularOnly", "all"}
+
+
+def create_expression(
+    expression: str,
+    name: Optional[str] = None,
+    object: Optional[str] = None,
+    object_name: Optional[str] = None,
+    attribute: Optional[str] = None,
+    unit_conversion: Union[str, int, None] = "all",
+) -> dict:
+    """Create an expression node.
+
+    Args:
+        expression: MEL expression string. Must be non-empty and non-whitespace.
+        name: Optional name for the expression node.
+        object: Optional object to set as 'defaultObject' on the expression
+            (alias for ``object_name``).
+        object_name: Optional object name used as context and to verify existence.
+        attribute: Optional attribute name recorded in context.
+        unit_conversion: One of ``"none"``, ``"angularOnly"``, ``"all"``. Default ``"all"``.
+
+    Returns:
+        ToolResult dict with ``context.expression_name``, ``context.expression_str``,
+        and optional ``context.object_name``.
+    """
+    if not expression or not expression.strip():
+        return skill_error("Missing parameter", "'expression' string is required and must not be empty")
+
+    # Validate unit_conversion
+    if unit_conversion is not None and not isinstance(unit_conversion, str):
+        return skill_error(
+            "Invalid parameter",
+            "'unit_conversion' must be one of: {}".format(sorted(_VALID_UNIT_CONVERSIONS)),
+        )
+    if isinstance(unit_conversion, str) and unit_conversion not in _VALID_UNIT_CONVERSIONS:
+        return skill_error(
+            "Invalid unit_conversion '{}'".format(unit_conversion),
+            "Must be one of: {}".format(sorted(_VALID_UNIT_CONVERSIONS)),
+        )
+
+    # Normalise object param
+    obj = object_name or object or None
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        # Validate object existence if specified
+        if obj and not cmds.objExists(obj):
+            return skill_error(
+                "Object '{}' not found".format(obj),
+                "Ensure the object exists in the scene before creating the expression.",
+            )
+
+        kwargs = {"string": expression}
+        if unit_conversion:
+            kwargs["unitConversion"] = unit_conversion
+        if name:
+            kwargs["name"] = name
+        if obj:
+            kwargs["object"] = obj
+
+        node = cmds.expression(**kwargs)
+
+        ctx = {
+            "expression_name": node,
+            "node": node,
+            "expression_str": expression,
+        }
+        if obj:
+            ctx["object_name"] = obj
+        if attribute:
+            ctx["attribute"] = attribute
+
+        return skill_success(
+            "Expression node '{}' created".format(node),
+            prompt="Expression is live. Use list_expressions to verify or delete_expression to remove.",
+            **ctx,
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create expression")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_expression`."""
+    return create_expression(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-expressions/scripts/delete_expression.py
+++ b/src/dcc_mcp_maya/skills/maya-expressions/scripts/delete_expression.py
@@ -1,0 +1,59 @@
+"""Delete an expression node from the Maya scene."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def delete_expression(expression_name: str) -> dict:
+    """Delete an expression node by name.
+
+    Args:
+        expression_name: Expression node name to delete.
+
+    Returns:
+        ToolResult dict with ``context.expression_name`` confirming deletion.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, expression_name)
+        if err:
+            return err
+
+        # Verify it is actually an expression node
+        node_type = cmds.objectType(expression_name)
+        if node_type != "expression":
+            return skill_error(
+                "Node '{}' is not an expression (type: {})".format(expression_name, node_type),
+                "Provide an expression node name. Use list_expressions to find them.",
+            )
+
+        cmds.delete(expression_name)
+        return skill_success(
+            "Expression node '{}' deleted".format(expression_name),
+            prompt="Expression removed. Driven attributes will retain their last evaluated values.",
+            expression_name=expression_name,
+            deleted_node=expression_name,
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete expression '{}'".format(expression_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`delete_expression`."""
+    return delete_expression(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-expressions/scripts/edit_expression.py
+++ b/src/dcc_mcp_maya/skills/maya-expressions/scripts/edit_expression.py
@@ -1,0 +1,62 @@
+"""Edit an existing Maya expression node's string."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def edit_expression(
+    name: str,
+    expression: str,
+    unit_conversion: Optional[str] = None,
+) -> dict:
+    """Edit the expression string of an existing expression node.
+
+    Args:
+        name: Expression node name to edit.
+        expression: New MEL expression string.
+        unit_conversion: Optional — ``"none"``, ``"angularOnly"``, or ``"all"``.
+
+    Returns:
+        ToolResult dict confirming the update.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, name)
+        if err:
+            return err
+
+        kwargs = {"edit": True, "string": expression}
+        if unit_conversion:
+            kwargs["unitConversion"] = unit_conversion
+
+        cmds.expression(name, **kwargs)
+        return skill_success(
+            "Expression '{}' updated".format(name),
+            prompt="Expression updated. Use list_expressions to verify the change.",
+            node=name,
+            expression=expression,
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to edit expression '{}'".format(name))
+
+
+@skill_entry
+def main(**kwargs):
+    return edit_expression(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-expressions/scripts/list_expressions.py
+++ b/src/dcc_mcp_maya/skills/maya-expressions/scripts/list_expressions.py
@@ -1,0 +1,82 @@
+"""List all expression nodes in the current Maya scene."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def list_expressions(
+    object: Optional[str] = None,
+    object_name: Optional[str] = None,
+) -> dict:
+    """List expression nodes in the scene.
+
+    Args:
+        object: Filter — only return expressions whose string or defaultObject
+            contains this value (alias for ``object_name``).
+        object_name: Filter by object name. Same behaviour as ``object``.
+
+    Returns:
+        ToolResult dict with ``context.expressions`` list and ``context.count``.
+        Each expression entry has keys ``name``, ``node``, ``expression_str``.
+    """
+    # Normalise filter param
+    obj_filter = object_name or object or None
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        # Validate object existence if filter specified
+        if obj_filter and not cmds.objExists(obj_filter):
+            return skill_error(
+                "Object '{}' not found".format(obj_filter),
+                "Ensure the object exists in the scene.",
+            )
+
+        all_expr = cmds.ls(type="expression") or []
+        results = []
+        for node in all_expr:
+            expr_str = cmds.expression(node, query=True, string=True) or ""
+            if obj_filter and obj_filter not in expr_str:
+                continue
+            default_obj = ""
+            try:
+                default_obj = cmds.expression(node, query=True, object=True) or ""
+            except Exception:
+                pass
+            results.append(
+                {
+                    "name": node,
+                    "node": node,
+                    "expression_str": expr_str,
+                    "default_object": default_obj,
+                }
+            )
+
+        return skill_success(
+            "Found {} expression node(s)".format(len(results)),
+            prompt="Use create_expression to add more or delete_expression to remove unwanted ones.",
+            expressions=results,
+            count=len(results),
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list expressions")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_expressions`."""
+    return list_expressions(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-expressions/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-expressions/tools.yaml
@@ -1,0 +1,23 @@
+tools:
+- name: create_expression
+  execution: sync
+  affinity: main
+  group: animation
+- name: delete_expression
+  execution: sync
+  affinity: main
+  annotations:
+    destructive_hint: true
+    idempotent_hint: true
+  group: animation
+- name: edit_expression
+  execution: sync
+  affinity: main
+  group: animation
+- name: list_expressions
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: animation

--- a/src/dcc_mcp_maya/skills/maya-materials/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-materials/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: maya-materials
+description: Maya shading materials — create, assign, query, and manage Lambert, Blinn, and surface shader networks. Use when building basic material assignments. Not for material library management or advanced render setups — use maya-material-library or maya-render for that.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    version: 1.0.0
+    tags:
+    - maya
+    - material
+    - shader
+    - shading
+    search-hint: assign shader, basic material, surface shader, lambert blinn
+    depends: []
+    tools: tools.yaml
+    groups: groups.yaml
+---
+> **Deprecated (merge bucket):** This skill contains only thin \maya.cmds\ wrappers.
+> Use \xecute_python\ with \maya-scripting/references/RECIPES.md#materials\ instead.
+> Will be removed in the next release.
+

--- a/src/dcc_mcp_maya/skills/maya-materials/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-materials/groups.yaml
@@ -1,0 +1,13 @@
+groups:
+- name: shading-lighting
+  description: Materials, shading, lighting, and environment tools
+  default_active: false
+  tools:
+  - assign_material
+  - create_material
+  - get_material_connections
+  - get_shader_assignment
+  - list_materials
+  - list_shading_groups
+  - reset_to_default_material
+  - set_material_attribute

--- a/src/dcc_mcp_maya/skills/maya-materials/scripts/assign_material.py
+++ b/src/dcc_mcp_maya/skills/maya-materials/scripts/assign_material.py
@@ -1,0 +1,72 @@
+"""Assign a material to one or more objects."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SUPPORTED_SHADERS = ("lambert", "blinn", "phong", "phongE", "aiStandardSurface")
+
+
+def assign_material(material_name: str, objects: List[str]) -> dict:
+    """Assign a material to one or more objects.
+
+    Args:
+        material_name: Name of the shading group **or** the material node.
+        objects: List of mesh/transform object names.
+
+    Returns:
+        ToolResult dict.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        # Accept either SG or material name
+        if cmds.objectType(material_name) != "shadingEngine":
+            connections = cmds.listConnections(
+                "{}.outColor".format(material_name),
+                type="shadingEngine",
+            )
+            if not connections:
+                return skill_error(
+                    "No shading group found for '{}'".format(material_name),
+                    "Connect material to a shading group first or use assign_material with the SG name",
+                )
+            sg = connections[0]
+        else:
+            sg = material_name
+
+        existing = cmds.ls(objects)
+        if not existing:
+            return skill_error(
+                "No objects found",
+                "None of the requested objects exist: {}".format(objects),
+            )
+
+        cmds.sets(existing, edit=True, forceElement=sg)
+        return skill_success(
+            "Assigned '{}' to {} object(s)".format(sg, len(existing)),
+            shading_group=sg,
+            objects=existing,
+            prompt="Use set_material_attribute to fine-tune the material properties.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to assign material")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`assign_material`."""
+    return assign_material(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-materials/scripts/create_material.py
+++ b/src/dcc_mcp_maya/skills/maya-materials/scripts/create_material.py
@@ -1,0 +1,65 @@
+"""Create a Maya shading material."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SUPPORTED_SHADERS = ("lambert", "blinn", "phong", "phongE", "aiStandardSurface")
+
+
+def create_material(
+    material_type: str = "lambert",
+    shader_type: Optional[str] = None,
+    name: Optional[str] = None,
+) -> dict:
+    """Create a Maya shading material.
+
+    Args:
+        material_type: Shader node type (preferred param name).  Supported:
+            ``lambert``, ``blinn``, ``phong``, ``phongE``, ``aiStandardSurface``.
+            Default: ``lambert``.
+        shader_type: Alias for ``material_type`` (legacy).
+        name: Optional name for the created material.
+
+    Returns:
+        ToolResult dict with ``context.material_name`` and
+        ``context.shading_group``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        # shader_type is legacy alias for material_type
+        resolved_type = shader_type if shader_type is not None else material_type
+        mat = cmds.shadingNode(resolved_type, asShader=True)
+        if name:
+            mat = cmds.rename(mat, name)
+        sg = cmds.sets(renderable=True, noSurfaceShader=True, empty=True, name="{}_SG".format(mat))
+        cmds.connectAttr("{}.outColor".format(mat), "{}.surfaceShader".format(sg), force=True)
+        return skill_success(
+            "Created material: {}".format(mat),
+            material_name=mat,
+            material_type=resolved_type,
+            shading_group=sg,
+            prompt="Use assign_material to apply to objects or set_material_attribute to configure.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create material")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_material`."""
+    return create_material(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-materials/scripts/get_material_connections.py
+++ b/src/dcc_mcp_maya/skills/maya-materials/scripts/get_material_connections.py
@@ -1,0 +1,91 @@
+"""List all nodes connected to a material (textures, utilities, etc.)."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+_SUPPORTED_SHADERS = ("lambert", "blinn", "phong", "phongE", "aiStandardSurface")
+
+
+def get_material_connections(material_name: str) -> dict:
+    """List all nodes connected to a material (textures, utilities, etc.).
+
+    Returns the full set of incoming connections to every attribute on the
+    material node, which lets an Agent understand the complete shading network.
+
+    Args:
+        material_name: Name of the material node to inspect.
+
+    Returns:
+        ToolResult dict with ``context.connections`` — a list of dicts
+        with ``source_node``, ``source_attr``, ``dest_attr``, ``node_type``
+        keys, and ``context.count``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, material_name)
+        if err:
+            return err
+
+        # List all source plugs connected into this material
+        raw_connections = (
+            cmds.listConnections(
+                material_name,
+                source=True,
+                destination=False,
+                connections=True,
+                plugs=True,
+            )
+            or []
+        )
+
+        # listConnections with connections=True returns pairs: [dest, src, dest, src, …]
+        connections = []
+        i = 0
+        while i + 1 < len(raw_connections):
+            dest_plug = raw_connections[i]
+            src_plug = raw_connections[i + 1]
+            # dest_plug is "material.attr"; src_plug is "node.attr"
+            dest_attr = dest_plug.split(".", 1)[-1] if "." in dest_plug else dest_plug
+            src_parts = src_plug.split(".", 1)
+            src_node = src_parts[0]
+            src_attr = src_parts[1] if len(src_parts) > 1 else ""
+            node_type = cmds.nodeType(src_node) if cmds.objExists(src_node) else "unknown"
+            connections.append(
+                {
+                    "source_node": src_node,
+                    "source_attr": src_attr,
+                    "dest_attr": dest_attr,
+                    "node_type": node_type,
+                }
+            )
+            i += 2
+
+        return skill_success(
+            "Found {} connection(s) into material '{}'".format(len(connections), material_name),
+            material_name=material_name,
+            connections=connections,
+            count=len(connections),
+            prompt="Use set_material_attribute to modify or assign_material to reassign.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get connections for material '{}'".format(material_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_material_connections`."""
+    return get_material_connections(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-materials/scripts/get_shader_assignment.py
+++ b/src/dcc_mcp_maya/skills/maya-materials/scripts/get_shader_assignment.py
@@ -1,0 +1,74 @@
+"""Query which shader is assigned to an object or face set."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+_SUPPORTED_SHADERS = ("lambert", "blinn", "phong", "phongE", "aiStandardSurface")
+
+
+def get_shader_assignment(object_name: str) -> dict:
+    """Query which shader (material) is assigned to an object or face set.
+
+    Args:
+        object_name: Transform or mesh node name, or a face component
+            (e.g. ``"pCube1"`` or ``"pCube1.f[0:5]"``).
+
+    Returns:
+        ToolResult dict with ``context.shading_groups`` — a list of
+        dicts with ``shading_group`` and ``material`` keys.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        # Resolve shading engines connected to the shape(s)
+        shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+        if not shapes:
+            # Might already be a shape or component
+            shapes = [object_name]
+
+        shading_groups = []
+        seen_sgs = set()  # type: ignore[var-annotated]
+
+        for shape in shapes:
+            sgs = cmds.listConnections(shape, type="shadingEngine") or []
+            for sg in sgs:
+                if sg in seen_sgs:
+                    continue
+                seen_sgs.add(sg)
+                # Find surface shader connected to this SG
+                shaders = cmds.listConnections("{}.surfaceShader".format(sg)) or []
+                material = shaders[0] if shaders else ""
+                shading_groups.append({"shading_group": sg, "material": material})
+
+        return skill_success(
+            "Found {} shading group(s) on '{}'".format(len(shading_groups), object_name),
+            object_name=object_name,
+            shading_groups=shading_groups,
+            count=len(shading_groups),
+            prompt="Use assign_material to change or set_material_attribute to adjust.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get shader assignment for '{}'".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_shader_assignment`."""
+    return get_shader_assignment(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-materials/scripts/list_materials.py
+++ b/src/dcc_mcp_maya/skills/maya-materials/scripts/list_materials.py
@@ -1,0 +1,64 @@
+"""List all material nodes in the scene."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SUPPORTED_SHADERS = ("lambert", "blinn", "phong", "phongE", "aiStandardSurface")
+
+
+def list_materials(shader_type: Optional[str] = None) -> dict:
+    """List all material nodes in the scene.
+
+    Args:
+        shader_type: Optional filter by shader type (e.g. ``"lambert"``).
+
+    Returns:
+        ToolResult dict with ``context.materials`` list.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        if shader_type:
+            materials = cmds.ls(type=shader_type) or []
+        else:
+            all_shaders = []
+            for st in _SUPPORTED_SHADERS:
+                all_shaders.extend(cmds.ls(type=st) or [])
+            # Also catch any user-created materials not in known list
+            all_shaders.extend(cmds.ls(materials=True) or [])
+            # Deduplicate preserving order
+            seen = set()  # type: ignore[var-annotated]
+            materials = []  # type: List[str]
+            for m in all_shaders:
+                if m not in seen:
+                    seen.add(m)
+                    materials.append(m)
+
+        return skill_success(
+            "Found {} material(s)".format(len(materials)),
+            materials=[{"name": m} for m in materials],
+            count=len(materials),
+            prompt="Use assign_material or set_material_attribute to manage the listed shaders.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list materials")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_materials`."""
+    return list_materials(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-materials/scripts/list_shading_groups.py
+++ b/src/dcc_mcp_maya/skills/maya-materials/scripts/list_shading_groups.py
@@ -1,0 +1,67 @@
+"""List all shading engine (shadingEngine) nodes in the current scene."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SUPPORTED_SHADERS = ("lambert", "blinn", "phong", "phongE", "aiStandardSurface")
+
+
+def list_shading_groups() -> dict:
+    """List all shading engine (shadingEngine) nodes in the current scene.
+
+    Provides a scene-level view of every shading group, including the
+    assigned surface shader and the number of members.
+
+    Returns:
+        ToolResult dict with ``context.shading_groups`` — a list of
+        dicts with ``name``, ``surface_shader``, ``shader_type``,
+        ``member_count`` keys, and ``context.count``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        sgs = cmds.ls(type="shadingEngine") or []
+        result = []
+        for sg in sgs:
+            shaders = cmds.listConnections("{}.surfaceShader".format(sg)) or []
+            surface_shader = shaders[0] if shaders else ""
+            shader_type = cmds.nodeType(surface_shader) if surface_shader else ""
+            try:
+                members = cmds.sets(sg, query=True) or []
+                member_count = len(members)
+            except Exception:
+                member_count = 0
+            result.append(
+                {
+                    "name": sg,
+                    "surface_shader": surface_shader,
+                    "shader_type": shader_type,
+                    "member_count": member_count,
+                }
+            )
+
+        return skill_success(
+            "Found {} shading group(s)".format(len(result)),
+            shading_groups=result,
+            count=len(result),
+            prompt="Use assign_material or get_shader_assignment to inspect.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list shading groups")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_shading_groups`."""
+    return list_shading_groups(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-materials/scripts/reset_to_default_material.py
+++ b/src/dcc_mcp_maya/skills/maya-materials/scripts/reset_to_default_material.py
@@ -1,0 +1,57 @@
+"""Assign the built-in lambert1 to an object, resetting to default material."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+_SUPPORTED_SHADERS = ("lambert", "blinn", "phong", "phongE", "aiStandardSurface")
+
+
+def reset_to_default_material(object_name: str) -> dict:
+    """Assign the built-in ``lambert1`` (initialShadingGroup) to an object.
+
+    This effectively resets the object to Maya's default material, removing
+    any previously assigned custom material.
+
+    Args:
+        object_name: Transform or mesh node name to reset.
+
+    Returns:
+        ToolResult dict with ``context.object_name``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        cmds.sets(object_name, edit=True, forceElement="initialShadingGroup")
+
+        return skill_success(
+            "Reset '{}' to default material (lambert1)".format(object_name),
+            object_name=object_name,
+            shading_group="initialShadingGroup",
+            material="lambert1",
+            prompt="Use create_material and assign_material to set a new shader.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to reset material for '{}'".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`reset_to_default_material`."""
+    return reset_to_default_material(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-materials/scripts/set_material_attribute.py
+++ b/src/dcc_mcp_maya/skills/maya-materials/scripts/set_material_attribute.py
@@ -1,0 +1,67 @@
+"""Set an attribute on a material node."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Any
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+_SUPPORTED_SHADERS = ("lambert", "blinn", "phong", "phongE", "aiStandardSurface")
+
+
+def set_material_attribute(
+    material_name: str,
+    attribute: str,
+    value: Any,
+) -> dict:
+    """Set an attribute on a material node.
+
+    Args:
+        material_name: Name of the material node.
+        attribute: Attribute name (e.g. ``"color"``, ``"transparency"``).
+        value: New value.  Scalar, list-of-3 (RGB), or list-of-4 (RGBA).
+
+    Returns:
+        ToolResult dict.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, material_name)
+        if err:
+            return err
+
+        attr_path = "{}.{}".format(material_name, attribute)
+        if isinstance(value, (list, tuple)):
+            cmds.setAttr(attr_path, *value, type="double3" if len(value) == 3 else "double4")
+        else:
+            cmds.setAttr(attr_path, value)
+
+        return skill_success(
+            "Set {}.{} = {}".format(material_name, attribute, value),
+            material_name=material_name,
+            attribute=attribute,
+            value=value,
+            prompt="Use get_material_connections to verify or render_frame to preview.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set material attribute")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_material_attribute`."""
+    return set_material_attribute(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-materials/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-materials/tools.yaml
@@ -1,0 +1,51 @@
+tools:
+- name: assign_material
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: shading-lighting
+- name: create_material
+  execution: sync
+  affinity: main
+  group: shading-lighting
+- name: get_material_connections
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: shading-lighting
+- name: get_shader_assignment
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: shading-lighting
+- name: list_materials
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: shading-lighting
+- name: list_shading_groups
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: shading-lighting
+- name: reset_to_default_material
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: shading-lighting
+- name: set_material_attribute
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: shading-lighting

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: maya-mesh-ops
+description: Maya polygon mesh editing operations — bevel, extrude, bridge, combine, separate, cleanup, and boolean. Use when modifying existing polygon geometry. Not for primitive creation, UV layout, or rendering — use maya-primitives, maya-uv-ops, or maya-render for that.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    version: 1.0.0
+    tags:
+    - maya
+    - mesh
+    - polygon
+    - geometry
+    - topology
+    search-hint: edit mesh, modify polygons, boolean, cleanup, subdivide geometry
+    depends: []
+    tools: tools.yaml
+    groups: groups.yaml
+---

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/groups.yaml
@@ -1,0 +1,17 @@
+groups:
+- name: modeling
+  description: Geometry creation, editing, and UV tools
+  default_active: false
+  tools:
+  - apply_subdivision
+  - cleanup_mesh
+  - combine_meshes
+  - create_proxy_mesh
+  - extract_faces
+  - get_mesh_edge_info
+  - get_poly_count
+  - merge_vertices
+  - mirror_mesh
+  - select_by_material
+  - separate_mesh
+  - triangulate

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/apply_subdivision.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/apply_subdivision.py
@@ -1,0 +1,79 @@
+"""Apply subdivision to a polygon mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def apply_subdivision(
+    object_name: str,
+    level: int = 1,
+    method: str = "preview",
+) -> dict:
+    """Apply subdivision to a polygon mesh.
+
+    Args:
+        object_name: Transform or mesh shape name.
+        level: Subdivision level / divisions.  Default: 1.
+        method: ``"preview"`` (displaySmoothMesh — non-destructive) or
+            ``"subdivide"`` (polySubdivideFacet — destructive).
+            Default: ``"preview"``.
+
+    Returns:
+        ToolResult dict.
+    """
+    if method not in ("preview", "subdivide"):
+        return skill_error(
+            "Invalid method: {}".format(method),
+            "Use 'preview' or 'subdivide'",
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        shapes = cmds.listRelatives(object_name, shapes=True, type="mesh") or []
+        if not shapes:
+            if cmds.objectType(object_name) == "mesh":
+                shapes = [object_name]
+            else:
+                return skill_error("'{}' has no polygon mesh shape".format(object_name), "")
+
+        shape = shapes[0]
+
+        if method == "preview":
+            cmds.setAttr("{}.displaySmoothMesh".format(shape), 2)
+            cmds.setAttr("{}.smoothLevel".format(shape), level)
+        else:
+            cmds.polySubdivideFacet(object_name, dv=level)
+
+        return skill_success(
+            "Subdivision applied to '{}' (method={}, level={})".format(object_name, method, level),
+            object_name=object_name,
+            method=method,
+            level=level,
+            prompt="Use get_poly_count to verify the increased density.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to apply subdivision")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`apply_subdivision`."""
+    return apply_subdivision(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/cleanup_mesh.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/cleanup_mesh.py
@@ -1,0 +1,68 @@
+"""Clean up mesh issues such as non-manifold geometry and lamina faces."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def cleanup_mesh(
+    object_name: str,
+    non_manifold: bool = True,
+    lamina_faces: bool = True,
+    invalid_components: bool = True,
+) -> dict:
+    """Clean up mesh issues such as non-manifold geometry and lamina faces.
+
+    Args:
+        object_name: Transform or mesh name.
+        non_manifold: Fix non-manifold geometry.  Default: True.
+        lamina_faces: Remove lamina (zero-area) faces.  Default: True.
+        invalid_components: Remove invalid (degenerate) polygons.
+            Default: True.
+
+    Returns:
+        ToolResult dict.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        kwargs = {
+            "selectOnly": False,
+            "nonManifold": 1 if non_manifold else 0,
+            "lamina": 1 if lamina_faces else 0,
+            "nsi": 1 if invalid_components else 0,
+        }
+        cmds.polyClean(object_name, **kwargs)
+
+        return skill_success(
+            "Cleaned mesh '{}'".format(object_name),
+            object_name=object_name,
+            non_manifold=non_manifold,
+            lamina_faces=lamina_faces,
+            invalid_components=invalid_components,
+            prompt="Use get_poly_count or select_by_material to inspect the result.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to clean mesh")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`cleanup_mesh`."""
+    return cleanup_mesh(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/combine_meshes.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/combine_meshes.py
@@ -1,0 +1,76 @@
+"""Combine multiple polygon meshes into a single mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def combine_meshes(
+    objects,  # type: List[str]
+    name=None,  # type: Optional[str]
+):
+    # type: (...) -> dict
+    """Combine multiple polygon meshes into a single mesh.
+
+    Uses ``cmds.polyUnite`` to merge the meshes and then deletes the original
+    transform nodes.
+
+    Args:
+        objects: List of two or more polygon mesh transform names.
+        name: Optional name for the resulting combined mesh.
+
+    Returns:
+        ToolResult dict with ``context.combined_mesh`` (name of the
+        result) and ``context.input_count``.
+    """
+    if not objects or len(objects) < 2:
+        return skill_error(
+            "At least two objects are required for combine_meshes",
+            "Provide a list of two or more polygon mesh names",
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        for obj in objects:
+            err = validate_node_exists(cmds, obj)
+            if err:
+                return err
+
+        kwargs = {}
+        if name:
+            kwargs["name"] = name
+        result = cmds.polyUnite(*objects, constructionHistory=False, **kwargs) or []
+        combined = result[0] if result else None
+        if not combined:
+            return skill_error(
+                "polyUnite returned no result",
+                "polyUnite did not produce any output mesh",
+            )
+
+        return skill_success(
+            "Combined {} meshes into '{}'".format(len(objects), combined),
+            combined_mesh=combined,
+            input_count=len(objects),
+            prompt="Use cleanup_mesh or assign_material to finalise the combined mesh.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to combine meshes")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`combine_meshes`."""
+    return combine_meshes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/create_proxy_mesh.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/create_proxy_mesh.py
@@ -1,0 +1,107 @@
+"""Create a simplified proxy mesh from a polygon object."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def create_proxy_mesh(
+    object_name: str,
+    reduction: float = 0.5,
+    name: Optional[str] = None,
+) -> dict:
+    """Create a simplified proxy mesh from a polygon object.
+
+    Uses ``cmds.polyReduce`` to produce a lower-resolution version of the
+    source mesh.  The original object is left unchanged; a copy is created
+    first and the reduction is applied to the copy.
+
+    Args:
+        object_name: Name of the source polygon mesh transform.
+        reduction: Fraction of faces to *remove* (0.0 = no reduction,
+            0.9 = remove 90% of faces).  Must be in range [0.0, 1.0).
+            Default: 0.5.
+        name: Optional name for the proxy mesh transform.  If None,
+            Maya auto-generates a name.
+
+    Returns:
+        ToolResult dict with ``context.proxy_mesh``,
+        ``context.original``, ``context.reduction``,
+        ``context.face_count_before``, ``context.face_count_after``.
+    """
+    if not (0.0 <= reduction < 1.0):
+        return skill_error(
+            "Invalid reduction: {}".format(reduction),
+            "reduction must be in range [0.0, 1.0)",
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        shapes = cmds.listRelatives(object_name, shapes=True, type="mesh") or []
+        if not shapes:
+            obj_type = cmds.objectType(object_name)
+            if obj_type != "mesh":
+                return skill_error("'{}' has no polygon mesh shape".format(object_name), "")
+
+        # Record original face count
+        face_count_before = cmds.polyEvaluate(object_name, face=True)
+        face_count_before = face_count_before if isinstance(face_count_before, int) else 0
+
+        # Duplicate source mesh
+        dup_kwargs = {}
+        if name:
+            dup_kwargs["name"] = name
+        dup_result = cmds.duplicate(object_name, **dup_kwargs)
+        proxy = dup_result[0] if dup_result else None
+        if not proxy:
+            return skill_error("Failed to duplicate '{}'".format(object_name), "")
+
+        # Apply polyReduce
+        percentage = (1.0 - reduction) * 100.0
+        cmds.polyReduce(
+            proxy,
+            percentage=percentage,
+            triangulate=False,
+            constructionHistory=False,
+        )
+
+        face_count_after = cmds.polyEvaluate(proxy, face=True)
+        face_count_after = face_count_after if isinstance(face_count_after, int) else 0
+
+        return skill_success(
+            "Created proxy mesh '{}' from '{}' (reduction={})".format(proxy, object_name, reduction),
+            proxy_mesh=proxy,
+            original=object_name,
+            reduction=reduction,
+            face_count_before=face_count_before,
+            face_count_after=face_count_after,
+            prompt="Use swap_proxy in maya-proxy-mesh to toggle between proxy and hi-res.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create proxy mesh from '{}'".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_proxy_mesh`."""
+    return create_proxy_mesh(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/extract_faces.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/extract_faces.py
@@ -1,0 +1,90 @@
+"""Extract (separate) specified polygon faces into a new mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def extract_faces(
+    object_name,  # type: str
+    face_indices,  # type: List[int]
+    keep_original=False,  # type: bool
+    separate=True,  # type: bool
+):
+    # type: (...) -> dict
+    """Extract (separate) specified polygon faces into a new mesh.
+
+    Uses ``cmds.polyChipOff`` with *duplicate=keep_original* and then
+    ``cmds.polySeparate`` if *separate* is True.
+
+    Args:
+        object_name: Polygon mesh transform name.
+        face_indices: List of face indices to extract.
+        keep_original: If ``True``, keep extracted faces on the original mesh
+            (duplicate mode).  Default ``False`` (chip-off).
+        separate: If ``True`` (default), separate the result into an
+            independent mesh.
+
+    Returns:
+        ToolResult dict with ``context.extracted_mesh`` and
+        ``context.face_count``.
+    """
+    if not object_name:
+        return skill_error(
+            "object_name is required",
+            "Provide a non-empty polygon mesh name",
+        )
+    if not face_indices:
+        return skill_error(
+            "face_indices is required",
+            "Provide a non-empty list of integer face indices",
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        face_components = ["{}.f[{}]".format(object_name, idx) for idx in face_indices]
+
+        cmds.polyChipOff(*face_components, constructionHistory=False, duplicate=keep_original, keepFacesTogether=True)
+
+        extracted = object_name
+        if separate:
+            sep_result = cmds.polySeparate(object_name, constructionHistory=False) or []
+            if sep_result:
+                last = sep_result[-1]
+                if cmds.objectType(last) == "transform":
+                    extracted = last
+                else:
+                    parents = cmds.listRelatives(last, parent=True, fullPath=False) or []
+                    extracted = parents[0] if parents else object_name
+
+        return skill_success(
+            "Extracted {} face(s) from '{}'".format(len(face_indices), object_name),
+            extracted_mesh=extracted,
+            face_count=len(face_indices),
+            prompt="Use combine_meshes or cleanup_mesh to post-process.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to extract faces from '{}'".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`extract_faces`."""
+    return extract_faces(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/get_mesh_edge_info.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/get_mesh_edge_info.py
@@ -1,0 +1,111 @@
+"""Query edge length and connected vertex indices for a polygon mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def get_mesh_edge_info(
+    object_name: str,
+    edge_indices: Optional[List[int]] = None,
+) -> dict:
+    """Query edge length and connected vertex indices for a polygon mesh.
+
+    Args:
+        object_name: Transform or mesh shape name.
+        edge_indices: Optional list of zero-based edge indices to query.
+            If None, all edges are queried (may be slow on dense meshes).
+
+    Returns:
+        ToolResult dict with ``context.edges`` (list of dicts with
+        ``index``, ``length``, ``vertices``), ``context.edge_count``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        total_edges = cmds.polyEvaluate(object_name, edge=True)
+        if not isinstance(total_edges, int) or total_edges == 0:
+            return skill_error("'{}' has no edges — ensure it is a polygon mesh".format(object_name), "")
+
+        if edge_indices is None:
+            indices = list(range(total_edges))
+        else:
+            invalid = [i for i in edge_indices if not (0 <= i < total_edges)]
+            if invalid:
+                return skill_error(
+                    "Invalid edge indices: {}".format(invalid),
+                    "Valid range is 0 to {}".format(total_edges - 1),
+                )
+            indices = list(edge_indices)
+
+        edges = []
+        for idx in indices:
+            edge_comp = "{}.e[{}]".format(object_name, idx)
+            # Edge length via polyInfo
+            try:
+                info_lines = cmds.polyInfo(edge_comp, edgeToVertex=True) or []
+                verts = []
+                for line in info_lines:
+                    parts = line.strip().split()
+                    # Format: EDGE n : v1 v2
+                    colon_pos = [i for i, p in enumerate(parts) if p == ":"]
+                    if colon_pos:
+                        for p in parts[colon_pos[0] + 1 :]:
+                            try:
+                                verts.append(int(p))
+                            except ValueError:
+                                pass
+            except Exception:
+                verts = []
+
+            try:
+                _ = cmds.polyInfo(edge_comp, edgeToFace=False) or []
+                # Edge length via arclen approximation
+                length = None
+                if verts and len(verts) >= 2:
+                    v0_pos = cmds.pointPosition("{}.vtx[{}]".format(object_name, verts[0]), world=True)
+                    v1_pos = cmds.pointPosition("{}.vtx[{}]".format(object_name, verts[1]), world=True)
+                    length = (
+                        (v1_pos[0] - v0_pos[0]) ** 2 + (v1_pos[1] - v0_pos[1]) ** 2 + (v1_pos[2] - v0_pos[2]) ** 2
+                    ) ** 0.5
+                    length = round(length, 6)
+            except Exception:
+                length = None
+
+            edges.append({"index": idx, "length": length, "vertices": verts})
+
+        return skill_success(
+            "Edge info for '{}' ({} edge(s) queried)".format(object_name, len(edges)),
+            object_name=object_name,
+            edges=edges,
+            edge_count=len(edges),
+            total_edges=total_edges,
+            prompt="Use merge_vertices or cleanup_mesh to fix edge issues.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get edge info")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_mesh_edge_info`."""
+    return get_mesh_edge_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/get_poly_count.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/get_poly_count.py
@@ -1,0 +1,96 @@
+"""Query polygon statistics for an object or the entire scene."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def get_poly_count(object_name: Optional[str] = None) -> dict:
+    """Query polygon statistics for an object or the entire scene.
+
+    Args:
+        object_name: Transform or mesh shape name.  If None, queries the full
+            scene.
+
+    Returns:
+        ToolResult dict with ``context.faces``, ``context.vertices``,
+        ``context.edges``, and ``context.triangles``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        if object_name:
+            err = validate_node_exists(cmds, object_name)
+            if err:
+                return err
+            targets = [object_name]
+        else:
+            targets = cmds.ls(type="mesh") or []
+
+        total_faces = 0
+        total_verts = 0
+        total_edges = 0
+        total_tris = 0
+        per_object = []
+
+        for target in targets:
+            try:
+                faces = cmds.polyEvaluate(target, face=True)
+                verts = cmds.polyEvaluate(target, vertex=True)
+                edges = cmds.polyEvaluate(target, edge=True)
+                tris = cmds.polyEvaluate(target, triangle=True)
+            except Exception:
+                faces = verts = edges = tris = 0
+
+            total_faces += faces if isinstance(faces, int) else 0
+            total_verts += verts if isinstance(verts, int) else 0
+            total_edges += edges if isinstance(edges, int) else 0
+            total_tris += tris if isinstance(tris, int) else 0
+
+            if object_name:
+                per_object.append(
+                    {
+                        "name": target,
+                        "faces": faces,
+                        "vertices": verts,
+                        "edges": edges,
+                        "triangles": tris,
+                    }
+                )
+
+        label = "Poly count for '{}'".format(object_name) if object_name else "Scene poly count"
+        result_kwargs = {
+            "faces": total_faces,
+            "vertices": total_verts,
+            "edges": total_edges,
+            "triangles": total_tris,
+        }
+        if object_name:
+            result_kwargs["objects"] = per_object
+
+        return skill_success(
+            label, **result_kwargs, prompt="Use apply_subdivision or cleanup_mesh to adjust the geometry."
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get poly count")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_poly_count`."""
+    return get_poly_count(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/merge_vertices.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/merge_vertices.py
@@ -1,0 +1,64 @@
+"""Merge coincident vertices on a polygon mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def merge_vertices(
+    object_name: str,
+    threshold: float = 0.001,
+) -> dict:
+    """Merge coincident vertices on a polygon mesh.
+
+    Args:
+        object_name: Transform or mesh name.
+        threshold: Distance threshold for merging.  Default: 0.001.
+
+    Returns:
+        ToolResult dict with ``context.merged_count`` (approximate).
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        before = cmds.polyEvaluate(object_name, vertex=True)
+        cmds.polyMergeVertex(object_name, distance=threshold, ch=False)
+        after = cmds.polyEvaluate(object_name, vertex=True)
+
+        before_count = before if isinstance(before, int) else 0
+        after_count = after if isinstance(after, int) else 0
+        merged = before_count - after_count
+
+        return skill_success(
+            "Merged {} vertices on '{}' (threshold={})".format(merged, object_name, threshold),
+            object_name=object_name,
+            merged_count=merged,
+            vertex_count_before=before_count,
+            vertex_count_after=after_count,
+            threshold=threshold,
+            prompt="Use cleanup_mesh to verify or get_poly_count to check the result.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to merge vertices")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`merge_vertices`."""
+    return merge_vertices(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/mirror_mesh.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/mirror_mesh.py
@@ -1,0 +1,98 @@
+"""Mirror a polygon mesh along a world axis and merge the result."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def mirror_mesh(
+    object_name,  # type: str
+    axis="x",  # type: str
+    cut_position=0.0,  # type: float
+    merge_threshold=0.001,  # type: float
+    merge_border=True,  # type: bool
+):
+    # type: (...) -> dict
+    """Mirror a polygon mesh along a world axis and merge the result.
+
+    Uses ``cmds.polyMirrorFace`` to mirror the mesh about a world-axis cut
+    plane and optionally merge border vertices.
+
+    Args:
+        object_name: Polygon mesh transform name.
+        axis: World axis to mirror across — ``"x"``, ``"y"``, or ``"z"``.
+            Default ``"x"``.
+        cut_position: World-space position of the mirror plane along *axis*.
+            Default ``0.0``.
+        merge_threshold: Distance threshold for merging border vertices.
+            Default ``0.001``.
+        merge_border: If ``True`` (default), merge vertices on the mirror
+            border after mirroring.
+
+    Returns:
+        ToolResult dict with ``context.object_name``, ``context.axis``,
+        ``context.cut_position``.
+    """
+    axis_lower = (axis or "x").lower()
+    if axis_lower not in ("x", "y", "z"):
+        return skill_error(
+            "Invalid axis: {}".format(axis),
+            "axis must be one of 'x', 'y', 'z'",
+        )
+
+    if not object_name:
+        return skill_error(
+            "object_name is required",
+            "Provide a non-empty polygon mesh name",
+        )
+
+    # polyMirrorFace axis indices: 0=X, 1=Y, 2=Z
+    axis_index = {"x": 0, "y": 1, "z": 2}[axis_lower]
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        cmds.polyMirrorFace(
+            object_name,
+            constructionHistory=False,
+            axis=axis_index,
+            axisDirection=1,
+            cutMesh=1,
+            worldSpace=True,
+            axisPos=cut_position,
+            mergeMode=1 if merge_border else 0,
+            mergeThresholdType=1,
+            mergeThreshold=merge_threshold,
+        )
+
+        return skill_success(
+            "Mirrored '{}' along {} axis at {}".format(object_name, axis_lower, cut_position),
+            object_name=object_name,
+            axis=axis_lower,
+            cut_position=cut_position,
+            prompt="Use freeze_transforms in maya-xform-utils to clean up.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to mirror mesh '{}'".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`mirror_mesh`."""
+    return mirror_mesh(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/select_by_material.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/select_by_material.py
@@ -1,0 +1,95 @@
+"""Select all objects in the scene that use a given material."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def select_by_material(material_name: str) -> dict:
+    """Select all objects in the scene that use a given material.
+
+    Looks up the shading group(s) associated with *material_name*, then
+    queries the group members to find polygon mesh transforms.
+
+    Args:
+        material_name: Name of the material (shader) node, e.g.
+            ``"lambert1"``, ``"blinn1"``, ``"aiStandardSurface1"``.
+
+    Returns:
+        ToolResult dict with ``context.objects`` (list of selected
+        object names), ``context.count``, ``context.material``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, material_name)
+        if err:
+            return err
+
+        # Find all shading engines connected to this material
+        shading_engines = (
+            cmds.listConnections(material_name, type="shadingEngine", source=False, destination=True) or []
+        )
+
+        if not shading_engines:
+            return skill_success(
+                "Material '{}' is not assigned to any objects".format(material_name),
+                objects=[],
+                count=0,
+                material=material_name,
+                prompt="Use assign_material to replace or list_materials to inspect.",
+            )
+
+        # Collect all mesh members from shading groups
+        objects = []
+        seen = set()
+        for sg in shading_engines:
+            members = cmds.sets(sg, query=True) or []
+            for member in members:
+                # member can be a transform or a component (face assignment)
+                node = member.split(".")[0] if "." in member else member
+                if node in seen:
+                    continue
+                seen.add(node)
+                # Resolve to transform
+                node_type = cmds.objectType(node)
+                if node_type == "mesh":
+                    parents = cmds.listRelatives(node, parent=True, fullPath=False) or []
+                    transform = parents[0] if parents else node
+                elif node_type == "transform":
+                    transform = node
+                else:
+                    continue
+                if transform not in objects:
+                    objects.append(transform)
+
+        if objects:
+            cmds.select(objects, replace=True)
+
+        return skill_success(
+            "Selected {} object(s) with material '{}'".format(len(objects), material_name),
+            objects=objects,
+            count=len(objects),
+            material=material_name,
+            prompt="Use assign_material to replace or list_materials to inspect.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to select by material")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`select_by_material`."""
+    return select_by_material(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/separate_mesh.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/separate_mesh.py
@@ -1,0 +1,81 @@
+"""Separate a polygon mesh containing disconnected shells into individual meshes."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def separate_mesh(
+    object_name,  # type: str
+):
+    # type: (...) -> dict
+    """Separate a polygon mesh that contains disconnected shells into individual meshes.
+
+    Uses ``cmds.polySeparate`` to split each disconnected shell into its own
+    transform node.
+
+    Args:
+        object_name: Name of the polygon mesh transform to separate.
+
+    Returns:
+        ToolResult dict with ``context.separated_meshes`` (list of
+        result transform names) and ``context.count``.
+    """
+    if not object_name:
+        return skill_error(
+            "object_name is required",
+            "Provide a non-empty polygon mesh name",
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        result = cmds.polySeparate(object_name, constructionHistory=False) or []
+        # polySeparate returns shape nodes; get their parent transforms
+        separated = []
+        for node in result:
+            if cmds.objectType(node) == "transform":
+                separated.append(node)
+            else:
+                parents = cmds.listRelatives(node, parent=True, fullPath=False) or []
+                if parents:
+                    separated.append(parents[0])
+
+        # Deduplicate while preserving order
+        seen = set()  # type: set
+        unique = []
+        for s in separated:
+            if s not in seen:
+                seen.add(s)
+                unique.append(s)
+
+        return skill_success(
+            "Separated '{}' into {} meshes".format(object_name, len(unique)),
+            separated_meshes=unique,
+            count=len(unique),
+            prompt="Use combine_meshes to undo or cleanup_mesh on each piece.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to separate mesh '{}'".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`separate_mesh`."""
+    return separate_mesh(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/triangulate.py
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/scripts/triangulate.py
@@ -1,0 +1,57 @@
+"""Triangulate all faces of a polygon mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def triangulate(object_name: str) -> dict:
+    """Triangulate all faces of a polygon mesh.
+
+    Args:
+        object_name: Transform or mesh name.
+
+    Returns:
+        ToolResult dict with face counts before and after.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        before = cmds.polyEvaluate(object_name, face=True)
+        cmds.polyTriangulate(object_name)
+        after = cmds.polyEvaluate(object_name, face=True)
+
+        before_count = before if isinstance(before, int) else 0
+        after_count = after if isinstance(after, int) else 0
+
+        return skill_success(
+            "Triangulated '{}': {} -> {} faces".format(object_name, before_count, after_count),
+            object_name=object_name,
+            face_count_before=before_count,
+            face_count_after=after_count,
+            prompt="Use export_shot_fbx or get_poly_count to verify the result.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to triangulate")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`triangulate`."""
+    return triangulate(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/tools.yaml
@@ -1,0 +1,57 @@
+tools:
+- name: apply_subdivision
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: modeling
+- name: cleanup_mesh
+  execution: sync
+  affinity: main
+  group: modeling
+- name: combine_meshes
+  execution: sync
+  affinity: main
+  group: modeling
+- name: create_proxy_mesh
+  execution: sync
+  affinity: main
+  group: modeling
+- name: extract_faces
+  execution: sync
+  affinity: main
+  group: modeling
+- name: get_mesh_edge_info
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: modeling
+- name: get_poly_count
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: modeling
+- name: merge_vertices
+  execution: sync
+  affinity: main
+  group: modeling
+- name: mirror_mesh
+  execution: sync
+  affinity: main
+  group: modeling
+- name: select_by_material
+  execution: sync
+  affinity: main
+  group: modeling
+- name: separate_mesh
+  execution: sync
+  affinity: main
+  group: modeling
+- name: triangulate
+  execution: sync
+  affinity: main
+  group: modeling

--- a/src/dcc_mcp_maya/skills/maya-node-graph/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: maya-node-graph
+description: Maya node graph operations — connect and disconnect attributes, query construction history and DG topology. Use when working with dependency graph connections. Not for attribute value editing or scene file operations — use maya-attributes or maya-scene for that.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    version: 1.0.0
+    tags:
+    - maya
+    - node
+    - attribute
+    - graph
+    - utility
+    search-hint: node connection, DG topology, construction history, attribute link
+    depends: []
+    tools: tools.yaml
+---
+# maya-node-graph
+
+Maya node graph skill. Provides actions for connecting and disconnecting attributes, querying history, and managing mesh topology.
+
+## Scripts
+
+- `connect_attr` — Connect two Maya node attributes
+- `disconnect_attr` — Disconnect two connected Maya node attributes
+- `list_connections` — List nodes/attributes connected to a Maya node or attribute
+- `get_dag_path` — Return the full DAG path of a Maya node
+- `smooth_mesh` — Apply smooth mesh preview or subdivision to a polygon mesh
+- `list_history` — List construction history nodes for a Maya object
+- `delete_history` — Delete the construction history on a Maya object
+- `apply_symmetry` — Apply mesh symmetry to a polygon object
+- `transfer_attributes` — Transfer mesh attributes (UVs, normals, vertex colors) from one mesh to another

--- a/src/dcc_mcp_maya/skills/maya-node-graph/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/groups.yaml
@@ -1,0 +1,14 @@
+groups:
+- name: node_graph
+  description: DAG traversal, attribute connections, and construction history tools
+  default_active: false
+  tools:
+  - apply_symmetry
+  - connect_attr
+  - delete_history
+  - disconnect_attr
+  - get_dag_path
+  - list_connections
+  - list_history
+  - smooth_mesh
+  - transfer_attributes

--- a/src/dcc_mcp_maya/skills/maya-node-graph/scripts/apply_symmetry.py
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/scripts/apply_symmetry.py
@@ -1,0 +1,87 @@
+"""Apply mesh symmetry to a polygon object."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def apply_symmetry(
+    object_name: str,
+    axis: str = "x",
+    world_space: bool = True,
+) -> dict:
+    """Apply mesh symmetry to a polygon object using ``cmds.symmetricModelling``.
+
+    This enables Maya's interactive Symmetry tool on the specified axis so
+    that subsequent edits are mirrored automatically.  To disable symmetry,
+    call with ``axis="none"``.
+
+    Args:
+        object_name: Name of the polygon mesh transform to apply symmetry on.
+        axis: Symmetry axis – one of ``"x"``, ``"y"``, ``"z"``, ``"none"``.
+            Default: ``"x"``.
+        world_space: If True, symmetry is evaluated in world space; otherwise
+            object space.  Default: True.
+
+    Returns:
+        ToolResult dict with ``context.object_name``,
+        ``context.axis``, ``context.world_space``.
+    """
+
+    _VALID_AXES = ("x", "y", "z", "none")
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        axis_lower = axis.lower()
+        if axis_lower not in _VALID_AXES:
+            return skill_error(
+                "Invalid axis: {}".format(axis),
+                "axis must be one of {}".format(_VALID_AXES),
+            )
+
+        if axis_lower == "none":
+            cmds.symmetricModelling(symmetry=False)
+        else:
+            space = "world" if world_space else "object"
+            cmds.symmetricModelling(
+                object_name,
+                symmetry=True,
+                axis=axis_lower,
+                about=space,
+            )
+
+        return skill_success(
+            "Applied {} symmetry on '{}' ({} space)".format(
+                axis_lower, object_name, "world" if world_space else "object"
+            ),
+            object_name=object_name,
+            axis=axis_lower,
+            world_space=world_space,
+            prompt="Check the result with list_node_graph or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to apply symmetry on {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`apply_symmetry`."""
+    return apply_symmetry(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-node-graph/scripts/connect_attr.py
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/scripts/connect_attr.py
@@ -1,0 +1,65 @@
+"""Connect two Maya node attributes."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
+
+from dcc_mcp_maya.api import batch_validate_nodes
+
+
+def connect_attr(
+    source_attr: str,
+    dest_attr: str,
+    force: bool = False,
+) -> dict:
+    """Connect two Maya node attributes.
+
+    Args:
+        source_attr: Full attribute path of the driver, e.g.
+            ``"pSphere1.translateX"``.
+        dest_attr: Full attribute path of the driven attribute.
+        force: If True, break any existing connection on *dest_attr* before
+            connecting.  Default: False.
+
+    Returns:
+        ToolResult dict with ``context.source_attr`` and
+        ``context.dest_attr``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = batch_validate_nodes(cmds, [source_attr, dest_attr])
+        if err:
+            return err
+
+        cmds.connectAttr(source_attr, dest_attr, force=force)
+
+        return skill_success(
+            "Connected {} -> {}".format(source_attr, dest_attr),
+            source_attr=source_attr,
+            dest_attr=dest_attr,
+            prompt="Check the result with list_node_graph or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_error(
+            "Failed to connect {} -> {}".format(source_attr, dest_attr),
+            str(exc),
+        )
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`connect_attr`."""
+    return connect_attr(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-node-graph/scripts/delete_history.py
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/scripts/delete_history.py
@@ -1,0 +1,58 @@
+"""Delete the construction history on a Maya object."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def delete_history(
+    object_name: str,
+) -> dict:
+    """Delete the construction history on a Maya object.
+
+    Equivalent to *Edit > Delete by Type > History* in Maya.  Bakes the
+    current deformed state into the mesh and removes all upstream history
+    nodes, which can improve scene performance.
+
+    Args:
+        object_name: Name of the transform or shape node to process.
+
+    Returns:
+        ToolResult dict with ``context.object_name``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        cmds.delete(object_name, constructionHistory=True)
+
+        return skill_success(
+            "Deleted construction history on '{}'".format(object_name),
+            object_name=object_name,
+            prompt="Check the result with list_node_graph or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete history for {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`delete_history`."""
+    return delete_history(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-node-graph/scripts/disconnect_attr.py
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/scripts/disconnect_attr.py
@@ -1,0 +1,69 @@
+"""Disconnect two connected Maya node attributes."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
+
+from dcc_mcp_maya.api import batch_validate_nodes
+
+
+def disconnect_attr(
+    source_attr: str,
+    dest_attr: str,
+) -> dict:
+    """Disconnect two connected Maya node attributes.
+
+    Args:
+        source_attr: Full attribute path of the driver, e.g.
+            ``"pSphere1.translateX"``.
+        dest_attr: Full attribute path of the driven attribute.
+
+    Returns:
+        ToolResult dict with ``context.source_attr`` and
+        ``context.dest_attr``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = batch_validate_nodes(cmds, [source_attr, dest_attr])
+        if err:
+            return err
+
+        # Check if actually connected before attempting disconnect
+        if not cmds.isConnected(source_attr, dest_attr):
+            return skill_error(
+                "Attributes not connected: {} -> {}".format(source_attr, dest_attr),
+                "No connection exists between these attributes",
+            )
+
+        cmds.disconnectAttr(source_attr, dest_attr)
+
+        return skill_success(
+            "Disconnected {} -x-> {}".format(source_attr, dest_attr),
+            source_attr=source_attr,
+            dest_attr=dest_attr,
+            prompt="Check the result with list_node_graph or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_error(
+            "Failed to disconnect {} -> {}".format(source_attr, dest_attr),
+            str(exc),
+        )
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`disconnect_attr`."""
+    return disconnect_attr(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-node-graph/scripts/get_dag_path.py
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/scripts/get_dag_path.py
@@ -1,0 +1,71 @@
+"""Return the full DAG path of a Maya node."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def get_dag_path(
+    object_name: str,
+) -> dict:
+    """Return the full DAG path of a Maya node.
+
+    Resolves the shortest unique path for the given node name, then returns
+    its full absolute DAG path (e.g. ``"|group1|pSphere1"``).
+
+    Args:
+        object_name: Short or partial name of the node.
+
+    Returns:
+        ToolResult dict with ``context.dag_path`` (full path),
+        ``context.short_name``, and ``context.node_type``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        # ls -long returns full DAG paths
+        full_paths = cmds.ls(object_name, long=True)
+        if not full_paths:
+            return skill_error(
+                "Could not resolve DAG path for: {}".format(object_name),
+                "cmds.ls returned empty list",
+            )
+
+        dag_path = full_paths[0]
+        node_type = cmds.objectType(object_name)
+        short_name = dag_path.split("|")[-1]
+
+        return skill_success(
+            "DAG path for '{}': {}".format(object_name, dag_path),
+            dag_path=dag_path,
+            short_name=short_name,
+            node_type=node_type,
+            object_name=object_name,
+            prompt="Check the result with list_node_graph or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get DAG path for {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_dag_path`."""
+    return get_dag_path(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-node-graph/scripts/list_connections.py
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/scripts/list_connections.py
@@ -1,0 +1,91 @@
+"""List nodes/attributes connected to a Maya node or attribute."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def list_connections(
+    object_name: str,
+    attribute: Optional[str] = None,
+    incoming: bool = True,
+    outgoing: bool = True,
+) -> dict:
+    """List nodes/attributes connected to a Maya node or attribute.
+
+    Args:
+        object_name: Name of the Maya node to inspect.
+        attribute: If specified, inspect connections on this specific
+            attribute (e.g. ``"translateX"``).  If None, inspect all
+            connections on the node.
+        incoming: Include incoming connections.  Default: True.
+        outgoing: Include outgoing connections.  Default: True.
+
+    Returns:
+        ToolResult dict with ``context.connections`` — a list of
+        connected attribute path strings, and ``context.count``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        query_target = "{}.{}".format(object_name, attribute) if attribute else object_name
+        if attribute and not cmds.objExists(query_target):
+            return skill_error(
+                "Attribute not found: {}".format(query_target),
+                "The attribute '{}' does not exist on '{}'".format(attribute, object_name),
+            )
+
+        connections = (
+            cmds.listConnections(
+                query_target,
+                source=incoming,
+                destination=outgoing,
+                plugs=True,
+                connections=True,
+            )
+            or []
+        )
+
+        # listConnections returns alternating pairs [src, dst, src, dst, ...]
+        # Flatten into a list of connection dicts
+        pairs = []
+        it = iter(connections)
+        for a, b in zip(it, it):
+            pairs.append({"from": a, "to": b})
+
+        return skill_success(
+            "Found {} connection(s) on '{}'".format(len(pairs), query_target),
+            object_name=object_name,
+            attribute=attribute,
+            connections=pairs,
+            count=len(pairs),
+            prompt="Check the result with list_node_graph or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list connections on {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_connections`."""
+    return list_connections(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-node-graph/scripts/list_history.py
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/scripts/list_history.py
@@ -1,0 +1,71 @@
+"""List construction history nodes for a Maya object."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def list_history(
+    object_name: str,
+    future: bool = False,
+    levels: int = 0,
+) -> dict:
+    """List construction history nodes for a Maya object.
+
+    Args:
+        object_name: Name of the Maya node to inspect.
+        future: If True, include *downstream* (future) nodes in addition to
+            upstream history.  Default: False.
+        levels: Maximum number of levels to traverse.  ``0`` means unlimited.
+            Default: 0.
+
+    Returns:
+        ToolResult dict with ``context.history`` — a list of dicts
+        with ``name`` and ``type`` for each history node, and
+        ``context.count``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        kwargs = {
+            "future": future,
+            "levels": levels,
+        }
+        history_nodes = cmds.listHistory(object_name, **kwargs) or []
+
+        history = [{"name": node, "type": cmds.objectType(node)} for node in history_nodes if node != object_name]
+
+        return skill_success(
+            "Found {} history node(s) for '{}'".format(len(history), object_name),
+            object_name=object_name,
+            history=history,
+            count=len(history),
+            future=future,
+            prompt="Check the result with list_node_graph or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list history for {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_history`."""
+    return list_history(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-node-graph/scripts/smooth_mesh.py
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/scripts/smooth_mesh.py
@@ -1,0 +1,100 @@
+"""Apply smooth mesh preview or subdivision to a polygon mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def smooth_mesh(
+    object_name: str,
+    divisions: int = 1,
+    method: str = "preview",
+) -> dict:
+    """Apply smooth mesh preview or subdivision to a polygon mesh.
+
+    Two methods are supported:
+
+    * ``"preview"`` – activates Maya's Smooth Mesh Preview
+      (``displaySmoothMesh`` attribute, non-destructive).
+    * ``"subdivide"`` – applies ``cmds.polySmooth`` to subdivide the mesh
+      destructively.
+
+    Args:
+        object_name: Name of the polygon transform/mesh to smooth.
+        divisions: Subdivision level.  For ``"preview"`` this sets the
+            ``smoothLevel`` attribute.  For ``"subdivide"`` it is the number
+            of subdivision iterations.  Default: 1.
+        method: ``"preview"`` (default) or ``"subdivide"``.
+
+    Returns:
+        ToolResult dict with ``context.object_name``,
+        ``context.divisions``, ``context.method``.
+    """
+
+    _VALID_METHODS = ("preview", "subdivide")
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        if method not in _VALID_METHODS:
+            return skill_error(
+                "Invalid method: {}".format(method),
+                "method must be one of {}".format(_VALID_METHODS),
+            )
+
+        if divisions < 0:
+            return skill_error(
+                "Invalid divisions: {}".format(divisions),
+                "divisions must be >= 0",
+            )
+
+        if method == "preview":
+            # Enable smooth mesh preview — attribute lives on the shape node
+            shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+            target = shapes[0] if shapes else object_name
+            cmds.setAttr("{}.displaySmoothMesh".format(target), 2)  # 2 = smooth + cage
+            cmds.setAttr("{}.smoothLevel".format(target), divisions)
+            return skill_success(
+                "Enabled smooth mesh preview on '{}' (level {})".format(object_name, divisions),
+                object_name=object_name,
+                divisions=divisions,
+                method=method,
+                prompt="Check the result with list_node_graph or use related actions to continue.",
+            )
+
+        # method == "subdivide"
+        result = cmds.polySmooth(object_name, divisions=divisions)
+        node_name = result[0] if result else "polySmoothFace1"
+        return skill_success(
+            "Subdivided '{}' with {} iteration(s)".format(object_name, divisions),
+            object_name=object_name,
+            divisions=divisions,
+            method=method,
+            poly_smooth_node=node_name,
+            prompt="Check the result with list_node_graph or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to smooth mesh {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`smooth_mesh`."""
+    return smooth_mesh(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-node-graph/scripts/transfer_attributes.py
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/scripts/transfer_attributes.py
@@ -1,0 +1,102 @@
+"""Transfer mesh attributes (UVs, normals, vertex colors) from one mesh to another."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def transfer_attributes(
+    source: str,
+    target: str,
+    sample_space: int = 0,
+    transfer_positions: bool = False,
+    transfer_normals: bool = True,
+    transfer_uvs: bool = True,
+    transfer_colors: bool = False,
+) -> dict:
+    """Transfer mesh attributes (UVs, normals, vertex colors) from one mesh to another.
+
+    Uses ``cmds.transferAttributes`` to copy surface data between two polygon
+    meshes that share a similar topology or surface shape.
+
+    Args:
+        source: Name of the *source* mesh (or its transform).
+        target: Name of the *target* mesh (or its transform) that will
+            receive the transferred data.
+        sample_space: Space used for attribute sampling:
+            ``0`` = World space (default), ``1`` = Local space,
+            ``4`` = UV space, ``5`` = Component space.
+        transfer_positions: If True, transfer vertex positions.
+            Default: False.
+        transfer_normals: If True, transfer vertex normals.  Default: True.
+        transfer_uvs: If True, transfer UV sets.  Default: True.
+        transfer_colors: If True, transfer vertex color sets.  Default: False.
+
+    Returns:
+        ToolResult dict with ``context.source``, ``context.target``,
+        ``context.transfer_node`` (the created ``transferAttributes`` node).
+    """
+
+    _VALID_SPACES = (0, 1, 4, 5)
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, source)
+        if err:
+            return err
+
+        err = validate_node_exists(cmds, target)
+        if err:
+            return err
+
+        if sample_space not in _VALID_SPACES:
+            return skill_error(
+                "Invalid sample_space: {}".format(sample_space),
+                "sample_space must be one of {} (0=World, 1=Local, 4=UV, 5=Component)".format(_VALID_SPACES),
+            )
+
+        result = cmds.transferAttributes(
+            source,
+            target,
+            transferPositions=int(transfer_positions),
+            transferNormals=int(transfer_normals),
+            transferUVs=int(transfer_uvs),
+            transferColors=int(transfer_colors),
+            sampleSpace=sample_space,
+        )
+        node_name = result[0] if result else "transferAttributes1"
+
+        return skill_success(
+            "Transferred attributes from '{}' to '{}'".format(source, target),
+            source=source,
+            target=target,
+            transfer_node=node_name,
+            sample_space=sample_space,
+            transfer_positions=transfer_positions,
+            transfer_normals=transfer_normals,
+            transfer_uvs=transfer_uvs,
+            transfer_colors=transfer_colors,
+            prompt="Check the result with list_node_graph or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_error("Failed to transfer attributes from '{}' to '{}'".format(source, target), str(exc))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`transfer_attributes`."""
+    return transfer_attributes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-node-graph/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/tools.yaml
@@ -1,0 +1,51 @@
+tools:
+- name: apply_symmetry
+  execution: sync
+  affinity: main
+  group: node_graph
+  annotations:
+    idempotent_hint: true
+- name: connect_attr
+  execution: sync
+  affinity: main
+  group: node_graph
+- name: delete_history
+  execution: sync
+  affinity: main
+  group: node_graph
+  annotations:
+    destructive_hint: true
+    idempotent_hint: true
+- name: disconnect_attr
+  execution: sync
+  affinity: main
+  group: node_graph
+- name: get_dag_path
+  execution: sync
+  affinity: main
+  group: node_graph
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+- name: list_connections
+  execution: sync
+  affinity: main
+  group: node_graph
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+- name: list_history
+  execution: sync
+  affinity: main
+  group: node_graph
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+- name: smooth_mesh
+  execution: sync
+  affinity: main
+  group: node_graph
+- name: transfer_attributes
+  execution: sync
+  affinity: main
+  group: node_graph

--- a/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: maya-primitives
+description: Maya polygon primitive creation and basic transform operations — spheres, cubes, cylinders, planes, and transforms. Use when creating individual basic geometry from scratch. Not for complex mesh editing, UV operations, or material assignment — use maya-mesh-ops, maya-uv-ops, or maya-materials for that.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    version: 1.0.0
+    tags:
+    - maya
+    - geometry
+    - primitives
+    - create
+    search-hint: create basic geometry, add primitive, simple shape, individual mesh
+    depends: []
+    tools: tools.yaml
+    groups: groups.yaml
+---
+> **Deprecated (merge bucket):** This skill contains only thin \maya.cmds\ wrappers.
+> Use \xecute_python\ with \maya-scripting/references/RECIPES.md#primitives\ instead.
+> Will be removed in the next release.
+
+# maya-primitives
+
+Maya polygon primitive creation skill. Provides actions for creating basic geometry (sphere, cube, cylinder, plane), deleting objects, and managing transforms.
+
+## Scripts
+
+- `create_sphere` — Create a polygon sphere
+- `create_cube` — Create a polygon cube
+- `create_cylinder` — Create a polygon cylinder
+- `create_plane` — Create a polygon plane
+- `delete_objects` — Delete objects from the Maya scene
+- `set_transform` — Set translate/rotate/scale on an object
+- `get_transform` — Get translate/rotate/scale of an object
+- `rename_object` — Rename an object in the scene

--- a/src/dcc_mcp_maya/skills/maya-primitives/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-primitives/groups.yaml
@@ -1,0 +1,13 @@
+groups:
+- name: modeling
+  description: Geometry creation, editing, and UV tools
+  default_active: false
+  tools:
+  - create_cube
+  - create_cylinder
+  - create_plane
+  - create_sphere
+  - delete_objects
+  - get_transform
+  - rename_object
+  - set_transform

--- a/src/dcc_mcp_maya/skills/maya-primitives/scripts/create_cube.py
+++ b/src/dcc_mcp_maya/skills/maya-primitives/scripts/create_cube.py
@@ -1,0 +1,61 @@
+"""Create a polygon cube."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def create_cube(
+    width: float = 1.0,
+    height: float = 1.0,
+    depth: float = 1.0,
+    name: Optional[str] = None,
+) -> dict:
+    """Create a polygon cube.
+
+    Args:
+        width: Cube width. Default: 1.0.
+        height: Cube height. Default: 1.0.
+        depth: Cube depth. Default: 1.0.
+        name: Optional name for the created object.
+
+    Returns:
+        ToolResult dict with ``context.object_name``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        result = cmds.polyCube(width=width, height=height, depth=depth)
+        obj = result[0]
+        if name:
+            obj = cmds.rename(obj, name)
+        return skill_success(
+            f"Created cube: {obj}",
+            object_name=obj,
+            width=width,
+            height=height,
+            depth=depth,
+            prompt="Use set_transform to position or assign_material to shade.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create cube")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_cube`."""
+    return create_cube(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-primitives/scripts/create_cylinder.py
+++ b/src/dcc_mcp_maya/skills/maya-primitives/scripts/create_cylinder.py
@@ -1,0 +1,58 @@
+"""Create a polygon cylinder."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def create_cylinder(
+    radius: float = 1.0,
+    height: float = 2.0,
+    name: Optional[str] = None,
+) -> dict:
+    """Create a polygon cylinder.
+
+    Args:
+        radius: Cylinder radius. Default: 1.0.
+        height: Cylinder height. Default: 2.0.
+        name: Optional name for the created object.
+
+    Returns:
+        ToolResult dict with ``context.object_name``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        result = cmds.polyCylinder(radius=radius, height=height, subdivisionsAxis=20)
+        obj = result[0]
+        if name:
+            obj = cmds.rename(obj, name)
+        return skill_success(
+            f"Created cylinder: {obj}",
+            object_name=obj,
+            radius=radius,
+            height=height,
+            prompt="Use set_transform to position or assign_material to shade.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create cylinder")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_cylinder`."""
+    return create_cylinder(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-primitives/scripts/create_plane.py
+++ b/src/dcc_mcp_maya/skills/maya-primitives/scripts/create_plane.py
@@ -1,0 +1,58 @@
+"""Create a polygon plane."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def create_plane(
+    width: float = 1.0,
+    height: float = 1.0,
+    name: Optional[str] = None,
+) -> dict:
+    """Create a polygon plane.
+
+    Args:
+        width: Plane width. Default: 1.0.
+        height: Plane height. Default: 1.0.
+        name: Optional name for the created object.
+
+    Returns:
+        ToolResult dict with ``context.object_name``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        result = cmds.polyPlane(width=width, height=height, subdivisionsX=1, subdivisionsY=1)
+        obj = result[0]
+        if name:
+            obj = cmds.rename(obj, name)
+        return skill_success(
+            "Created plane: {}".format(obj),
+            object_name=obj,
+            width=width,
+            height=height,
+            prompt="Use set_transform to position or assign_material to shade.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create plane")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_plane`."""
+    return create_plane(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-primitives/scripts/create_sphere.py
+++ b/src/dcc_mcp_maya/skills/maya-primitives/scripts/create_sphere.py
@@ -1,0 +1,55 @@
+"""Create a polygon sphere."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def create_sphere(radius: float = 1.0, name: Optional[str] = None) -> dict:
+    """Create a polygon sphere.
+
+    Args:
+        radius: Sphere radius. Default: 1.0.
+        name: Optional name for the created object.
+
+    Returns:
+        ToolResult dict with ``context.object_name``.
+    """
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        result = cmds.polySphere(radius=radius, subdivisionsAxis=20, subdivisionsHeight=20)
+        obj = result[0]
+        if name:
+            obj = cmds.rename(obj, name)
+        return skill_success(
+            f"Created sphere: {obj}",
+            object_name=obj,
+            radius=radius,
+            prompt="Use set_transform to position or assign_material to shade.",
+        )
+    except ImportError:
+        return skill_error(
+            "Maya not available",
+            "maya.cmds could not be imported",
+            possible_solutions=["Run inside Maya or mayapy"],
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create sphere")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_sphere`."""
+    return create_sphere(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-primitives/scripts/delete_objects.py
+++ b/src/dcc_mcp_maya/skills/maya-primitives/scripts/delete_objects.py
@@ -1,0 +1,55 @@
+"""Delete objects from the Maya scene."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def delete_objects(object_names: List[str]) -> dict:
+    """Delete objects from the Maya scene.
+
+    Args:
+        object_names: List of object names to delete.
+
+    Returns:
+        ToolResult dict.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        if not object_names:
+            return skill_success(
+                "No objects to delete",
+                prompt="Check the result with list_primitives or use related actions to continue.",
+            )
+        existing = cmds.ls(object_names) or []
+        if existing:
+            cmds.delete(existing)
+        return skill_success(
+            f"Deleted {len(existing)} objects",
+            deleted=existing,
+            requested=object_names,
+            prompt="Check the result with list_primitives or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete objects")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`delete_objects`."""
+    return delete_objects(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-primitives/scripts/get_transform.py
+++ b/src/dcc_mcp_maya/skills/maya-primitives/scripts/get_transform.py
@@ -1,0 +1,56 @@
+"""Get translate/rotate/scale of an object."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def get_transform(object_name: str) -> dict:
+    """Get the translate/rotate/scale of an object.
+
+    Args:
+        object_name: Name of the object to query.
+
+    Returns:
+        ToolResult dict with translate, rotate, scale lists.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        translate = list(cmds.getAttr("{}.translate".format(object_name))[0])
+        rotate = list(cmds.getAttr("{}.rotate".format(object_name))[0])
+        scale = list(cmds.getAttr("{}.scale".format(object_name))[0])
+        return skill_success(
+            "Transform of {}".format(object_name),
+            object_name=object_name,
+            translate=translate,
+            rotate=rotate,
+            scale=scale,
+            prompt="Check the result with list_primitives or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get transform of {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_transform`."""
+    return get_transform(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-primitives/scripts/rename_object.py
+++ b/src/dcc_mcp_maya/skills/maya-primitives/scripts/rename_object.py
@@ -1,0 +1,53 @@
+"""Rename an object in the Maya scene."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def rename_object(object_name: str, new_name: str) -> dict:
+    """Rename a Maya object.
+
+    Args:
+        object_name: Current name of the object.
+        new_name: New name to assign.
+
+    Returns:
+        ToolResult dict with ``context.object_name`` (new name).
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        result = cmds.rename(object_name, new_name)
+        return skill_success(
+            "Renamed '{}' to '{}'".format(object_name, result),
+            old_name=object_name,
+            object_name=result,
+            prompt="Check the result with list_primitives or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to rename {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`rename_object`."""
+    return rename_object(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-primitives/scripts/set_transform.py
+++ b/src/dcc_mcp_maya/skills/maya-primitives/scripts/set_transform.py
@@ -1,0 +1,72 @@
+"""Set translate/rotate/scale on an object."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def set_transform(
+    object_name: str,
+    translate: Optional[List[float]] = None,
+    rotate: Optional[List[float]] = None,
+    scale: Optional[List[float]] = None,
+) -> dict:
+    """Set the translate/rotate/scale of an object.
+
+    Args:
+        object_name: Name of the object to transform.
+        translate: [tx, ty, tz] in scene units.  None = no change.
+        rotate: [rx, ry, rz] in degrees.  None = no change.
+        scale: [sx, sy, sz].  None = no change.
+
+    Returns:
+        ToolResult dict with applied transform values.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        applied: dict = {}
+        if translate is not None and len(translate) == 3:
+            cmds.setAttr(f"{object_name}.translate", *translate, type="double3")
+            applied["translate"] = translate
+        if rotate is not None and len(rotate) == 3:
+            cmds.setAttr(f"{object_name}.rotate", *rotate, type="double3")
+            applied["rotate"] = rotate
+        if scale is not None and len(scale) == 3:
+            cmds.setAttr(f"{object_name}.scale", *scale, type="double3")
+            applied["scale"] = scale
+
+        return skill_success(
+            f"Transform applied to {object_name}",
+            object_name=object_name,
+            **applied,
+            prompt="Check the result with list_primitives or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to set transform on {object_name}")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_transform`."""
+    return set_transform(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-primitives/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-primitives/tools.yaml
@@ -1,0 +1,51 @@
+tools:
+- name: create_cube
+  description: Create a polygon cube
+  execution: sync
+  affinity: main
+  group: modeling
+- name: create_cylinder
+  description: Create a polygon cylinder
+  execution: sync
+  affinity: main
+  group: modeling
+- name: create_plane
+  description: Create a polygon plane
+  execution: sync
+  affinity: main
+  group: modeling
+- name: create_sphere
+  description: Create a polygon sphere
+  execution: sync
+  affinity: main
+  group: modeling
+- name: delete_objects
+  description: Delete objects from the Maya scene
+  execution: sync
+  affinity: main
+  annotations:
+    destructive_hint: true
+    idempotent_hint: true
+  group: modeling
+- name: get_transform
+  description: Get translate/rotate/scale of an object
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: modeling
+- name: rename_object
+  description: Rename an object in the scene
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: modeling
+- name: set_transform
+  description: Set translate/rotate/scale on an object
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: modeling

--- a/src/dcc_mcp_maya/skills/maya-rigging/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-rigging/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: maya-rigging
+description: Maya character rigging workflow — joints, IK, skin clusters, deformers, blend shapes, and control curves. Use when building character or prop rigs. Not for animation keyframing or final scene assembly — use maya-animation or maya-scene-assembly for that.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    version: 1.0.0
+    tags:
+    - maya
+    - rigging
+    - skeleton
+    - deformer
+    - animation
+    search-hint: build character rig, skeleton setup, skin bind, control curve
+    depends: []
+    tools: tools.yaml
+    groups: groups.yaml
+---

--- a/src/dcc_mcp_maya/skills/maya-rigging/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-rigging/groups.yaml
@@ -1,0 +1,17 @@
+groups:
+- name: rigging
+  description: Rigging, deformation, and skinning tools
+  default_active: false
+  tools:
+  - assign_deformer
+  - blend_shape_add_target
+  - create_blend_shape
+  - create_curve
+  - create_ik_handle
+  - create_joint
+  - mirror_joints
+  - set_driven_key
+  - set_ik_fk_blend
+  - set_joint_limit
+  - set_joint_orient
+  - skin_cluster_bind

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/assign_deformer.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/assign_deformer.py
@@ -1,0 +1,111 @@
+"""Apply a deformer to an object."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+# Import built-in modules
+
+
+def assign_deformer(
+    object_name: str,
+    deformer_type: str = "cluster",
+) -> dict:
+    """Apply a deformer to an object.
+
+    Supported deformer types: ``"cluster"``, ``"blendShape"``, ``"lattice"``,
+    ``"wrap"``, ``"nonLinear"`` (bend/twist/flare/sine/squash/wave).
+
+    Args:
+        object_name: Name of the mesh/surface to deform.
+        deformer_type: Deformer type string.  Default: ``"cluster"``.
+
+    Returns:
+        ToolResult dict with ``context.deformer_name``,
+        ``context.handle_name`` (for cluster/lattice) if applicable.
+    """
+
+    _SUPPORTED = ("cluster", "blendShape", "lattice", "wrap", "bend", "twist", "flare", "sine", "squash", "wave")
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        if deformer_type not in _SUPPORTED:
+            return skill_error(
+                "Unsupported deformer type: {}".format(deformer_type),
+                "deformer_type must be one of {}".format(_SUPPORTED),
+            )
+
+        cmds.select(object_name, replace=True)
+
+        if deformer_type == "cluster":
+            result = cmds.cluster(object_name)
+            deformer_name = result[0]
+            handle_name = result[1] if len(result) > 1 else None
+            return skill_success(
+                "Applied cluster deformer to '{}'".format(object_name),
+                object_name=object_name,
+                deformer_name=deformer_name,
+                handle_name=handle_name,
+                deformer_type=deformer_type,
+                prompt="Check the result with list_rigging or use related actions to continue.",
+            )
+
+        if deformer_type == "lattice":
+            result = cmds.lattice(object_name)
+            deformer_name = result[0]
+            return skill_success(
+                "Applied lattice deformer to '{}'".format(object_name),
+                object_name=object_name,
+                deformer_name=deformer_name,
+                deformer_type=deformer_type,
+                prompt="Check the result with list_rigging or use related actions to continue.",
+            )
+
+        if deformer_type in ("bend", "twist", "flare", "sine", "squash", "wave"):
+            result = cmds.nonLinear(object_name, type=deformer_type)
+            deformer_name = result[0]
+            handle_name = result[1] if len(result) > 1 else None
+            return skill_success(
+                "Applied {} deformer to '{}'".format(deformer_type, object_name),
+                object_name=object_name,
+                deformer_name=deformer_name,
+                handle_name=handle_name,
+                deformer_type=deformer_type,
+                prompt="Check the result with list_rigging or use related actions to continue.",
+            )
+
+        # blendShape / wrap — generic path
+        result = cmds.deformer(object_name, type=deformer_type)
+        deformer_name = result[0] if result else deformer_type
+        return skill_success(
+            "Applied {} deformer to '{}'".format(deformer_type, object_name),
+            object_name=object_name,
+            deformer_name=deformer_name,
+            deformer_type=deformer_type,
+            prompt="Check the result with list_rigging or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to assign deformer to {}".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`assign_deformer`."""
+    return assign_deformer(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/blend_shape_add_target.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/blend_shape_add_target.py
@@ -1,0 +1,98 @@
+"""Add a target mesh to an existing blend shape deformer."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def blend_shape_add_target(
+    blend_shape: str,
+    target_mesh: str,
+    weight: float = 0.0,
+    index: Optional[int] = None,
+) -> dict:
+    """Add a target mesh to an existing blend shape deformer.
+
+    Args:
+        blend_shape: Name of the blendShape node to modify.
+        target_mesh: Name of the mesh to use as the new blend shape target.
+        weight: Initial weight value for the new target (0.0–1.0).
+            Default: 0.0.
+        index: Target index slot.  If None, Maya assigns the next available
+            index automatically.
+
+    Returns:
+        ToolResult dict with ``context.blend_shape``,
+        ``context.target_mesh``, ``context.target_index``.
+    """
+
+    if not (0.0 <= weight <= 1.0):
+        return skill_error(
+            "Invalid weight: {}".format(weight),
+            "weight must be between 0.0 and 1.0",
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, blend_shape)
+        if err:
+            return err
+
+        node_type = cmds.objectType(blend_shape)
+        if node_type != "blendShape":
+            return skill_error("'{}' is not a blendShape node (type: {})".format(blend_shape, node_type))
+
+        err = validate_node_exists(cmds, target_mesh)
+        if err:
+            return err
+
+        # Determine target index
+        if index is None:
+            existing = cmds.blendShape(blend_shape, query=True, weightCount=True) or 0
+            target_index = int(existing)
+        else:
+            target_index = int(index)
+
+        cmds.blendShape(
+            blend_shape,
+            edit=True,
+            target=(
+                cmds.blendShape(blend_shape, query=True, geometry=True)[0],
+                target_index,
+                target_mesh,
+                weight,
+            ),
+        )
+
+        return skill_success(
+            "Added target '{}' to blend shape '{}' at index {}".format(target_mesh, blend_shape, target_index),
+            blend_shape=blend_shape,
+            target_mesh=target_mesh,
+            target_index=target_index,
+            weight=weight,
+            prompt="Check the result with list_rigging or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to add blend shape target")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`blend_shape_add_target`."""
+    return blend_shape_add_target(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/create_blend_shape.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/create_blend_shape.py
@@ -1,0 +1,78 @@
+"""Create a blend shape deformer on a base mesh with optional targets."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import batch_validate_nodes, validate_node_exists
+
+
+def create_blend_shape(
+    base_mesh: str,
+    target_meshes: Optional[List[str]] = None,
+    name: Optional[str] = None,
+    origin: str = "local",
+) -> dict:
+    """Create a blend shape deformer on a base mesh with optional targets.
+
+    Args:
+        base_mesh: Name of the base (destination) mesh.
+        target_meshes: List of target mesh names whose shapes drive the blend.
+            If None or empty, a zero-target blend shape node is created.
+        name: Optional name for the blend shape node.
+        origin: ``"local"`` (default) or ``"world"`` space blend.
+
+    Returns:
+        ToolResult dict with ``context.blend_shape_name``,
+        ``context.target_count``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, base_mesh)
+        if err:
+            return err
+
+        targets = target_meshes or []
+        err = batch_validate_nodes(cmds, list(targets))
+        if err:
+            return err
+
+        all_meshes = targets + [base_mesh]
+        kwargs = {"origin": origin}  # type: dict
+        if name:
+            kwargs["name"] = name
+
+        result = cmds.blendShape(*all_meshes, **kwargs)
+        bs_name = result[0] if result else (name or "blendShape1")
+
+        return skill_success(
+            "Created blend shape '{}' on '{}'".format(bs_name, base_mesh),
+            blend_shape_name=bs_name,
+            base_mesh=base_mesh,
+            target_count=len(targets),
+            targets=targets,
+            prompt="Check the result with list_rigging or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create blend shape on {}".format(base_mesh))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_blend_shape`."""
+    return create_blend_shape(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/create_curve.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/create_curve.py
@@ -1,0 +1,84 @@
+"""Create a NURBS curve from a list of control points."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def create_curve(
+    points: Optional[List[List[float]]] = None,
+    name: Optional[str] = None,
+    degree: int = 3,
+    periodic: bool = False,
+) -> dict:
+    """Create a NURBS curve from a list of control points.
+
+    Args:
+        points: List of ``[x, y, z]`` control-point positions.  A minimum of
+            ``degree + 1`` points is required (e.g. 4 points for degree-3).
+            Defaults to a simple line along the X axis if not provided.
+        name: Optional name for the curve's transform node.
+        degree: Curve degree.  Typical values: ``1`` (linear), ``3`` (cubic).
+            Default: ``3``.
+        periodic: If True, creates a closed (periodic) curve.  Default: False.
+
+    Returns:
+        ToolResult dict with ``context.object_name``,
+        ``context.degree``, ``context.point_count``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        if points is None:
+            # Default: a straight line with degree+2 CV points along X
+            points = [[float(i), 0.0, 0.0] for i in range(degree + 2)]
+
+        if len(points) < degree + 1:
+            return skill_error(
+                "Not enough control points",
+                "Need at least {} points for degree-{} curve, got {}".format(degree + 1, degree, len(points)),
+            )
+
+        point_tuples = [(p[0], p[1], p[2]) for p in points]
+        periodic_val = 2 if periodic else 0  # 0=open, 2=periodic
+
+        kwargs = {
+            "point": point_tuples,
+            "degree": degree,
+            "periodic": periodic_val,
+        }
+        if name:
+            kwargs["name"] = name
+
+        result = cmds.curve(**kwargs)
+
+        return skill_success(
+            "Created NURBS curve '{}'".format(result),
+            object_name=result,
+            degree=degree,
+            point_count=len(points),
+            periodic=periodic,
+            prompt="Check the result with list_rigging or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create curve")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_curve`."""
+    return create_curve(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/create_ik_handle.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/create_ik_handle.py
@@ -1,0 +1,88 @@
+"""Create an IK handle between two joints."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import batch_validate_nodes
+
+
+def create_ik_handle(
+    start_joint: str,
+    end_joint: str,
+    solver: str = "ikRPsolver",
+    name: Optional[str] = None,
+) -> dict:
+    """Create an IK handle between two joints.
+
+    Args:
+        start_joint: Name of the start (root) joint of the IK chain.
+        end_joint: Name of the end (tip) joint of the IK chain.
+        solver: IK solver to use.  Supported values:
+            ``"ikRPsolver"`` (Rotate-Plane, default) or
+            ``"ikSCsolver"`` (Single-Chain).
+        name: Optional name for the IK handle node.  Maya auto-generates a
+            name when None.
+
+    Returns:
+        ToolResult dict with ``context.handle_name``,
+        ``context.effector_name``, and ``context.solver``.
+    """
+
+    _VALID_SOLVERS = ("ikRPsolver", "ikSCsolver")
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = batch_validate_nodes(cmds, [start_joint, end_joint])
+        if err:
+            return err
+
+        if solver not in _VALID_SOLVERS:
+            return skill_error(
+                "Invalid solver: {}".format(solver),
+                "solver must be one of {}".format(_VALID_SOLVERS),
+            )
+
+        kwargs = {
+            "startJoint": start_joint,
+            "endEffector": end_joint,
+            "solver": solver,
+        }
+        if name:
+            kwargs["name"] = name
+
+        result = cmds.ikHandle(**kwargs)
+        handle_name = result[0]
+        effector_name = result[1]
+
+        return skill_success(
+            "Created IK handle '{}'".format(handle_name),
+            handle_name=handle_name,
+            effector_name=effector_name,
+            start_joint=start_joint,
+            end_joint=end_joint,
+            solver=solver,
+            prompt="Check the result with list_rigging or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create IK handle")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_ik_handle`."""
+    return create_ik_handle(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/create_joint.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/create_joint.py
@@ -1,0 +1,87 @@
+"""Create a Maya joint node."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def create_joint(
+    name: Optional[str] = None,
+    position: Optional[List[float]] = None,
+    parent: Optional[str] = None,
+) -> dict:
+    """Create a Maya joint node.
+
+    Joints are the fundamental building blocks for skeletal rigs used in
+    character animation.  If a *parent* is specified the joint is created as
+    a child of that node; otherwise it is placed at the world root.
+
+    Args:
+        name: Optional name for the new joint.  Maya generates a default name
+            (``"joint1"``, ``"joint2"``, …) when None.
+        position: World-space ``[x, y, z]`` position.  Defaults to
+            ``[0, 0, 0]``.
+        parent: Name of an existing transform/joint to parent the new joint
+            under.  If None, the joint is created at the world root.
+
+    Returns:
+        ToolResult dict with ``context.object_name``,
+        ``context.position``, and ``context.parent``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        if parent and not cmds.objExists(parent):
+            return skill_error(
+                "Parent not found: {}".format(parent),
+                "'{}' does not exist in the scene".format(parent),
+            )
+
+        pos = position or [0.0, 0.0, 0.0]
+        if len(pos) != 3:
+            return skill_error(
+                "Invalid position",
+                "position must be a list of 3 floats, got: {}".format(pos),
+            )
+
+        # Select parent first so joint is created as its child
+        if parent:
+            cmds.select(parent, replace=True)
+        else:
+            cmds.select(clear=True)
+
+        kwargs = {"position": (pos[0], pos[1], pos[2])}
+        if name:
+            kwargs["name"] = name
+
+        joint_name = cmds.joint(**kwargs)
+
+        return skill_success(
+            "Created joint '{}'".format(joint_name),
+            object_name=joint_name,
+            position=pos,
+            parent=parent,
+            prompt="Use bind_skin or add_ik_handle to complete the rig.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create joint")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_joint`."""
+    return create_joint(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/mirror_joints.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/mirror_joints.py
@@ -1,0 +1,93 @@
+"""Mirror a joint chain across an axis plane."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def mirror_joints(
+    joint_name: str,
+    mirror_behavior: bool = True,
+    search_replace: Optional[List[str]] = None,
+    mirror_axis: str = "YZ",
+) -> dict:
+    """Mirror a joint chain across an axis plane.
+
+    Creates a mirrored copy of the joint chain starting at *joint_name*.  The
+    most common use case is to build a symmetric rig (left-to-right or vice
+    versa) with a single call.
+
+    Args:
+        joint_name: Root joint of the chain to mirror.
+        mirror_behavior: If True, uses Maya's ``mirrorBehavior`` flag to
+            invert the orientation of mirrored joints.  Default: True.
+        search_replace: Two-element list ``[search, replace]`` used to rename
+            mirrored joints (e.g. ``["L_", "R_"]``).  Defaults to
+            ``["L_", "R_"]``.
+        mirror_axis: Plane to mirror across – one of ``"YZ"``, ``"XY"``,
+            ``"XZ"``.  Default: ``"YZ"``.
+
+    Returns:
+        ToolResult dict with ``context.mirrored_joints`` list.
+    """
+
+    _VALID_AXES = ("YZ", "XY", "XZ")
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, joint_name)
+        if err:
+            return err
+
+        if mirror_axis not in _VALID_AXES:
+            return skill_error(
+                "Invalid mirror axis: {}".format(mirror_axis),
+                "mirror_axis must be one of {}".format(_VALID_AXES),
+            )
+
+        sr = search_replace or ["L_", "R_"]
+        if len(sr) != 2:
+            return skill_error(
+                "Invalid search_replace",
+                "search_replace must be a list of exactly two strings",
+            )
+
+        axis_kwargs = {
+            "YZ": {"mirrorYZ": True},
+            "XY": {"mirrorXY": True},
+            "XZ": {"mirrorXZ": True},
+        }[mirror_axis]
+
+        mirrored = cmds.mirrorJoint(joint_name, mirrorBehavior=mirror_behavior, searchReplace=sr, **axis_kwargs)
+
+        return skill_success(
+            "Mirrored joint chain from '{}'".format(joint_name),
+            source_joint=joint_name,
+            mirrored_joints=list(mirrored) if mirrored else [],
+            mirror_axis=mirror_axis,
+            prompt="Check the result with list_rigging or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to mirror joints from {}".format(joint_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`mirror_joints`."""
+    return mirror_joints(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/set_driven_key.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/set_driven_key.py
@@ -1,0 +1,120 @@
+"""Create a set-driven key relationship between a driver and driven attributes."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import batch_validate_nodes, validate_node_exists
+
+
+def set_driven_key(
+    driver_attr: str,
+    driven_attrs: List[str],
+    driver_values: List[float],
+    driven_values: List[List[float]],
+    tangent_type: str = "linear",
+) -> dict:
+    """Create a set-driven key relationship between a driver and driven attrs.
+
+    A set-driven key creates an animation curve so that when *driver_attr*
+    reaches each value in *driver_values*, each driven attribute in
+    *driven_attrs* takes the corresponding value in *driven_values*.
+
+    Args:
+        driver_attr: Full attribute path for the driver (e.g.
+            ``"ctrl.rotateY"``).
+        driven_attrs: List of full attribute paths for driven attrs (e.g.
+            ``["joint1.translateX", "joint1.translateZ"]``).
+        driver_values: List of driver values that define the key positions.
+            Must have at least 1 entry.
+        driven_values: 2-D list ``[per_driver_value][per_driven_attr]``.
+            ``driven_values[i][j]`` is the value of ``driven_attrs[j]`` when
+            ``driver_attr == driver_values[i]``.
+        tangent_type: Tangent type for the keys — ``"linear"``, ``"smooth"``,
+            ``"flat"``, or ``"step"``.  Default: ``"linear"``.
+
+    Returns:
+        ToolResult dict with ``context.driver_attr``,
+        ``context.driven_attrs``, ``context.key_count``.
+    """
+
+    _VALID_TANGENTS = ("linear", "smooth", "flat", "step")
+
+    if not driver_values:
+        return skill_error(
+            "driver_values cannot be empty",
+            "Provide at least one driver value",
+        )
+
+    if len(driven_values) != len(driver_values):
+        return skill_error(
+            "Mismatched driver/driven value counts",
+            "driven_values must have the same length as driver_values",
+        )
+
+    if tangent_type not in _VALID_TANGENTS:
+        return skill_error(
+            "Invalid tangent_type: {}".format(tangent_type),
+            "Use one of: {}".format(", ".join(_VALID_TANGENTS)),
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        driver_obj = driver_attr.rsplit(".", 1)[0]
+        err = validate_node_exists(cmds, driver_obj)
+        if err:
+            return err
+
+        driven_objs = list({da.rsplit(".", 1)[0] for da in driven_attrs})
+        err = batch_validate_nodes(cmds, driven_objs)
+        if err:
+            return err
+
+        keys_set = 0
+        for i, drv_val in enumerate(driver_values):
+            cmds.setAttr(driver_attr, drv_val)
+            row = driven_values[i]
+            for j, da in enumerate(driven_attrs):
+                da_val = row[j] if j < len(row) else 0.0
+                cmds.setAttr(da, da_val)
+                cmds.setDrivenKeyframe(
+                    da,
+                    currentDriver=driver_attr,
+                    inTangentType=tangent_type,
+                    outTangentType=tangent_type,
+                )
+                keys_set += 1
+
+        return skill_success(
+            "Set driven key: '{}' drives {} attr(s) with {} key(s)".format(
+                driver_attr, len(driven_attrs), len(driver_values)
+            ),
+            driver_attr=driver_attr,
+            driven_attrs=driven_attrs,
+            key_count=len(driver_values),
+            keys_set=keys_set,
+            tangent_type=tangent_type,
+            prompt="Check the result with list_rigging or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set driven key")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_driven_key`."""
+    return set_driven_key(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/set_ik_fk_blend.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/set_ik_fk_blend.py
@@ -1,0 +1,88 @@
+"""Set the IK/FK blend weight on an IK handle."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+# Import built-in modules
+
+
+def set_ik_fk_blend(
+    ik_handle: str,
+    blend: float = 1.0,
+    attribute: str = "ikBlend",
+) -> dict:
+    """Set the IK/FK blend weight on an IK handle.
+
+    Most IK solvers expose an ``ikBlend`` attribute (0 = full FK,
+    1 = full IK).  This action sets that blend value and optionally
+    creates a keyframe on it.
+
+    Args:
+        ik_handle: Name of the IK handle node.
+        blend: Blend value between 0.0 (FK) and 1.0 (IK).  Default: 1.0.
+        attribute: Name of the blend attribute on the IK handle.
+            Default: ``"ikBlend"``.
+
+    Returns:
+        ToolResult dict with ``context.ik_handle``,
+        ``context.attribute``, ``context.blend``.
+    """
+
+    if not (0.0 <= blend <= 1.0):
+        return skill_error(
+            "blend must be in the range [0.0, 1.0]",
+            "Got blend={}".format(blend),
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, ik_handle)
+        if err:
+            return err
+
+        node_type = cmds.objectType(ik_handle)
+        if node_type not in ("ikHandle", "transform"):
+            return skill_error(
+                "Not an IK handle: {}".format(ik_handle),
+                "'{}' is of type '{}'; expected 'ikHandle'".format(ik_handle, node_type),
+            )
+
+        plug = "{}.{}".format(ik_handle, attribute)
+        err = validate_node_exists(cmds, plug)
+        if err:
+            return skill_error(
+                "Attribute not found: {}".format(plug),
+                "IK handle '{}' does not have attribute '{}'".format(ik_handle, attribute),
+            )
+
+        cmds.setAttr(plug, blend)
+
+        return skill_success(
+            "Set IK/FK blend on '{}' to {}".format(ik_handle, blend),
+            ik_handle=ik_handle,
+            attribute=attribute,
+            blend=blend,
+            prompt="Check the result with list_rigging or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set IK/FK blend on '{}'".format(ik_handle))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_ik_fk_blend`."""
+    return set_ik_fk_blend(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/set_joint_limit.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/set_joint_limit.py
@@ -1,0 +1,109 @@
+"""Set rotation limits on a joint axis."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def set_joint_limit(
+    joint_name: str,
+    axis: str,
+    min_angle: Optional[float] = None,
+    max_angle: Optional[float] = None,
+    enable: bool = True,
+) -> dict:
+    """Set rotation limits on a joint axis.
+
+    Limits constrain how far a joint can rotate on a given axis, preventing
+    unrealistic poses during animation or IK solving.
+
+    Args:
+        joint_name: Name of the joint node to configure.
+        axis: Rotation axis to limit – one of ``"x"``, ``"y"``, ``"z"``.
+        min_angle: Minimum rotation angle in degrees.  If None, the existing
+            minimum limit is left unchanged.
+        max_angle: Maximum rotation angle in degrees.  If None, the existing
+            maximum limit is left unchanged.
+        enable: If True (default), enable the limit on the specified axis.
+            Set to False to disable the limit without changing the stored angle
+            values.
+
+    Returns:
+        ToolResult dict with ``context.joint_name``,
+        ``context.axis``, ``context.min_angle``, ``context.max_angle``,
+        ``context.enable``.
+    """
+
+    _VALID_AXES = ("x", "y", "z")
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, joint_name)
+        if err:
+            return err
+
+        node_type = cmds.objectType(joint_name)
+        if node_type != "joint":
+            return skill_error(
+                "Not a joint: {}".format(joint_name),
+                "'{}' is of type '{}', expected 'joint'".format(joint_name, node_type),
+            )
+
+        axis_lower = axis.lower()
+        if axis_lower not in _VALID_AXES:
+            return skill_error(
+                "Invalid axis: {}".format(axis),
+                "axis must be one of {}".format(_VALID_AXES),
+            )
+
+        axis_upper = axis_lower.upper()
+        enable_attr_min = "minRot{}LimitEnable".format(axis_upper)
+        enable_attr_max = "maxRot{}LimitEnable".format(axis_upper)
+        min_attr = "minRot{}Limit".format(axis_upper)
+        max_attr = "maxRot{}Limit".format(axis_upper)
+
+        cmds.setAttr("{}.{}".format(joint_name, enable_attr_min), enable)
+        cmds.setAttr("{}.{}".format(joint_name, enable_attr_max), enable)
+
+        if min_angle is not None:
+            cmds.setAttr("{}.{}".format(joint_name, min_attr), min_angle)
+        if max_angle is not None:
+            cmds.setAttr("{}.{}".format(joint_name, max_attr), max_angle)
+
+        # Read back the actual stored values
+        actual_min = cmds.getAttr("{}.{}".format(joint_name, min_attr))
+        actual_max = cmds.getAttr("{}.{}".format(joint_name, max_attr))
+
+        return skill_success(
+            "Set rotation limit on '{}.{}': [{}, {}]".format(joint_name, axis_lower, actual_min, actual_max),
+            joint_name=joint_name,
+            axis=axis_lower,
+            min_angle=actual_min,
+            max_angle=actual_max,
+            enable=enable,
+            prompt="Check the result with list_rigging or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set joint limit on {}".format(joint_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_joint_limit`."""
+    return set_joint_limit(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/set_joint_orient.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/set_joint_orient.py
@@ -1,0 +1,78 @@
+"""Set the joint orientation of a Maya joint node."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists, validate_node_type
+
+
+def set_joint_orient(
+    joint_name: str,
+    orient: Optional[List[float]] = None,
+    zero_scale_orient: bool = False,
+) -> dict:
+    """Set the joint orientation of a Maya joint node.
+
+    Joint orientation defines the local rotation axes used by the joint and
+    affects how rotation channels are interpreted downstream in the rig.
+
+    Args:
+        joint_name: Name of the joint to orient.
+        orient: ``[x, y, z]`` orientation in degrees.  Defaults to
+            ``[0, 0, 0]`` (zero out joint orient).
+        zero_scale_orient: If True, also zeroes the scale-compensate orient
+            (``jointOrientX/Y/Z``).  Default: False.
+
+    Returns:
+        ToolResult dict with ``context.object_name`` and
+        ``context.orient``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, joint_name)
+        if err:
+            return err
+
+        err = validate_node_type(cmds, joint_name, "joint")
+        if err:
+            return err
+
+        ox, oy, oz = (orient or [0.0, 0.0, 0.0])[:3]
+        cmds.setAttr("{}.jointOrientX".format(joint_name), ox)
+        cmds.setAttr("{}.jointOrientY".format(joint_name), oy)
+        cmds.setAttr("{}.jointOrientZ".format(joint_name), oz)
+
+        if zero_scale_orient:
+            for ax in ("X", "Y", "Z"):
+                cmds.setAttr("{}.segmentScaleCompensate".format(joint_name), True)
+
+        return skill_success(
+            "Set joint orient on '{}' to [{}, {}, {}]".format(joint_name, ox, oy, oz),
+            object_name=joint_name,
+            orient=[ox, oy, oz],
+            prompt="Check the result with list_rigging or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set joint orient on {}".format(joint_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_joint_orient`."""
+    return set_joint_orient(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/scripts/skin_cluster_bind.py
+++ b/src/dcc_mcp_maya/skills/maya-rigging/scripts/skin_cluster_bind.py
@@ -1,0 +1,94 @@
+"""Bind a mesh to a set of joints using a skin cluster."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import List, Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import batch_validate_nodes, validate_node_exists
+
+
+def skin_cluster_bind(
+    joints: List[str],
+    mesh: str,
+    max_influences: int = 4,
+    bind_method: int = 0,
+    name: Optional[str] = None,
+) -> dict:
+    """Bind a mesh to a set of joints using a skin cluster.
+
+    Args:
+        joints: List of joint names to include in the skin cluster.
+        mesh: Name of the mesh to skin.
+        max_influences: Maximum number of joints that can influence each
+            vertex.  Default: 4.
+        bind_method: Binding algorithm:
+            ``0`` = closest distance (default),
+            ``1`` = closest joint,
+            ``2`` = heat map,
+            ``3`` = geodesic voxel.
+        name: Optional name for the skin cluster node.
+
+    Returns:
+        ToolResult dict with ``context.skin_cluster_name``,
+        ``context.joint_count``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        if not joints:
+            return skill_error(
+                "No joints specified",
+                "joints list must contain at least one joint name",
+            )
+
+        err = validate_node_exists(cmds, mesh)
+        if err:
+            return err
+
+        err = batch_validate_nodes(cmds, joints)
+        if err:
+            return err
+
+        objects = list(joints) + [mesh]
+        kwargs = {
+            "maximumInfluences": max_influences,
+            "bindMethod": bind_method,
+            "toSelectedBones": True,
+        }  # type: dict
+        if name:
+            kwargs["name"] = name
+
+        result = cmds.skinCluster(*objects, **kwargs)
+        sc_name = result[0] if result else (name or "skinCluster1")
+
+        return skill_success(
+            "Bound '{}' to {} joint(s) via skin cluster '{}'".format(mesh, len(joints), sc_name),
+            skin_cluster_name=sc_name,
+            mesh=mesh,
+            joint_count=len(joints),
+            joints=joints,
+            max_influences=max_influences,
+            prompt="Check the result with list_rigging or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to bind skin cluster on {}".format(mesh))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`skin_cluster_bind`."""
+    return skin_cluster_bind(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-rigging/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-rigging/tools.yaml
@@ -1,0 +1,59 @@
+tools:
+- name: assign_deformer
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: rigging
+- name: blend_shape_add_target
+  execution: sync
+  affinity: main
+  group: rigging
+- name: create_blend_shape
+  execution: sync
+  affinity: main
+  group: rigging
+- name: create_curve
+  execution: sync
+  affinity: main
+  group: rigging
+- name: create_ik_handle
+  execution: sync
+  affinity: main
+  group: rigging
+- name: create_joint
+  execution: sync
+  affinity: main
+  group: rigging
+- name: mirror_joints
+  execution: sync
+  affinity: main
+  group: rigging
+- name: set_driven_key
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: rigging
+- name: set_ik_fk_blend
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: rigging
+- name: set_joint_limit
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: rigging
+- name: set_joint_orient
+  execution: sync
+  affinity: main
+  annotations:
+    idempotent_hint: true
+  group: rigging
+- name: skin_cluster_bind
+  execution: sync
+  affinity: main
+  group: rigging

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: maya-uv-ops
+description: Maya UV operations — create, delete, project, unfold, layout, and normalize UV sets. Use when working with texture coordinates and UV layouts. Not for mesh modeling, material authoring, or texture baking — use maya-mesh-ops, maya-materials, or maya-texture-bake for that.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    version: 1.0.0
+    tags:
+    - maya
+    - uv
+    - texture
+    - geometry
+    search-hint: layout UVs, unfold UV, texture coordinates, UV projection
+    depends: []
+    tools: tools.yaml
+    groups: groups.yaml
+---

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/groups.yaml
@@ -1,0 +1,13 @@
+groups:
+- name: modeling
+  description: Geometry creation, editing, and UV tools
+  default_active: false
+  tools:
+  - copy_uvs
+  - create_uv_set
+  - delete_uv_set
+  - get_uv_info
+  - get_uv_shell_info
+  - normalize_uvs
+  - project_uvs
+  - unfold_uvs

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/copy_uvs.py
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/copy_uvs.py
@@ -1,0 +1,77 @@
+"""Copy UV layout from one mesh to another via polyTransfer."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import batch_validate_nodes
+
+
+def copy_uvs(
+    source: str,
+    target: str,
+    source_uv_set: Optional[str] = None,
+    target_uv_set: Optional[str] = None,
+) -> dict:
+    """Copy UV layout from one mesh to another via polyTransfer.
+
+    Args:
+        source: Source mesh transform or shape name.
+        target: Target mesh transform or shape name.
+        source_uv_set: UV set on the source to copy from.  If None, uses
+            the current UV set.
+        target_uv_set: UV set on the target to copy into.  If None, uses
+            the current UV set.
+
+    Returns:
+        ToolResult dict.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = batch_validate_nodes(cmds, [source, target])
+        if err:
+            return err
+
+        kwargs = {
+            "transferUVs": 1,
+            "sampleSpace": 4,  # UV space
+            "ch": False,
+        }
+        if source_uv_set:
+            kwargs["sourceUvSet"] = source_uv_set
+        if target_uv_set:
+            kwargs["targetUvSet"] = target_uv_set
+
+        cmds.transferAttributes(source, target, **kwargs)
+
+        return skill_success(
+            "Copied UVs from '{}' to '{}'".format(source, target),
+            source=source,
+            target=target,
+            source_uv_set=source_uv_set,
+            target_uv_set=target_uv_set,
+            prompt="Use layout_uvs to arrange or export_uv_snapshot to preview.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to copy UVs")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`copy_uvs`."""
+    return copy_uvs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/create_uv_set.py
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/create_uv_set.py
@@ -1,0 +1,67 @@
+"""Create a new UV set on a polygon mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def create_uv_set(object_name: str, uv_set_name: str, copy_from: Optional[str] = None) -> dict:
+    """Create a new UV set on a polygon mesh.
+
+    Args:
+        object_name: Transform or mesh shape name.
+        uv_set_name: Name for the new UV set.
+        copy_from: Optional existing UV set name to copy UVs from.
+
+    Returns:
+        ToolResult dict with ``context.uv_set_name``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        existing = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+        if uv_set_name in existing:
+            return skill_error("UV set '{}' already exists on '{}'".format(uv_set_name, object_name))
+
+        if copy_from:
+            if copy_from not in existing:
+                return skill_error("Source UV set '{}' not found on '{}'".format(copy_from, object_name))
+            cmds.polyUVSet(object_name, copy=True, uvSet=copy_from, newUVSet=uv_set_name)
+        else:
+            cmds.polyUVSet(object_name, create=True, uvSet=uv_set_name)
+
+        return skill_success(
+            "Created UV set '{}' on '{}'".format(uv_set_name, object_name),
+            object_name=object_name,
+            uv_set_name=uv_set_name,
+            copied_from=copy_from,
+            prompt="Check the result with list_uv_ops or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create UV set")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_uv_set`."""
+    return create_uv_set(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/delete_uv_set.py
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/delete_uv_set.py
@@ -1,0 +1,68 @@
+"""Delete a UV set from a polygon mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+# Import built-in modules
+
+
+def delete_uv_set(object_name: str, uv_set_name: str) -> dict:
+    """Delete a UV set from a polygon mesh.
+
+    Args:
+        object_name: Transform or mesh shape name.
+        uv_set_name: Name of the UV set to delete.
+
+    Returns:
+        ToolResult dict.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        existing = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+        if uv_set_name not in existing:
+            return skill_error(
+                "UV set '{}' not found on '{}'".format(uv_set_name, object_name),
+                "Available UV sets: {}".format(existing),
+            )
+
+        # Protect the only remaining UV set
+        if len(existing) <= 1:
+            return skill_error(
+                "Cannot delete the only UV set on '{}'".format(object_name), "A mesh must have at least one UV set"
+            )
+
+        cmds.polyUVSet(object_name, delete=True, uvSet=uv_set_name)
+
+        return skill_success(
+            "Deleted UV set '{}' from '{}'".format(uv_set_name, object_name),
+            object_name=object_name,
+            uv_set_name=uv_set_name,
+            prompt="Check the result with list_uv_ops or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete UV set")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`delete_uv_set`."""
+    return delete_uv_set(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/get_uv_info.py
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/get_uv_info.py
@@ -1,0 +1,74 @@
+"""Query UV sets and coordinates on a polygon mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def get_uv_info(object_name: str, uv_set: Optional[str] = None) -> dict:
+    """Query UV sets and coordinates on a polygon mesh.
+
+    Args:
+        object_name: Transform or mesh shape name.
+        uv_set: UV set name to query coordinates from.  If None, returns
+            info about all UV sets without coordinate data.
+
+    Returns:
+        ToolResult dict with ``context.uv_sets``, ``context.current_uv_set``,
+        and optionally ``context.uv_count`` / ``context.uvs``.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        uv_sets = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+        current_set = cmds.polyUVSet(object_name, query=True, currentUVSet=True)
+        if isinstance(current_set, list):
+            current_set = current_set[0] if current_set else None
+
+        result_kwargs = {
+            "uv_sets": uv_sets,
+            "current_uv_set": current_set,
+            "uv_set_count": len(uv_sets),
+        }  # type: Dict
+
+        if uv_set:
+            if uv_set not in uv_sets:
+                return skill_error("UV set '{}' not found on '{}'".format(uv_set, object_name))
+            u_coords = cmds.polyEditUV("{}.map[*]".format(object_name), query=True, uValue=True) or []
+            _ = cmds.polyEditUV("{}.map[*]".format(object_name), query=True, vValue=True) or []
+            result_kwargs["uv_count"] = len(u_coords)
+            result_kwargs["queried_uv_set"] = uv_set
+
+        return skill_success(
+            "UV info for '{}'".format(object_name),
+            **result_kwargs,
+            prompt="Check the result with list_uv_ops or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get UV info")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_uv_info`."""
+    return get_uv_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/get_uv_shell_info.py
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/get_uv_shell_info.py
@@ -1,0 +1,106 @@
+"""Get UV shell information for a polygon mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+
+def get_uv_shell_info(object_name: str, uv_set: Optional[str] = None) -> dict:
+    """Get UV shell information for a polygon mesh.
+
+    Reports the number of UV shells and the bounding box of each shell in
+    UV space (u_min, v_min, u_max, v_max).
+
+    Args:
+        object_name: Transform or mesh shape name.
+        uv_set: UV set to query.  If None, uses the current active UV set.
+
+    Returns:
+        ToolResult dict with ``context.shell_count``,
+        ``context.shells`` (list of dicts with ``u_min``, ``v_min``,
+        ``u_max``, ``v_max``, ``uv_indices``).
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        # Resolve UV set
+        if uv_set:
+            existing = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+            if uv_set not in existing:
+                return skill_error(
+                    "UV set '{}' not found on '{}'".format(uv_set, object_name),
+                    "Available UV sets: {}".format(existing),
+                )
+            cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+
+        active_set = cmds.polyUVSet(object_name, query=True, currentUVSet=True)
+        if isinstance(active_set, list):
+            active_set = active_set[0] if active_set else "map1"
+
+        # Query UV shell IDs per UV component
+        shell_ids = cmds.polyEvaluate(object_name, uvShellsIds=True) or []
+
+        # Build shell groups: shell_id -> list of UV component indices
+        shell_map = {}
+        for i, sid in enumerate(shell_ids):
+            shell_map.setdefault(int(sid), []).append(i)
+
+        # Query all U and V coordinates
+        u_vals = cmds.polyEditUV("{}.map[*]".format(object_name), query=True, uValue=True) or []
+        v_vals = cmds.polyEditUV("{}.map[*]".format(object_name), query=True, vValue=True) or []
+
+        shells = []
+        for sid in sorted(shell_map.keys()):
+            indices = shell_map[sid]
+            us = [u_vals[i] for i in indices if i < len(u_vals)]
+            vs = [v_vals[i] for i in indices if i < len(v_vals)]
+            if us and vs:
+                shells.append(
+                    {
+                        "shell_id": sid,
+                        "uv_count": len(indices),
+                        "u_min": min(us),
+                        "u_max": max(us),
+                        "v_min": min(vs),
+                        "v_max": max(vs),
+                    }
+                )
+            else:
+                shells.append({"shell_id": sid, "uv_count": len(indices)})
+
+        return skill_success(
+            "UV shell info for '{}' (UV set: {})".format(object_name, active_set),
+            object_name=object_name,
+            uv_set=active_set,
+            shell_count=len(shells),
+            shells=shells,
+            prompt="Check the result with list_uv_ops or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get UV shell info")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_uv_shell_info`."""
+    return get_uv_shell_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/normalize_uvs.py
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/normalize_uvs.py
@@ -1,0 +1,82 @@
+"""Normalize UV coordinates to fit within the 0-1 UV tile."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+# Import built-in modules
+
+
+def normalize_uvs(
+    object_name: str,
+    layout_u: float = 1.0,
+    layout_v: float = 1.0,
+    preserve_aspect: bool = True,
+) -> dict:
+    """Normalize UV coordinates to fit within the 0-1 UV tile.
+
+    Args:
+        object_name: Transform or mesh shape name.
+        layout_u: Target U dimension (0 < value <= 1).  Default: 1.0.
+        layout_v: Target V dimension (0 < value <= 1).  Default: 1.0.
+        preserve_aspect: When True, scale uniformly to preserve aspect ratio.
+            Default: True.
+
+    Returns:
+        ToolResult dict with ``context.object_name``.
+    """
+
+    if not (0 < layout_u <= 1):
+        return skill_error(
+            "Invalid layout_u: {}".format(layout_u),
+            "layout_u must be in range (0, 1]",
+        )
+    if not (0 < layout_v <= 1):
+        return skill_error(
+            "Invalid layout_v: {}".format(layout_v),
+            "layout_v must be in range (0, 1]",
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        cmds.polyNormalizeUV(
+            object_name,
+            normalizeType=1,
+            preserveAspectRatio=preserve_aspect,
+            centerOnTile=True,
+            ch=False,
+        )
+
+        return skill_success(
+            "Normalized UVs on '{}' (layout_u={}, layout_v={})".format(object_name, layout_u, layout_v),
+            object_name=object_name,
+            layout_u=layout_u,
+            layout_v=layout_v,
+            preserve_aspect=preserve_aspect,
+            prompt="Use layout_uvs or export_uv_snapshot to verify.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to normalize UVs on '{}'".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`normalize_uvs`."""
+    return normalize_uvs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/project_uvs.py
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/project_uvs.py
@@ -1,0 +1,98 @@
+"""Apply a UV projection to a polygon mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+# Import built-in modules
+
+
+def project_uvs(
+    object_name: str,
+    projection_type: str = "planar",
+    axis: str = "y",
+) -> dict:
+    """Apply a UV projection to a polygon mesh.
+
+    Args:
+        object_name: Transform or mesh name.
+        projection_type: Projection type — ``"planar"``, ``"cylindrical"``,
+            or ``"spherical"``.  Default: ``"planar"``.
+        axis: Projection axis — ``"x"``, ``"y"``, or ``"z"``.  Only used
+            for planar and cylindrical projections.  Default: ``"y"``.
+
+    Returns:
+        ToolResult dict.
+    """
+
+    valid_types = ("planar", "cylindrical", "spherical")
+    if projection_type not in valid_types:
+        return skill_error(
+            "Invalid projection_type: {}".format(projection_type),
+            "Use one of: {}".format(", ".join(valid_types)),
+        )
+
+    valid_axes = ("x", "y", "z")
+    if axis not in valid_axes:
+        return skill_error(
+            "Invalid axis: {}".format(axis),
+            "Use one of: x, y, z",
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        axis_index = {"x": 0, "y": 1, "z": 2}[axis]
+
+        if projection_type == "planar":
+            cmds.polyProjection(
+                object_name,
+                type="Planar",
+                mapDirection=axis.upper(),
+                ch=False,
+            )
+        elif projection_type == "cylindrical":
+            cmds.polyProjection(
+                object_name,
+                type="Cylindrical",
+                ch=False,
+            )
+        else:
+            cmds.polyProjection(
+                object_name,
+                type="Spherical",
+                ch=False,
+            )
+
+        return skill_success(
+            "Applied {} UV projection to '{}' (axis={})".format(projection_type, object_name, axis),
+            object_name=object_name,
+            projection_type=projection_type,
+            axis=axis,
+            axis_index=axis_index,
+            prompt="Check the result with list_uv_ops or use related actions to continue.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to project UVs")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`project_uvs`."""
+    return project_uvs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/unfold_uvs.py
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/scripts/unfold_uvs.py
@@ -1,0 +1,82 @@
+"""Unfold the UV layout on a polygon mesh."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_maya.api import validate_node_exists
+
+# Import built-in modules
+
+
+def unfold_uvs(
+    object_name: str,
+    iterations: int = 1,
+    optimize_scale: bool = True,
+) -> dict:
+    """Unfold the UV layout on a polygon mesh.
+
+    Uses ``cmds.u3dUnfold`` to iteratively unfold UV shells.
+
+    Args:
+        object_name: Transform or mesh shape name.
+        iterations: Number of unfold iterations (1–100).  Default: 1.
+        optimize_scale: When True, normalises UV shells after unfolding so
+            they all have the same texel density.  Default: True.
+
+    Returns:
+        ToolResult dict with ``context.object_name``,
+        ``context.iterations``.
+    """
+
+    if iterations < 1 or iterations > 100:
+        return skill_error(
+            "Invalid iterations: {}".format(iterations),
+            "iterations must be between 1 and 100",
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        err = validate_node_exists(cmds, object_name)
+        if err:
+            return err
+
+        cmds.u3dUnfold(
+            object_name,
+            iterations=iterations,
+            pack=False,
+            borderintersection=True,
+            triangleflip=True,
+            mapsize=512,
+            roomspace=0,
+        )
+
+        if optimize_scale:
+            cmds.u3dOptimize(object_name, iterations=1, power=1, resultScale=1)
+
+        return skill_success(
+            "Unfolded UVs on '{}' ({} iteration(s))".format(object_name, iterations),
+            object_name=object_name,
+            iterations=iterations,
+            optimize_scale=optimize_scale,
+            prompt="Use export_uv_snapshot to preview or layout_uvs to arrange.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to unfold UVs on '{}'".format(object_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`unfold_uvs`."""
+    return unfold_uvs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/tools.yaml
@@ -1,0 +1,42 @@
+tools:
+- name: copy_uvs
+  execution: sync
+  affinity: main
+  group: modeling
+- name: create_uv_set
+  execution: sync
+  affinity: main
+  group: modeling
+- name: delete_uv_set
+  execution: sync
+  affinity: main
+  annotations:
+    destructive_hint: true
+    idempotent_hint: true
+  group: modeling
+- name: get_uv_info
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: modeling
+- name: get_uv_shell_info
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: true
+    idempotent_hint: true
+  group: modeling
+- name: normalize_uvs
+  execution: sync
+  affinity: main
+  group: modeling
+- name: project_uvs
+  execution: sync
+  affinity: main
+  group: modeling
+- name: unfold_uvs
+  execution: sync
+  affinity: main
+  group: modeling

--- a/tests/test_e2e_maya_standalone.py
+++ b/tests/test_e2e_maya_standalone.py
@@ -1508,6 +1508,457 @@ class TestMultiInstanceConcurrentWorkflows:
 
 
 # ---------------------------------------------------------------------------
+# Full MCP skill lifecycle: search -> load -> activate -> call -> unload
+# ---------------------------------------------------------------------------
+#
+# Issue #180 restored ten bundled skills so `TestPrimitiveActions` et al. can
+# exercise the in-process dispatcher.  This class closes the remaining gap:
+# the *wire* contract — proving that an external MCP agent (Codebuddy,
+# Claude, Cursor, ...) can go from "I don't know what's available" to
+# "I called the tool and then cleaned up" using only HTTP JSON-RPC.
+#
+# The chain is intentionally built against the restored `maya-primitives`
+# skill so the test also functions as a regression guard for #180 at the
+# transport layer — if that skill ever regresses out of `tools/list`
+# again, this test will flag it before any in-process test notices.
+# ---------------------------------------------------------------------------
+
+
+class TestMcpSkillLifecycle:
+    """search_skills -> load_skill -> activate_tool_group -> tools/call -> unload_skill over HTTP.
+
+    Uses the `DCC_MCP_ALLOW_AMBIENT_PYTHON=1` escape hatch (same as
+    `TestScriptingHttpE2E`) because the in-process executor refuses to
+    execute skill scripts unless it can prove `import maya.cmds` works
+    under the ambient interpreter.  Inside mayapy that guarantee holds
+    but core has no way to auto-detect it — the env flag is the
+    documented workaround (upstream dcc-mcp-core#231).
+
+    Tool-naming note
+    ----------------
+    Depending on the registration mode, a skill action may be exposed as
+    either the bare script stem (``create_sphere``) or the fully
+    qualified form (``maya_primitives__create_sphere``).  The test
+    resolves the live name via ``_resolve_action_name`` instead of
+    hard-coding either spelling (same approach
+    ``TestScriptingHttpE2E._resolve_execute_python_tool_name`` uses).
+    """
+
+    _TARGET_SKILL = "maya-primitives"
+    _TARGET_GROUP = "modeling"
+    _TARGET_ACTION_STEM = "create_sphere"
+    _SPHERE_NAME = "mcpLifecycleSphere"
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _start_server(self, request):
+        import os  # noqa: PLC0415
+
+        from dcc_mcp_maya.server import MayaMcpServer  # noqa: PLC0415
+
+        ambient_env = "DCC_MCP_ALLOW_AMBIENT_PYTHON"
+        previous_env = os.environ.get(ambient_env)
+        os.environ[ambient_env] = "1"
+
+        _new_scene()
+        server = MayaMcpServer(port=0)
+        server.register_builtin_actions()
+        handle = server.start()
+        request.cls._mcp_url = handle.mcp_url()
+        try:
+            yield
+        finally:
+            server.stop()
+            if previous_env is None:
+                os.environ.pop(ambient_env, None)
+            else:
+                os.environ[ambient_env] = previous_env
+
+    @staticmethod
+    def _tools_call(mcp_url, tool_name, arguments, request_id):
+        code, body = _mcp_post(
+            mcp_url,
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "tools/call",
+                "params": {"name": tool_name, "arguments": arguments},
+            },
+        )
+        assert code == 200, "HTTP {} from tools/call({!r})".format(code, tool_name)
+        return body
+
+    @staticmethod
+    def _resolve_action_name(names, skill, stem):
+        """Return the wire-name of ``<skill>/scripts/<stem>.py`` in *names*, else None.
+
+        Accepts both the fully-qualified (``maya_primitives__create_sphere``)
+        and the bare (``create_sphere``) registration spellings so the
+        test works against either convention core picks at registration
+        time.
+        """
+        qualified = "{}__{}".format(skill.replace("-", "_"), stem)
+        if qualified in names:
+            return qualified
+        if stem in names:
+            return stem
+        return None
+
+    @staticmethod
+    def _names_for_skill(names, skill):
+        """Return the subset of *names* that look like they belong to *skill*."""
+        prefix = skill.replace("-", "_") + "__"
+        return {n for n in names if n.startswith(prefix)}
+
+    def test_search_load_activate_call_unload_roundtrip(self):
+        """End-to-end HTTP lifecycle against the restored maya-primitives skill."""
+        # 1) SEARCH — prove the skill is discoverable without prior knowledge.
+        search_body = self._tools_call(
+            self._mcp_url,
+            "search_skills",
+            {"query": "primitives"},
+            request_id=2100,
+        )
+        search_text = search_body["result"]["content"][0].get("text", "")
+        assert self._TARGET_SKILL in search_text, (
+            "search_skills(query='primitives') did not surface {!r}; got: {}".format(
+                self._TARGET_SKILL, search_text[:400]
+            )
+        )
+
+        # 2) LOAD — the skill's stub should disappear and real tools appear.
+        before_names = {t["name"] for t in _mcp_list_all_tools(self._mcp_url, request_id=2101)}
+        assert "__skill__" + self._TARGET_SKILL in before_names, (
+            "Expected stub __skill__{} before load, saw stubs: {}".format(
+                self._TARGET_SKILL,
+                sorted(n for n in before_names if n.startswith("__skill__")),
+            )
+        )
+
+        self._tools_call(
+            self._mcp_url,
+            "load_skill",
+            {"skill_name": self._TARGET_SKILL},
+            request_id=2102,
+        )
+
+        # 3) ACTIVATE — maya-primitives' `modeling` group has
+        # default_active: false so its tools arrive as a __group__ stub;
+        # activate it so the create_sphere action is callable.
+        after_load = {t["name"] for t in _mcp_list_all_tools(self._mcp_url, request_id=2103)}
+        assert "__skill__" + self._TARGET_SKILL not in after_load, (
+            "Stub __skill__{} should be gone after load_skill".format(self._TARGET_SKILL)
+        )
+        group_stub = "__group__" + self._TARGET_GROUP
+        if group_stub in after_load:
+            self._tools_call(
+                self._mcp_url,
+                "activate_tool_group",
+                {"group": self._TARGET_GROUP},
+                request_id=2104,
+            )
+            after_activate = {t["name"] for t in _mcp_list_all_tools(self._mcp_url, request_id=2105)}
+        else:
+            after_activate = after_load
+
+        target_tool = self._resolve_action_name(after_activate, self._TARGET_SKILL, self._TARGET_ACTION_STEM)
+        if target_tool is None:
+            # Failure diagnostic: show exactly what load_skill + activate added
+            # so future rename / namespace changes surface clearly.
+            added = sorted(after_activate - before_names)
+            removed = sorted(before_names - after_activate)
+            raise AssertionError(
+                "Could not locate create_sphere action after load+activate of {!r}. "
+                "Expected either {!r} (qualified) or {!r} (bare) in tools/list. "
+                "Tools ADDED by load+activate ({}): {}. Tools REMOVED: {}.".format(
+                    self._TARGET_SKILL,
+                    "maya_primitives__" + self._TARGET_ACTION_STEM,
+                    self._TARGET_ACTION_STEM,
+                    len(added),
+                    added[:40],
+                    removed[:20],
+                )
+            )
+
+        # 4) CALL — the canonical agent action; verify the sphere actually
+        # exists in the live Maya scene, not just that MCP returned 200.
+        call_body = self._tools_call(
+            self._mcp_url,
+            target_tool,
+            {"radius": 1.25, "name": self._SPHERE_NAME},
+            request_id=2106,
+        )
+        content = call_body["result"].get("content", [])
+        assert content, "tools/call response missing content: {}".format(call_body)
+        call_text = content[0].get("text", "")
+        assert "success" in call_text or self._SPHERE_NAME in call_text, (
+            "tools/call for {!r} did not look successful: {}".format(target_tool, call_text[:400])
+        )
+        assert cmds.objExists(self._SPHERE_NAME), "Expected Maya node {!r} to exist after tools/call {!r}".format(
+            self._SPHERE_NAME, target_tool
+        )
+
+        # 5) UNLOAD — the action tool must disappear from tools/list and
+        # the skill must be back in stub form.
+        self._tools_call(
+            self._mcp_url,
+            "unload_skill",
+            {"skill_name": self._TARGET_SKILL},
+            request_id=2107,
+        )
+        after_unload = {t["name"] for t in _mcp_list_all_tools(self._mcp_url, request_id=2108)}
+        assert target_tool not in after_unload, "{!r} should be removed from tools/list after unload_skill".format(
+            target_tool
+        )
+        # And nothing else that looks like a maya-primitives action tool
+        # should linger either.
+        leaks = self._names_for_skill(after_unload, self._TARGET_SKILL)
+        assert not leaks, "No maya_primitives__* tools should be exposed after unload_skill; saw: {}".format(
+            sorted(leaks)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-instance capability divergence
+# ---------------------------------------------------------------------------
+#
+# The existing `TestMultiInstanceIsolation` / `TestMultiInstanceConcurrentWorkflows`
+# classes prove that two servers share a scene and route calls correctly,
+# but they load the *same* default skill set on both instances — a
+# genuinely differentiated deployment (server A hosts the animator's
+# skills, server B hosts the FX artist's skills) is never exercised.
+#
+# This class closes that gap: two servers run in parallel, each loads a
+# disjoint set of restored skills, and the test asserts that their
+# MCP capability surfaces diverge in both directions — the tools one
+# exposes do not show up on the other.
+# ---------------------------------------------------------------------------
+
+
+class TestMultiInstanceCapabilityDivergence:
+    """Two concurrent servers with disjoint loaded-skill sets expose
+    disjoint tools over MCP.
+
+    Server A loads ``maya-primitives`` + activates the ``modeling`` group.
+    Server B loads ``maya-animation``  + activates the ``animation`` group.
+
+    The fixture records each server's ``tools/list`` both *before* and
+    *after* driving it into its load+activate state so the assertions
+    can compare DELTAs — i.e. "the action tools server A gained by
+    loading maya-primitives must not be the same ones server B
+    gained by loading maya-animation".  This keeps the test valid
+    regardless of whether the underlying registry uses bare
+    (``create_sphere``) or qualified (``maya_primitives__create_sphere``)
+    naming.
+    """
+
+    _SKILL_A = "maya-primitives"
+    _GROUP_A = "modeling"
+    _SAMPLE_ACTION_A = "create_sphere"
+
+    _SKILL_B = "maya-animation"
+    _GROUP_B = "animation"
+    _SAMPLE_ACTION_B = "set_timeline"
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _start_two_servers(self, request):
+        import os  # noqa: PLC0415
+
+        from dcc_mcp_maya.server import MayaMcpServer  # noqa: PLC0415
+
+        ambient_env = "DCC_MCP_ALLOW_AMBIENT_PYTHON"
+        previous_env = os.environ.get(ambient_env)
+        os.environ[ambient_env] = "1"
+
+        _new_scene()
+
+        # Two distinct server_names so we can differentiate them in
+        # `initialize` responses too (not strictly required by this class
+        # but keeps parity with TestMultiInstanceConcurrentWorkflows).
+        srv_a = MayaMcpServer(port=0, server_name="maya-capability-a")
+        srv_a.register_builtin_actions()
+        h_a = srv_a.start()
+
+        srv_b = MayaMcpServer(port=0, server_name="maya-capability-b")
+        srv_b.register_builtin_actions()
+        h_b = srv_b.start()
+
+        request.cls._url_a = h_a.mcp_url()
+        request.cls._url_b = h_b.mcp_url()
+
+        # Snapshot each server's tool surface before driving it into
+        # a distinct loaded-skill state.
+        baseline_a = {t["name"] for t in _mcp_list_all_tools(request.cls._url_a, request_id=2900)}
+        baseline_b = {t["name"] for t in _mcp_list_all_tools(request.cls._url_b, request_id=2901)}
+
+        TestMultiInstanceCapabilityDivergence._load_and_activate(
+            request.cls._url_a, request.cls._SKILL_A, request.cls._GROUP_A, base_id=3000
+        )
+        TestMultiInstanceCapabilityDivergence._load_and_activate(
+            request.cls._url_b, request.cls._SKILL_B, request.cls._GROUP_B, base_id=3100
+        )
+
+        # Final snapshots after skill activation.
+        final_a = {t["name"] for t in _mcp_list_all_tools(request.cls._url_a, request_id=3150)}
+        final_b = {t["name"] for t in _mcp_list_all_tools(request.cls._url_b, request_id=3151)}
+
+        # Expose every piece of evidence the assertions need.  Using
+        # request.cls so every test method in the class sees the same
+        # class-level view.
+        request.cls._baseline_a = baseline_a
+        request.cls._baseline_b = baseline_b
+        request.cls._final_a = final_a
+        request.cls._final_b = final_b
+
+        try:
+            yield
+        finally:
+            srv_a.stop()
+            srv_b.stop()
+            if previous_env is None:
+                os.environ.pop(ambient_env, None)
+            else:
+                os.environ[ambient_env] = previous_env
+
+    @staticmethod
+    def _load_and_activate(mcp_url, skill_name, group_name, base_id):
+        """Load *skill_name* and, if the group is default_active: false, activate it."""
+        _mcp_post(
+            mcp_url,
+            {
+                "jsonrpc": "2.0",
+                "id": base_id,
+                "method": "tools/call",
+                "params": {
+                    "name": "load_skill",
+                    "arguments": {"skill_name": skill_name},
+                },
+            },
+        )
+        names = {t["name"] for t in _mcp_list_all_tools(mcp_url, request_id=base_id + 1)}
+        if "__group__" + group_name in names:
+            _mcp_post(
+                mcp_url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": base_id + 2,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "activate_tool_group",
+                        "arguments": {"group": group_name},
+                    },
+                },
+            )
+
+    @staticmethod
+    def _real_tools(names):
+        """Drop stubs (__skill__*, __group__*) — leave only real action tools."""
+        return {n for n in names if not n.startswith("__")}
+
+    def test_each_server_exposes_distinct_action_tool_sets(self):
+        """The set of *real* tools A gained from loading maya-primitives
+        must not be the same set B gained from loading maya-animation.
+
+        Compared as set-deltas over the pre-load baseline so the
+        assertion is immune to whether tools end up registered under
+        bare (``create_sphere``) or qualified
+        (``maya_primitives__create_sphere``) names.
+        """
+        gained_a = self._real_tools(self._final_a - self._baseline_a)
+        gained_b = self._real_tools(self._final_b - self._baseline_b)
+
+        # Each server must have genuinely gained at least one new
+        # action tool from its load (otherwise the test is vacuous).
+        assert gained_a, "Server A gained no real tools from loading {!r}. Final set: {}".format(
+            self._SKILL_A, sorted(self._final_a)[:50]
+        )
+        assert gained_b, "Server B gained no real tools from loading {!r}. Final set: {}".format(
+            self._SKILL_B, sorted(self._final_b)[:50]
+        )
+
+        # Sample actions must be present on their own server under
+        # either naming convention.
+        qualified_a = "{}__{}".format(self._SKILL_A.replace("-", "_"), self._SAMPLE_ACTION_A)
+        qualified_b = "{}__{}".format(self._SKILL_B.replace("-", "_"), self._SAMPLE_ACTION_B)
+        has_sample_a = self._SAMPLE_ACTION_A in gained_a or qualified_a in gained_a
+        has_sample_b = self._SAMPLE_ACTION_B in gained_b or qualified_b in gained_b
+        assert has_sample_a, "Server A should expose a {!r} tool (bare or {!r}); gained only: {}".format(
+            self._SAMPLE_ACTION_A, qualified_a, sorted(gained_a)
+        )
+        assert has_sample_b, "Server B should expose a {!r} tool (bare or {!r}); gained only: {}".format(
+            self._SAMPLE_ACTION_B, qualified_b, sorted(gained_b)
+        )
+
+        # THE headline assertion: the gained-tool sets must differ.
+        # Bare-name registration is known to produce overlap on common
+        # names like ``create_sphere`` (maya-geometry already ships one),
+        # so we do NOT assert the sets are disjoint — we assert that
+        # each server gained at least one tool the OTHER did not.
+        a_only = gained_a - gained_b
+        b_only = gained_b - gained_a
+        assert a_only, (
+            "Server A's gained tools are a subset of Server B's — skill-set "
+            "divergence not observable via tools/list. gained_a={}, gained_b={}".format(
+                sorted(gained_a), sorted(gained_b)
+            )
+        )
+        assert b_only, (
+            "Server B's gained tools are a subset of Server A's — skill-set "
+            "divergence not observable via tools/list. gained_a={}, gained_b={}".format(
+                sorted(gained_a), sorted(gained_b)
+            )
+        )
+
+    def test_tool_call_for_unloaded_skill_is_rejected(self):
+        """Calling a skill action against a server that never loaded it
+        returns an error envelope — not a silent 200 with garbage, and
+        not a 500 either.
+
+        We target a tool that only exists under the qualified
+        ``maya_animation__*`` namespace so the check is valid regardless
+        of whether bare-name registration caused any overlap on the
+        positive test above.
+        """
+        animation_only = "maya_animation__set_timeline"
+        # Sanity: this tool must actually exist on server B.
+        assert animation_only in self._final_b or self._SAMPLE_ACTION_B in self._final_b, (
+            "Precondition failed: server B does not expose any recognisable set_timeline tool; "
+            "cannot meaningfully assert its absence on server A. final_b sample: {}".format(
+                sorted(n for n in self._final_b if "timeline" in n or "animation" in n)
+            )
+        )
+        # And it must NOT be present on server A — which is what makes
+        # the negative call below meaningful.
+        assert animation_only not in self._final_a, (
+            "Precondition failed: server A unexpectedly exposes {!r}, so the "
+            "negative-tool-call assertion below would pass trivially.".format(animation_only)
+        )
+
+        # Server A has only maya-primitives loaded; try to call an
+        # unambiguously-qualified maya-animation action against it.
+        code, body = _mcp_post(
+            self._url_a,
+            {
+                "jsonrpc": "2.0",
+                "id": 3300,
+                "method": "tools/call",
+                "params": {
+                    "name": animation_only,
+                    "arguments": {"start_frame": 1, "end_frame": 24},
+                },
+            },
+        )
+        # Core's contract: an unknown tool returns either a JSON-RPC
+        # error object or a result with isError=true (issue #165).
+        # Accept either shape; both are documented as valid.
+        assert code == 200, "Transport errors should not surface as HTTP {}".format(code)
+        has_jsonrpc_error = "error" in body
+        has_iserror = bool(body.get("result", {}).get("isError"))
+        assert has_jsonrpc_error or has_iserror, (
+            "Expected structured error for unknown tool {!r} on server A; got: {}".format(animation_only, body)
+        )
+
+
+# ---------------------------------------------------------------------------
 # Plugin entry-point (initializePlugin / uninitializePlugin)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_e2e_maya_standalone.py
+++ b/tests/test_e2e_maya_standalone.py
@@ -81,11 +81,6 @@ def _resolve_skills_root() -> Path:
 
 _SKILLS_ROOT = _resolve_skills_root()
 
-# Legacy bundled-skill workflows were removed when the project adopted the
-# thin-harness model (keep only 12 core skills). E2E classes below that rely
-# on deleted skill packages are conditionally skipped.
-_LEGACY_SKILLS_AVAILABLE = (_SKILLS_ROOT / "maya-primitives").is_dir()
-
 
 # Ensure dcc_mcp_maya is importable in packaged module mode
 # (Maya standalone does not process .mod PYTHONPATH directives)
@@ -654,7 +649,6 @@ class TestSceneActions:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _LEGACY_SKILLS_AVAILABLE, reason="legacy bundled skills removed in thin-harness mode")
 class TestPrimitiveActions:
     """Primitive creation skill scripts produce real Maya nodes."""
 
@@ -727,7 +721,6 @@ class TestScriptingActions:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _LEGACY_SKILLS_AVAILABLE, reason="legacy bundled skills removed in thin-harness mode")
 class TestAnimationActions:
     """Keyframe and timeline skill scripts work in Maya standalone."""
 
@@ -768,7 +761,6 @@ class TestAnimationActions:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _LEGACY_SKILLS_AVAILABLE, reason="legacy bundled skills removed in thin-harness mode")
 class TestMaterialActions:
     """Material creation and assignment skill scripts work in Maya standalone."""
 
@@ -800,7 +792,6 @@ class TestMaterialActions:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _LEGACY_SKILLS_AVAILABLE, reason="legacy bundled skills removed in thin-harness mode")
 class TestRiggingWorkflow:
     """Multi-step rigging workflows: joints, skin, IK, blend shapes."""
 
@@ -876,7 +867,6 @@ class TestRiggingWorkflow:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _LEGACY_SKILLS_AVAILABLE, reason="legacy bundled skills removed in thin-harness mode")
 class TestAnimationWorkflow:
     """Multi-attribute keyframe sequences, timeline, bake, curve queries."""
 
@@ -952,7 +942,6 @@ class TestAnimationWorkflow:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _LEGACY_SKILLS_AVAILABLE, reason="legacy bundled skills removed in thin-harness mode")
 class TestMeshAndMaterialWorkflow:
     """Subdivision, merge, cleanup, UV ops, material assignment chain."""
 
@@ -1039,7 +1028,6 @@ class TestMeshAndMaterialWorkflow:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _LEGACY_SKILLS_AVAILABLE, reason="legacy bundled skills removed in thin-harness mode")
 class TestNodeGraphWorkflow:
     """Attribute ops, connect/disconnect, expressions, display layers."""
 


### PR DESCRIPTION
## Summary

Restore the 10 bundled skill packages that the thin-harness refactor dropped in `04d0c65f`, so `tests/test_e2e_maya_standalone.py` exercises every scenario unconditionally on the `tahv/mayapy` CI matrix instead of silently skipping ~20 tests behind `_LEGACY_SKILLS_AVAILABLE`.

Fixes #180.

## Changes

- **Restore 10 skill packages** (115 files, verbatim salvage from rev `38b0f24a`, the parent of the removal commit — keeps script authorship context intact):
  - `maya-primitives`, `maya-animation`, `maya-materials`, `maya-rigging`, `maya-mesh-ops`
  - `maya-uv-ops`, `maya-node-graph`, `maya-attributes`, `maya-expressions`, `maya-display`
- **Synthesize `groups.yaml`** for `maya-node-graph` and `maya-attributes` (neither had one at the salvage revision) and add matching `group:` keys on each of their `tools.yaml` entries to match the modern convention used by `maya-geometry`.
- **Drop `_LEGACY_SKILLS_AVAILABLE`** and its seven `@pytest.mark.skipif(...)` decorators from `tests/test_e2e_maya_standalone.py` — `TestPrimitiveActions`, `TestAnimationActions`, `TestMaterialActions`, `TestRiggingWorkflow`, `TestAnimationWorkflow`, `TestMeshAndMaterialWorkflow`, `TestNodeGraphWorkflow`.

## Core API compatibility

Verified against the current upstream surface (https://github.com/loonghao/dcc-mcp-core/blob/main/llms.txt, installed `dcc-mcp-core==0.14.23`):

- All 84 restored scripts import `from dcc_mcp_core.skill import skill_entry, skill_success, skill_error, skill_exception, run_main` — the documented stable public API.
- No deprecated or removed symbols were in use. No migration required.
- Zero async tools in the restored packages, so no `timeout_hint_secs` additions were needed.

## Validation

- `ruff check` — clean across all 10 restored skills + the test file.
- `pytest -q --ignore=tests/test_e2e_maya_standalone.py --ignore=tests/e2e` — **754 passed, 0 failed** (the rest of the suite sees all 23 skills on disk without breakage; `test_skills_discovered`'s `>= 12` assertion still holds).
- `pytest --collect-only tests/test_e2e_maya_standalone.py` — module skips whole off-mayapy via the existing `pytest.importorskip("maya.standalone")`, as designed.
- Smoke-imported every restored script module without Maya present (all lazy-import `maya.cmds`) — 84/84 succeed.

## Acceptance checklist (from #180)

- [x] Bundled skills for primitives / animation / materials / rigging / mesh-ops / node-graph / uv-ops re-introduced (plus attributes / expressions / display, which supply scripts the legacy workflows reach into).
- [x] `_LEGACY_SKILLS_AVAILABLE` removed; `TestPrimitiveActions`, `TestAnimationActions`, `TestMaterialActions`, `TestRiggingWorkflow`, `TestAnimationWorkflow`, `TestMeshAndMaterialWorkflow`, `TestNodeGraphWorkflow` run on every mayapy E2E job.
- [ ] `mayapy -m pytest tests/test_e2e_maya_standalone.py -v` reports zero `SKIPPED` entries under the `legacy bundled skills removed` reason across 2022 / 2023 / 2024 / 2025 — will be confirmed by the `e2e.yml` CI matrix on this PR.

## Notes for reviewers

- `maya-geometry` keeps its own `create_sphere` and co-exists with `maya-primitives.create_sphere`; fully-qualified tool names (`maya_geometry__create_sphere` vs `maya_primitives__create_sphere`) avoid registry collision. Acceptance criterion #1 explicitly asks for `maya-primitives` to come back, so the duplication is intentional until a future consolidation pass.
- No server / dispatcher / capability-manifest changes — the skill loader already auto-discovers any directory under `src/dcc_mcp_maya/skills/` that has a `SKILL.md`, so the restored packages surface as `__skill__*` stubs in `tools/list` and as real tools after `load_skill`.
