### PR TITLE
feat(readiness): wire three-state ReadinessProbe into MayaMcpServer (#184)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ def create_sphere(radius: float = 1.0) -> dict:
 ### Layer 3 — You Are a Core Developer
 *Goal: Modify the server, dispatcher, or plugin behavior.*
 
-- **src/dcc_mcp_maya/server.py** — `MayaMcpServer` composition root (constructor, `register_builtin_actions`, `start`, `stop`, metrics, job persistence). Heavy lifting lives in private siblings: `_env`, `_executor`, `_skill_loader`, `_version_probe`, `_transport`, `_pyexec`, `_stale_cleanup`.
+- **src/dcc_mcp_maya/server.py** — `MayaMcpServer` composition root (constructor, `register_builtin_actions`, `start`, `stop`, metrics, job persistence, readiness). Heavy lifting lives in private siblings: `_env`, `_executor`, `_skill_loader`, `_version_probe`, `_transport`, `_pyexec`, `_stale_cleanup`, `_readiness`.
 - **src/dcc_mcp_maya/dispatcher/** — `MayaUiDispatcher`, `MayaStandaloneDispatcher`, `MayaUiPump`, `check_maya_cancelled` (split into `job` / `cancel` / `ui` / `standalone` / `pump` submodules — public symbols re-exported from the package).
 - **maya/plugin/dcc_mcp_maya_plugin.py** — Maya plugin entry point (`initializePlugin`, `uninitializePlugin`, menu, gateway auto-config).
 - **tests/** — 50+ unit tests, E2E tests (tahv/mayapy 2022–2025), multi-instance gateway tests.
@@ -147,6 +147,48 @@ from dcc_mcp_maya import (
 
 ---
 
+## Runtime Readiness (issue #184)
+
+Maya's embedded MCP HTTP server publishes itself to the `FileRegistry` long before Maya's main thread has finished booting. Without a readiness signal the gateway happily routes traffic to a Maya whose UI dispatcher has not yet drained its first job — `tools/call` with `affinity: main` accepts the request, queues it, and blocks until the scene finishes loading. Operators see "the service is up, but Maya is frozen".
+
+The adapter publishes a **three-state probe** that `GET /v1/readyz` serves honestly:
+
+| Bit           | Flips to `true` when…                                                                                       |
+|---------------|-------------------------------------------------------------------------------------------------------------|
+| `process`     | Python interpreter is alive (always `true` while the server object exists).                                 |
+| `dispatcher`  | `register_inprocess_executor(...)` has wired the in-process executor.                                       |
+| `dcc`         | Maya's main thread has executed **one** cheap no-op probe scheduled via the UI dispatcher.                  |
+
+Only when all three are `true` does `/v1/readyz` return `200`; otherwise it returns `503`.
+
+Entry points:
+
+| Surface                    | Where                                                                                          |
+|----------------------------|------------------------------------------------------------------------------------------------|
+| Programmatic snapshot      | `MayaMcpServer.readiness_report()` → `{"process": bool, "dispatcher": bool, "dcc": bool}`      |
+| Integration object         | `MayaMcpServer.readiness` → :class:`ReadinessProbe` (tests, diagnostic endpoints)              |
+| Wiring point               | `MayaMcpServer.__init__` / `attach_dispatcher` via `._readiness.install_readiness(server)`     |
+| Forward-compat core publish| `server._config.readiness` — populated automatically when core 0.14.27 exposes the attribute   |
+
+Key Python symbols:
+
+```python
+from dcc_mcp_maya import (
+    ENV_READINESS_TIMEOUT_SECS,      # "DCC_MCP_MAYA_READINESS_TIMEOUT_SECS"
+    ReadinessReport,                 # immutable three-state snapshot
+    StaticReadiness,                 # thread-safe mutable container
+    ReadinessProbe,                  # SOLID binder used by the server
+    install_readiness,               # one-shot helper (mirrors attach_project_tools)
+    resolve_readiness_timeout_secs,  # env-var → Optional[int]
+)
+```
+
+In batch / `mayapy` mode (`MayaStandaloneDispatcher`) the probe flips all-green synchronously on attach — there is no UI event loop to wait on. In interactive Maya the flip happens after the first idle pump tick, so `dcc=true` is an honest "main thread is alive and pumping" signal.
+
+Operator opt-in for a hard timeout: `DCC_MCP_MAYA_READINESS_TIMEOUT_SECS=60` — advisory only; the adapter does not auto-fail the probe when the timeout elapses (a hung Maya is better reported as "still booting" than as a synthetic error).
+
+---
+
 ## Key Conventions
 
 ### Tool Naming
@@ -200,6 +242,7 @@ All other skills appear as `__skill__<name>` stubs. Call `load_skill(name)` to a
 | `DCC_MCP_MAYA_JOB_RECOVERY` | `drop` | `requeue` = resume idempotent jobs on startup. |
 | `DCC_MCP_MAYA_TOOL_EXPOSURE` | — (core default `full`) | Gateway `tools/list` shaping (core 0.14.22 / #652): `full` \| `slim` \| `both` \| `rest`. Invalid values fall back to the inner default. |
 | `DCC_MCP_MAYA_CURSOR_SAFE_TOOL_NAMES` | — (core default `1`) | Toggle Cursor-safe gateway tool names (core 0.14.22 / #656). Set `0` during SEP-986 migration. |
+| `DCC_MCP_MAYA_READINESS_TIMEOUT_SECS` | — | Advisory Maya-side timeout (positive integer seconds) for the runtime readiness probe (issue #184). Consumed by orchestrators that want to bound how long a cold Maya can stall before `/v1/readyz` is considered permanently red. |
 | `DCC_MCP_GATEWAY_PORT` | `9765` | Multi-instance gateway election port. `0` = disable. |
 | `DCC_MCP_REGISTRY_DIR` | OS temp dir | Shared service-discovery registry directory. |
 
@@ -242,6 +285,7 @@ A: `src/dcc_mcp_maya/skills/` (12 packages, 73 scripts). Each package contains `
 | `src/dcc_mcp_maya/_pyexec.py` | Auto-correct `DCC_MCP_PYTHON_EXECUTABLE` (issue #125) |
 | `src/dcc_mcp_maya/_stale_cleanup.py` | Stale FileRegistry detection + warning (issue #126) |
 | `src/dcc_mcp_maya/_project_tools.py` | `register_project_tools` integration — `project.save/load/resume/status` MCP tools (issue #576 / core 0.14.21) |
+| `src/dcc_mcp_maya/_readiness.py` | Three-state readiness probe (`process` / `dispatcher` / `dcc`) — honest `/v1/readyz` signal during Maya boot (issue #184) |
 | `src/dcc_mcp_maya/dispatcher/` | Thread-affinity dispatchers + cancellation (directory module) |
 | `src/dcc_mcp_maya/api.py` | Skill authoring helpers |
 | `src/dcc_mcp_maya/plugin.py` | Maya plugin (`initializePlugin` / menu) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,39 +151,38 @@ from dcc_mcp_maya import (
 
 Maya's embedded MCP HTTP server publishes itself to the `FileRegistry` long before Maya's main thread has finished booting. Without a readiness signal the gateway happily routes traffic to a Maya whose UI dispatcher has not yet drained its first job — `tools/call` with `affinity: main` accepts the request, queues it, and blocks until the scene finishes loading. Operators see "the service is up, but Maya is frozen".
 
-The adapter publishes a **three-state probe** that `GET /v1/readyz` serves honestly:
+The three-state probe itself (`process` / `dispatcher` / `dcc`) lives in `dcc-mcp-core` as `dcc_mcp_core.ReadinessProbe` (core 0.14.28+). `GET /v1/readyz` returns `200` only when all three bits are green; otherwise `503` with a `not-ready` envelope. The Maya adapter owns just the **wiring**:
 
-| Bit           | Flips to `true` when…                                                                                       |
-|---------------|-------------------------------------------------------------------------------------------------------------|
-| `process`     | Python interpreter is alive (always `true` while the server object exists).                                 |
-| `dispatcher`  | `register_inprocess_executor(...)` has wired the in-process executor.                                       |
-| `dcc`         | Maya's main thread has executed **one** cheap no-op probe scheduled via the UI dispatcher.                  |
-
-Only when all three are `true` does `/v1/readyz` return `200`; otherwise it returns `503`.
+| Bit           | Flips to `true` when…                                                                                                               |
+|---------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `process`     | Python interpreter is alive (always `true` while the server object exists — core's default).                                        |
+| `dispatcher`  | `register_inprocess_executor(...)` has wired the in-process executor (unconditional — the binder flips it the moment `__init__` returns). |
+| `dcc`         | A host dispatcher is attached **and** Maya's main thread has pumped one deferred no-op, **or** — in inline executor mode (no host dispatcher, `mayapy` / tests) — immediately, since the HTTP worker thread *is* the pump. |
 
 Entry points:
 
-| Surface                    | Where                                                                                          |
-|----------------------------|------------------------------------------------------------------------------------------------|
-| Programmatic snapshot      | `MayaMcpServer.readiness_report()` → `{"process": bool, "dispatcher": bool, "dcc": bool}`      |
-| Integration object         | `MayaMcpServer.readiness` → :class:`ReadinessProbe` (tests, diagnostic endpoints)              |
-| Wiring point               | `MayaMcpServer.__init__` / `attach_dispatcher` via `._readiness.install_readiness(server)`     |
-| Forward-compat core publish| `server._config.readiness` — populated automatically when core 0.14.27 exposes the attribute   |
+| Surface                    | Where                                                                                              |
+|----------------------------|----------------------------------------------------------------------------------------------------|
+| Programmatic snapshot      | `MayaMcpServer.readiness_report()` → `{"process": bool, "dispatcher": bool, "dcc": bool}`          |
+| Binder object              | `MayaMcpServer.readiness` → `ReadinessBinder` (tests, diagnostic endpoints)                        |
+| Raw core probe             | `MayaMcpServer.readiness.probe` → `dcc_mcp_core.ReadinessProbe`                                    |
+| Wiring point               | `MayaMcpServer.__init__` / `attach_dispatcher` via `._readiness.install_readiness(server)`          |
+| Core publish               | `server._server.set_readiness_probe(probe)` — called automatically by `ReadinessBinder.bind`       |
 
 Key Python symbols:
 
 ```python
 from dcc_mcp_maya import (
     ENV_READINESS_TIMEOUT_SECS,      # "DCC_MCP_MAYA_READINESS_TIMEOUT_SECS"
-    ReadinessReport,                 # immutable three-state snapshot
-    StaticReadiness,                 # thread-safe mutable container
-    ReadinessProbe,                  # SOLID binder used by the server
+    ReadinessBinder,                 # Maya-side lifecycle binder (wraps core ReadinessProbe)
     install_readiness,               # one-shot helper (mirrors attach_project_tools)
     resolve_readiness_timeout_secs,  # env-var → Optional[int]
 )
+# The three-state probe itself comes from core:
+from dcc_mcp_core import ReadinessProbe
 ```
 
-In batch / `mayapy` mode (`MayaStandaloneDispatcher`) the probe flips all-green synchronously on attach — there is no UI event loop to wait on. In interactive Maya the flip happens after the first idle pump tick, so `dcc=true` is an honest "main thread is alive and pumping" signal.
+In batch / `mayapy` mode (`MayaStandaloneDispatcher` attached, or no host dispatcher at all — i.e. inline executor mode) the probe lands all-green synchronously — there is no UI event loop to wait on. In interactive Maya with a real UI dispatcher, the `dcc` bit flips after the first idle pump tick, so `dcc=true` is an honest "main thread is alive and pumping" signal.
 
 Operator opt-in for a hard timeout: `DCC_MCP_MAYA_READINESS_TIMEOUT_SECS=60` — advisory only; the adapter does not auto-fail the probe when the timeout elapses (a hung Maya is better reported as "still booting" than as a synthetic error).
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -451,6 +451,7 @@ tools:
 | `DCC_MCP_MAYA_HOT_RELOAD` | `0` | per-process | `1`=watch bundled skills for edit-on-disk reload. |
 | `DCC_MCP_MAYA_ENABLE_GATEWAY_FAILOVER` | `1` | per-process | Auto-promote on gateway loss. |
 | `DCC_MCP_MAYA_DCC_PID` | `os.getpid()` | per-process | PID advertised to gateway for diagnostics routing. |
+| `DCC_MCP_MAYA_READINESS_TIMEOUT_SECS` | — | per-process | Advisory timeout (positive integer seconds) for the three-state readiness probe (issue #184). Consumed by orchestrators; never auto-fails the probe on its own. |
 | `DCC_MCP_GATEWAY_PORT` | `9765` | per-host | Gateway election port. `0`=disable gateway mode. |
 | `DCC_MCP_REGISTRY_DIR` | OS temp dir | per-user | Shared FileRegistry directory. |
 | `DCC_MCP_PYTHON_EXECUTABLE` | `sys.executable` | per-process | Python interpreter for skill worker subprocesses. |

--- a/llms.txt
+++ b/llms.txt
@@ -112,6 +112,13 @@ Project-state persistence (issue #576 / core 0.14.21):
 * `dcc_mcp_maya._project_tools.attach_to_server(server)` — registers `project.save / project.load / project.resume / project.status` MCP tools that persist scene state to `<scene_dir>/.dcc-mcp/project.json`.  Auto-invoked by `register_builtin_actions()`; opt out with `DCC_MCP_MAYA_PROJECT_TOOLS=0`.
 * Public symbols: `ProjectToolsIntegration`, `MayaSceneResolver`, `attach_project_tools`, `ENV_PROJECT_TOOLS`.
 
+Runtime readiness probe (issue #184):
+
+* `server.readiness_report()` → `{"process": bool, "dispatcher": bool, "dcc": bool}` — honest three-state signal for `GET /v1/readyz` so orchestrators stop trusting the always-green default during Maya's boot window.  `process` starts `True`; `dispatcher` flips `True` after `register_inprocess_executor(...)`; `dcc` flips `True` after Maya's main thread pumps the first deferred no-op (synchronous on `MayaStandaloneDispatcher`).
+* Opt-in advisory timeout: `DCC_MCP_MAYA_READINESS_TIMEOUT_SECS=<positive int>` — consumed by orchestrators, never auto-fails the probe.
+* Public symbols: `ReadinessReport`, `StaticReadiness`, `ReadinessProbe`, `install_readiness`, `resolve_readiness_timeout_secs`, `ENV_READINESS_TIMEOUT_SECS`.
+
+
 ---
 
 ## Skill Authoring Helpers (api.py)

--- a/llms.txt
+++ b/llms.txt
@@ -112,7 +112,7 @@ Project-state persistence (issue #576 / core 0.14.21):
 * `dcc_mcp_maya._project_tools.attach_to_server(server)` — registers `project.save / project.load / project.resume / project.status` MCP tools that persist scene state to `<scene_dir>/.dcc-mcp/project.json`.  Auto-invoked by `register_builtin_actions()`; opt out with `DCC_MCP_MAYA_PROJECT_TOOLS=0`.
 * Public symbols: `ProjectToolsIntegration`, `MayaSceneResolver`, `attach_project_tools`, `ENV_PROJECT_TOOLS`.
 
-Runtime readiness wiring (issue #184, requires `dcc-mcp-core>=0.14.28`):
+Runtime readiness wiring (issue #184, requires `dcc-mcp-core>=0.15.0`; API landed in 0.14.28):
 
 * Maya adapter owns the *wiring*; the three-state probe itself lives in core as `dcc_mcp_core.ReadinessProbe`.  Published to the inner Rust server via `McpHttpServer.set_readiness_probe(probe)` so `GET /v1/readyz` serves honest values (`200` only when all three bits green, `503` + `not-ready` envelope otherwise — core also rejects `tools/call` with `BACKEND_NOT_READY (-32002)` when not ready).
 * `server.readiness_report()` → `{"process": bool, "dispatcher": bool, "dcc": bool}` shorthand.  `server.readiness` → `ReadinessBinder`; `server.readiness.probe` → the underlying `dcc_mcp_core.ReadinessProbe`.

--- a/llms.txt
+++ b/llms.txt
@@ -112,11 +112,13 @@ Project-state persistence (issue #576 / core 0.14.21):
 * `dcc_mcp_maya._project_tools.attach_to_server(server)` — registers `project.save / project.load / project.resume / project.status` MCP tools that persist scene state to `<scene_dir>/.dcc-mcp/project.json`.  Auto-invoked by `register_builtin_actions()`; opt out with `DCC_MCP_MAYA_PROJECT_TOOLS=0`.
 * Public symbols: `ProjectToolsIntegration`, `MayaSceneResolver`, `attach_project_tools`, `ENV_PROJECT_TOOLS`.
 
-Runtime readiness probe (issue #184):
+Runtime readiness wiring (issue #184, requires `dcc-mcp-core>=0.14.28`):
 
-* `server.readiness_report()` → `{"process": bool, "dispatcher": bool, "dcc": bool}` — honest three-state signal for `GET /v1/readyz` so orchestrators stop trusting the always-green default during Maya's boot window.  `process` starts `True`; `dispatcher` flips `True` after `register_inprocess_executor(...)`; `dcc` flips `True` after Maya's main thread pumps the first deferred no-op (synchronous on `MayaStandaloneDispatcher`).
+* Maya adapter owns the *wiring*; the three-state probe itself lives in core as `dcc_mcp_core.ReadinessProbe`.  Published to the inner Rust server via `McpHttpServer.set_readiness_probe(probe)` so `GET /v1/readyz` serves honest values (`200` only when all three bits green, `503` + `not-ready` envelope otherwise — core also rejects `tools/call` with `BACKEND_NOT_READY (-32002)` when not ready).
+* `server.readiness_report()` → `{"process": bool, "dispatcher": bool, "dcc": bool}` shorthand.  `server.readiness` → `ReadinessBinder`; `server.readiness.probe` → the underlying `dcc_mcp_core.ReadinessProbe`.
+* Transitions: `process` starts `True` (core default); `dispatcher` flips `True` the moment `MayaMcpServer.__init__` returns (executor always wired by then, whether inline or through a host dispatcher); `dcc` flips `True` synchronously in inline-executor mode (no host dispatcher — `mayapy` / tests) or after the first main-thread pump when a real host dispatcher is attached.
 * Opt-in advisory timeout: `DCC_MCP_MAYA_READINESS_TIMEOUT_SECS=<positive int>` — consumed by orchestrators, never auto-fails the probe.
-* Public symbols: `ReadinessReport`, `StaticReadiness`, `ReadinessProbe`, `install_readiness`, `resolve_readiness_timeout_secs`, `ENV_READINESS_TIMEOUT_SECS`.
+* Maya public symbols: `ReadinessBinder`, `install_readiness`, `resolve_readiness_timeout_secs`, `ENV_READINESS_TIMEOUT_SECS`.  Core public symbols used here: `dcc_mcp_core.ReadinessProbe` (with `set_dispatcher_ready` / `set_dcc_ready` / `report` / `is_ready` / `fully_ready`).
 
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,16 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.14.28 ships the three-state ``ReadinessProbe`` + ``McpHttpServer.set_readiness_probe``
-    # surface required by the runtime-readiness wiring (issue #184).  0.14.23 added the
-    # cross-DCC HostAdapter/QueueDispatcher surface and real per-DCC REST skill endpoints
-    # used by MayaHost, maya_bootstrap, and the /v1/search /v1/describe /v1/call
-    # regression tests — still needed, just rolled into the newer floor.
-    "dcc-mcp-core>=0.14.28,<1.0.0",
+    # 0.15.0 is the SOLID crate split release (``dcc-mcp-jsonrpc`` /
+    # ``dcc-mcp-job`` / ``dcc-mcp-skill-rest`` / ``dcc-mcp-gateway``) — behaviour-
+    # preserving via ``pub use`` aliases so existing imports keep working.
+    # 0.14.28 shipped the three-state ``ReadinessProbe`` +
+    # ``McpHttpServer.set_readiness_probe`` surface required by the runtime-
+    # readiness wiring (issue #184); 0.14.23 added the cross-DCC HostAdapter /
+    # QueueDispatcher surface and real per-DCC REST skill endpoints used by
+    # MayaHost, maya_bootstrap, and the /v1/search /v1/describe /v1/call
+    # regression tests.  All rolled into the 0.15.0 floor below.
+    "dcc-mcp-core>=0.15.0,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,12 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.14.23 adds the cross-DCC HostAdapter/QueueDispatcher surface and
-    # real per-DCC REST skill endpoints used by MayaHost, maya_bootstrap,
-    # and the /v1/search /v1/describe /v1/call regression tests.
-    "dcc-mcp-core>=0.14.23,<1.0.0",
+    # 0.14.28 ships the three-state ``ReadinessProbe`` + ``McpHttpServer.set_readiness_probe``
+    # surface required by the runtime-readiness wiring (issue #184).  0.14.23 added the
+    # cross-DCC HostAdapter/QueueDispatcher surface and real per-DCC REST skill endpoints
+    # used by MayaHost, maya_bootstrap, and the /v1/search /v1/describe /v1/call
+    # regression tests — still needed, just rolled into the newer floor.
+    "dcc-mcp-core>=0.14.28,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_maya/__init__.py
+++ b/src/dcc_mcp_maya/__init__.py
@@ -48,6 +48,14 @@ from dcc_mcp_maya._project_tools import (
 from dcc_mcp_maya._project_tools import (
     attach_to_server as attach_project_tools,
 )
+from dcc_mcp_maya._readiness import (
+    ENV_READINESS_TIMEOUT_SECS,
+    ReadinessProbe,
+    ReadinessReport,
+    StaticReadiness,
+    install_readiness,
+    resolve_readiness_timeout_secs,
+)
 from dcc_mcp_maya.api import (
     MissingParamError,
     batch_validate_nodes,
@@ -167,4 +175,11 @@ __all__ = [
     "VALID_TOOL_EXPOSURE_MODES",
     "resolve_tool_exposure",
     "resolve_cursor_safe_tool_names",
+    # Runtime readiness probe (issue #184)
+    "ENV_READINESS_TIMEOUT_SECS",
+    "ReadinessProbe",
+    "ReadinessReport",
+    "StaticReadiness",
+    "install_readiness",
+    "resolve_readiness_timeout_secs",
 ]

--- a/src/dcc_mcp_maya/__init__.py
+++ b/src/dcc_mcp_maya/__init__.py
@@ -50,9 +50,7 @@ from dcc_mcp_maya._project_tools import (
 )
 from dcc_mcp_maya._readiness import (
     ENV_READINESS_TIMEOUT_SECS,
-    ReadinessProbe,
-    ReadinessReport,
-    StaticReadiness,
+    ReadinessBinder,
     install_readiness,
     resolve_readiness_timeout_secs,
 )
@@ -175,11 +173,12 @@ __all__ = [
     "VALID_TOOL_EXPOSURE_MODES",
     "resolve_tool_exposure",
     "resolve_cursor_safe_tool_names",
-    # Runtime readiness probe (issue #184)
+    # Runtime readiness (issue #184) — Maya-side binder wrapping
+    # ``dcc_mcp_core.ReadinessProbe`` (core 0.14.28+).  The three-state
+    # probe itself comes from core; import directly when you need it:
+    #   from dcc_mcp_core import ReadinessProbe
     "ENV_READINESS_TIMEOUT_SECS",
-    "ReadinessProbe",
-    "ReadinessReport",
-    "StaticReadiness",
+    "ReadinessBinder",
     "install_readiness",
     "resolve_readiness_timeout_secs",
 ]

--- a/src/dcc_mcp_maya/_readiness.py
+++ b/src/dcc_mcp_maya/_readiness.py
@@ -1,0 +1,492 @@
+"""Runtime readiness probe wiring for :class:`MayaMcpServer` (issue #184).
+
+Maya's embedded MCP HTTP server publishes itself to the ``FileRegistry``
+long before Maya's main thread has finished booting.  During that window
+``list_dcc_instances`` happily reports ``status: "available"``, any
+``tools/call`` with ``affinity: main`` is accepted and then **blocks**
+until Maya's main thread is pumping, and the gateway's first
+auto-aggregation probe fails with "not a DCC MCP HTTP endpoint" because
+the fresh HTTP listener has not answered its first request yet.
+
+The upstream design (see the issue) is a three-state readiness probe —
+``process`` / ``dispatcher`` / ``dcc`` — that the Rust skill-REST layer
+serves via ``/v1/readyz``.  The Maya adapter owns the ``dispatcher`` and
+``dcc`` transitions:
+
+* ``dispatcher = true``  — after :meth:`register_inprocess_executor` has
+  wired the in-process executor.
+* ``dcc = true``         — after Maya's main thread has executed **one**
+  cheap no-op job that we schedule via the UI dispatcher.  In
+  ``mayapy`` / batch mode (``MayaStandaloneDispatcher``) this flips
+  synchronously because every submit runs on the calling thread.
+
+Core-side exposure
+------------------
+Until ``dcc-mcp-core`` exposes the ``StaticReadiness`` Python binding
+(pending in 0.14.27), the Maya adapter still drives an **in-process**
+readiness report.  Callers (tests, ``ReadinessProbe.report``) can consult
+it directly.  When core ships the binding, :func:`ReadinessProbe.bind`
+will detect the config attribute and publish the report to the Rust
+layer in one line — no surrounding code changes required.
+
+SOLID notes
+-----------
+* **Single Responsibility** — this module *only* tracks and publishes
+  the three readiness bits; it never owns lifecycle or dispatcher state
+  (those stay on :class:`MayaMcpServer`).
+* **Open/Closed** — the dispatcher-probe strategy is injectable
+  (:attr:`ReadinessProbe.probe_scheduler`), so tests can verify the
+  flip without running a live Maya event loop.
+* **Dependency Inversion** — ``register_inprocess_executor`` /
+  ``submit_async_callable`` are looked up *on the passed object*, not
+  imported at module scope, so an older core wheel or a fake dispatcher
+  in a unit test is fully supported.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Environment variable that bounds how long orchestrators are willing
+#: to wait for a cold Maya before readiness is considered red.  Parsed
+#: as a positive integer number of seconds.  Unset → no Maya-side
+#: timeout; the gateway / orchestrator decides.
+ENV_READINESS_TIMEOUT_SECS = "DCC_MCP_MAYA_READINESS_TIMEOUT_SECS"
+
+#: Request ID used for the no-op probe job scheduled on the UI
+#: dispatcher.  Kept stable so operators grepping the Maya log can
+#: correlate the "readiness flip" line with the exact job.
+READINESS_PROBE_REQUEST_ID = "dcc_mcp_maya__readiness__dcc_ready_probe"
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReadinessReport:
+    """Immutable three-state readiness snapshot.
+
+    Mirrors the core-side ``ReadinessReport`` struct so the Maya adapter
+    can serve honest values via the same REST contract
+    (``GET /v1/readyz`` → ``{"process": ..., "dispatcher": ..., "dcc": ...}``).
+    ``process`` is always ``True`` on the adapter side: when this object
+    is alive, the Python interpreter is alive, so the HTTP listener's
+    in-process plumbing has been spun up.  The gateway still gets to
+    veto (e.g. port bind failed) via its own probe.
+    """
+
+    process: bool = True
+    dispatcher: bool = False
+    dcc: bool = False
+
+    def is_ready(self) -> bool:
+        """Return ``True`` when all three bits are green."""
+        return self.process and self.dispatcher and self.dcc
+
+    def to_dict(self) -> dict:
+        """Return a plain ``dict`` suitable for JSON serialisation."""
+        return {
+            "process": self.process,
+            "dispatcher": self.dispatcher,
+            "dcc": self.dcc,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Mutable static readiness (Python analogue of the Rust ``StaticReadiness``)
+# ---------------------------------------------------------------------------
+
+
+class StaticReadiness:
+    """Thread-safe mutable readiness container.
+
+    The two setters are idempotent — flipping to ``True`` twice is a
+    no-op; flipping back to ``False`` is accepted (callers that want to
+    re-arm the probe after a Maya scene reload can do so).  A single
+    ``threading.Lock`` guards the three booleans; the readers (``report``)
+    take a short critical section and return an immutable dataclass.
+
+    This class exists because core 0.14.23 / 0.14.26 do not yet expose
+    a Python binding for their Rust ``StaticReadiness``.  Once the
+    binding lands (tracked in core 0.14.27, see
+    ``dcc-mcp-maya#184``) the Maya side can adopt the binding without
+    changing the surface any caller of this module relies on — the two
+    classes are intentionally shape-compatible.
+    """
+
+    def __init__(
+        self,
+        *,
+        process: bool = True,
+        dispatcher: bool = False,
+        dcc: bool = False,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._process = bool(process)
+        self._dispatcher = bool(dispatcher)
+        self._dcc = bool(dcc)
+
+    # ── Mutations ─────────────────────────────────────────────────────
+
+    def set_dispatcher_ready(self, value: bool) -> None:
+        """Flip the ``dispatcher`` bit."""
+        with self._lock:
+            self._dispatcher = bool(value)
+
+    def set_dcc_ready(self, value: bool) -> None:
+        """Flip the ``dcc`` bit."""
+        with self._lock:
+            self._dcc = bool(value)
+
+    def set_process_ready(self, value: bool) -> None:
+        """Flip the ``process`` bit (rarely useful from Python side)."""
+        with self._lock:
+            self._process = bool(value)
+
+    # ── Reads ──────────────────────────────────────────────────────────
+
+    def report(self) -> ReadinessReport:
+        """Return an immutable snapshot of the three bits."""
+        with self._lock:
+            return ReadinessReport(
+                process=self._process,
+                dispatcher=self._dispatcher,
+                dcc=self._dcc,
+            )
+
+    def is_ready(self) -> bool:
+        """Convenience for ``self.report().is_ready()`` — single lock take."""
+        with self._lock:
+            return self._process and self._dispatcher and self._dcc
+
+    @classmethod
+    def fully_ready(cls) -> "StaticReadiness":
+        """Return an all-green probe — matches the core-side constructor.
+
+        Mostly useful in tests that want to bypass the probe entirely.
+        Startup code should instead build ``StaticReadiness()`` (which
+        defaults to ``dispatcher=False, dcc=False``) and let the probe
+        flip the bits as each subsystem comes online.
+        """
+        return cls(process=True, dispatcher=True, dcc=True)
+
+
+# ---------------------------------------------------------------------------
+# Env-var resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_readiness_timeout_secs(
+    readiness_timeout_secs: Optional[int] = None,
+) -> Optional[int]:
+    """Resolve :data:`ENV_READINESS_TIMEOUT_SECS` into a positive integer.
+
+    Priority: explicit argument > env var > ``None``.  ``None`` means
+    "no Maya-side timeout — let the orchestrator decide".  Invalid
+    values (non-integer, ``<= 0``) collapse to ``None`` and log a
+    warning so a typo never kills startup.
+    """
+    if readiness_timeout_secs is not None:
+        try:
+            val = int(readiness_timeout_secs)
+        except (TypeError, ValueError):
+            return None
+        return val if val > 0 else None
+
+    raw = os.environ.get(ENV_READINESS_TIMEOUT_SECS)
+    if raw is None:
+        return None
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        val = int(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid %s=%r (expected positive integer seconds)",
+            ENV_READINESS_TIMEOUT_SECS,
+            raw,
+        )
+        return None
+    if val <= 0:
+        logger.warning(
+            "Ignoring non-positive %s=%r (expected positive integer seconds)",
+            ENV_READINESS_TIMEOUT_SECS,
+            raw,
+        )
+        return None
+    return val
+
+
+# ---------------------------------------------------------------------------
+# Integration object — binds the probe to a :class:`MayaMcpServer`
+# ---------------------------------------------------------------------------
+
+
+ProbeScheduler = Callable[[Any, Callable[[], None]], bool]
+"""Dispatcher-agnostic scheduler: ``(dispatcher, on_done) -> scheduled?``.
+
+Returns ``True`` when ``on_done`` is guaranteed to eventually be called
+(either synchronously on standalone dispatchers, or after the next pump
+cycle on UI dispatchers).  Returns ``False`` when the dispatcher is a
+shape we do not recognise and the caller should leave ``dcc`` red.
+"""
+
+
+def _default_probe_scheduler(dispatcher: Any, on_done: Callable[[], None]) -> bool:
+    """Submit a no-op job on *dispatcher* and flip ``dcc`` in its callback.
+
+    We prefer :meth:`submit_async_callable` because it's non-blocking —
+    the caller returns immediately and the callback fires on the UI
+    thread once Maya finishes booting.  On :class:`MayaStandaloneDispatcher`
+    the callback fires synchronously on the calling thread, which
+    mirrors the "dcc is ready the moment we're in mayapy" contract.
+
+    The ``on_complete`` callback signature accepts a result dict per the
+    upstream contract; we ignore the payload because we only care about
+    the fact that the main thread executed *something*.
+    """
+    submit_async = getattr(dispatcher, "submit_async_callable", None)
+    if submit_async is None:
+        # Older dispatchers that only expose ``submit_callable`` block
+        # the caller — that would stall server startup, so we refuse to
+        # downgrade and let the probe stay red.
+        logger.debug(
+            "readiness: dispatcher %r has no submit_async_callable; leaving dcc=false",
+            type(dispatcher).__name__,
+        )
+        return False
+
+    def _on_complete(_result: Any) -> None:  # noqa: ARG001 — signature contract
+        try:
+            on_done()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("readiness: dcc-ready callback raised: %s", exc)
+
+    try:
+        submit_async(
+            request_id=READINESS_PROBE_REQUEST_ID,
+            task=lambda: None,
+            affinity="main",
+            timeout_ms=5_000,
+            on_complete=_on_complete,
+        )
+    except TypeError:
+        # Core 0.14.23 dispatchers that don't accept ``on_complete`` as
+        # a kwarg — retry without it and poll the dispatcher instead.
+        try:
+            submit_async(
+                request_id=READINESS_PROBE_REQUEST_ID,
+                task=lambda: None,
+                affinity="main",
+                timeout_ms=5_000,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("readiness: submit_async_callable fallback failed: %s", exc)
+            return False
+        # Best-effort: we can't confirm the main thread actually ran
+        # the probe, so leave ``dcc`` red.  Callers that want a hard
+        # signal should use a dispatcher that supports ``on_complete``.
+        return False
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("readiness: submit_async_callable raised: %s", exc)
+        return False
+    return True
+
+
+class ReadinessProbe:
+    """Drive the three readiness bits across a :class:`MayaMcpServer` lifecycle.
+
+    Usage (called once from ``server.register_builtin_actions``)::
+
+        probe = ReadinessProbe()
+        probe.bind(server)
+        # ``probe.report()`` now transitions through:
+        #   dispatcher=False, dcc=False   (construction)
+        # → dispatcher=True,  dcc=False   (after executor is attached)
+        # → dispatcher=True,  dcc=True    (after first main-thread pump)
+
+    All transitions are idempotent — calling :meth:`bind` twice is safe
+    (the second call is a no-op on the same server).
+
+    Parameters
+    ----------
+    timeout_secs:
+        Advisory Maya-side timeout (seconds) for how long a cold Maya
+        can stall before callers should consider ``dcc`` permanently
+        red.  Consumed by orchestration layers; this class does *not*
+        auto-fail the probe when the timeout elapses — a hung Maya is
+        better reported as "still booting" than as a synthetic error.
+    probe_scheduler:
+        Strategy for scheduling the dcc-ready probe on the attached
+        dispatcher.  Override in tests to avoid depending on a real
+        :class:`MayaUiDispatcher` pump.
+    """
+
+    def __init__(
+        self,
+        *,
+        timeout_secs: Optional[int] = None,
+        probe_scheduler: Optional[ProbeScheduler] = None,
+    ) -> None:
+        self.timeout_secs: Optional[int] = resolve_readiness_timeout_secs(
+            timeout_secs,
+        )
+        self.readiness: StaticReadiness = StaticReadiness()
+        self.probe_scheduler: ProbeScheduler = probe_scheduler or _default_probe_scheduler
+        # Populated by :meth:`bind` so tests can assert what we wired.
+        self.bound_server: Any = None
+        self.bound_dispatcher: Any = None
+        self.dcc_scheduled: bool = False
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    def report(self) -> ReadinessReport:
+        """Return the current immutable readiness snapshot."""
+        return self.readiness.report()
+
+    def bind(self, server: Any) -> bool:
+        """Wire the probe into *server*.
+
+        Steps:
+
+        1. If the server already has a live dispatcher
+           (``server._maya_dispatcher`` is not ``None``), flip
+           ``dispatcher=True`` immediately.  Otherwise :meth:`bind`
+           returns having only wired what's possible; callers may
+           re-invoke :meth:`mark_dispatcher_ready` once the dispatcher
+           shows up.
+        2. Publish :attr:`readiness` to the inner Rust config when the
+           currently-installed ``dcc-mcp-core`` wheel exposes the
+           ``readiness`` attribute on :class:`McpHttpConfig`.  Today
+           (core 0.14.23 / 0.14.26) that attribute does not exist; the
+           call is a silent no-op and will light up automatically when
+           core 0.14.27 ships the Python binding.  The Maya-side
+           in-process report remains authoritative for tests regardless.
+        3. Schedule a no-op probe on the attached dispatcher so the
+           first main-thread pump flips ``dcc=True``.  On
+           :class:`MayaStandaloneDispatcher` this callback fires
+           synchronously, so the flip is observed immediately.
+
+        Returns
+        -------
+        bool
+            ``True`` when binding fully succeeded (dispatcher already
+            live and dcc probe scheduled).  ``False`` when the server
+            has no dispatcher yet or the probe couldn't be scheduled —
+            the readiness object is still usable and may be advanced
+            later via :meth:`mark_dispatcher_ready` and
+            :meth:`mark_dcc_ready`.
+        """
+        if self.bound_server is server:
+            return self.dcc_scheduled
+        self.bound_server = server
+
+        # Step 2 — publish to the inner Rust config if supported.
+        self._maybe_publish_to_config(server)
+
+        # Step 1 — dispatcher attached already?
+        dispatcher = getattr(server, "_maya_dispatcher", None)
+        if dispatcher is None:
+            dispatcher = getattr(server, "_host_dispatcher", None)
+        if dispatcher is None:
+            logger.debug(
+                "readiness.bind: no dispatcher attached to %r yet; dispatcher/dcc stay red until one is wired",
+                type(server).__name__,
+            )
+            return False
+
+        self.bound_dispatcher = dispatcher
+        self.mark_dispatcher_ready()
+
+        # Step 3 — schedule the dcc probe.
+        scheduled = self.probe_scheduler(dispatcher, self.mark_dcc_ready)
+        self.dcc_scheduled = bool(scheduled)
+        if not scheduled:
+            logger.debug(
+                "readiness.bind: dispatcher %r did not accept the probe; dcc stays red until another trigger flips it",
+                type(dispatcher).__name__,
+            )
+        return self.dcc_scheduled
+
+    def mark_dispatcher_ready(self, value: bool = True) -> None:
+        """Flip the ``dispatcher`` bit.  Idempotent."""
+        self.readiness.set_dispatcher_ready(value)
+        if value:
+            logger.debug("readiness: dispatcher=true")
+
+    def mark_dcc_ready(self, value: bool = True) -> None:
+        """Flip the ``dcc`` bit.  Typically called from the probe callback."""
+        self.readiness.set_dcc_ready(value)
+        if value:
+            logger.info("[maya] readiness: dcc-ready — main thread is pumping")
+
+    # ── Internals ───────────────────────────────────────────────────────
+
+    def _maybe_publish_to_config(self, server: Any) -> bool:
+        """Best-effort publish of :attr:`readiness` to ``server._config``.
+
+        Core 0.14.27 is expected to expose a ``readiness`` attribute on
+        :class:`dcc_mcp_core.McpHttpConfig` (tracked by the companion
+        core issue cited in #184).  Until then this method is a silent
+        no-op — the Maya adapter still tracks readiness in-process for
+        tests and any REST surface the adapter owns directly.
+
+        Returns
+        -------
+        bool
+            ``True`` when the config attribute was set successfully;
+            ``False`` otherwise.  Failures are logged at debug level to
+            keep startup quiet on older core wheels.
+        """
+        config = getattr(server, "_config", None)
+        if config is None:
+            return False
+        # Inspect the attribute without touching it — ``hasattr`` also
+        # guards against property getters that raise.
+        if not hasattr(config, "readiness"):
+            return False
+        try:
+            setattr(config, "readiness", self.readiness)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "readiness: could not publish probe to inner config: %s",
+                exc,
+            )
+            return False
+        logger.debug("readiness: probe published to inner Rust config")
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience
+# ---------------------------------------------------------------------------
+
+
+def install_readiness(
+    server: Any,
+    *,
+    timeout_secs: Optional[int] = None,
+    probe_scheduler: Optional[ProbeScheduler] = None,
+) -> ReadinessProbe:
+    """One-shot helper used by :class:`MayaMcpServer.register_builtin_actions`.
+
+    Always returns a :class:`ReadinessProbe` — even when binding fails
+    (no dispatcher yet, older core, etc.) — so callers can stash the
+    probe on the server and consult :meth:`ReadinessProbe.report` from
+    tests or diagnostic endpoints.
+    """
+    probe = ReadinessProbe(
+        timeout_secs=timeout_secs,
+        probe_scheduler=probe_scheduler,
+    )
+    probe.bind(server)
+    return probe

--- a/src/dcc_mcp_maya/_readiness.py
+++ b/src/dcc_mcp_maya/_readiness.py
@@ -8,9 +8,10 @@ until Maya's main thread pumps, and the gateway's first auto-aggregation
 probe fails with *"not a DCC MCP HTTP endpoint"* because the fresh HTTP
 listener has not answered its first request yet.
 
-Core 0.14.28 ships the three-state probe in Rust and exposes the Python
-binding (``dcc_mcp_core.ReadinessProbe`` + ``McpHttpServer.set_readiness_probe``).
-This module owns the **Maya-specific** half of the contract:
+Core 0.14.28 first exposed the three-state probe in Rust and its Python
+binding (``dcc_mcp_core.ReadinessProbe`` + ``McpHttpServer.set_readiness_probe``);
+``pyproject.toml`` now pins the floor at 0.15.0, the SOLID crate-split
+release.  This module owns the **Maya-specific** half of the contract:
 
 * flip ``dispatcher = true`` the moment the in-process executor is wired;
 * schedule a cheap no-op job on the UI dispatcher and flip ``dcc = true``

--- a/src/dcc_mcp_maya/_readiness.py
+++ b/src/dcc_mcp_maya/_readiness.py
@@ -115,25 +115,34 @@ UI dispatchers).
 
 
 def _default_probe_scheduler(dispatcher: Any, on_done: Callable[[], None]) -> bool:
-    """Submit a no-op job on *dispatcher* and flip ``dcc`` in its callback.
+    """Schedule a dcc-ready probe on *dispatcher*.
 
-    We use :meth:`submit_async_callable` because it's non-blocking — the
-    caller returns immediately and the callback fires on the UI thread
-    once Maya pumps.  On :class:`MayaStandaloneDispatcher` the callback
-    fires synchronously on the calling thread, which mirrors the "dcc is
-    ready the moment we're in mayapy" contract.
+    Two dispatcher shapes are in play at runtime:
 
-    Every dispatcher shipped by this package
-    (:class:`MayaUiDispatcher` / :class:`MayaStandaloneDispatcher` /
-    :class:`MayaCallableDispatcher`) implements the full core 0.14.28
-    :class:`BaseDccCallableDispatcherFull` protocol, so no fallback
-    branches are needed.
+    * **Full callable protocol** (:class:`MayaUiDispatcher` /
+      :class:`MayaStandaloneDispatcher`): implements
+      :meth:`submit_async_callable` with an ``on_complete`` callback.
+      Submit a no-op job at ``affinity="main"`` and flip ``dcc`` from
+      the callback — guaranteeing the bit only flips after Maya's
+      main thread has actually pumped one job.
+    * **Post/tick protocol** (core's ``BlockingDispatcher`` /
+      ``QueueDispatcher`` attached via the plugin bootstrap): no
+      ``submit_async_callable`` hook and no per-job callback API, so
+      we trust the dispatcher to pump correctly and flip ``dcc``
+      immediately.  The alternative — leaving ``dcc`` red forever —
+      would make ``/v1/readyz`` return 503 for every real-world
+      plugin-driven server.
     """
+    submit_async = getattr(dispatcher, "submit_async_callable", None)
+    if submit_async is None:
+        # Post/tick-style dispatcher — flip optimistically.
+        on_done()
+        return True
 
     def _on_complete(_result: Any) -> None:  # noqa: ARG001 — signature contract
         on_done()
 
-    dispatcher.submit_async_callable(
+    submit_async(
         request_id=READINESS_PROBE_REQUEST_ID,
         task=lambda: None,
         affinity="main",

--- a/src/dcc_mcp_maya/_readiness.py
+++ b/src/dcc_mcp_maya/_readiness.py
@@ -1,55 +1,46 @@
-"""Runtime readiness probe wiring for :class:`MayaMcpServer` (issue #184).
+"""Runtime readiness wiring for :class:`MayaMcpServer` (issue #184).
 
 Maya's embedded MCP HTTP server publishes itself to the ``FileRegistry``
 long before Maya's main thread has finished booting.  During that window
-``list_dcc_instances`` happily reports ``status: "available"``, any
+``list_dcc_instances`` reports ``status: "available"``, any
 ``tools/call`` with ``affinity: main`` is accepted and then **blocks**
-until Maya's main thread is pumping, and the gateway's first
-auto-aggregation probe fails with "not a DCC MCP HTTP endpoint" because
-the fresh HTTP listener has not answered its first request yet.
+until Maya's main thread pumps, and the gateway's first auto-aggregation
+probe fails with *"not a DCC MCP HTTP endpoint"* because the fresh HTTP
+listener has not answered its first request yet.
 
-The upstream design (see the issue) is a three-state readiness probe —
-``process`` / ``dispatcher`` / ``dcc`` — that the Rust skill-REST layer
-serves via ``/v1/readyz``.  The Maya adapter owns the ``dispatcher`` and
-``dcc`` transitions:
+Core 0.14.28 ships the three-state probe in Rust and exposes the Python
+binding (``dcc_mcp_core.ReadinessProbe`` + ``McpHttpServer.set_readiness_probe``).
+This module owns the **Maya-specific** half of the contract:
 
-* ``dispatcher = true``  — after :meth:`register_inprocess_executor` has
-  wired the in-process executor.
-* ``dcc = true``         — after Maya's main thread has executed **one**
-  cheap no-op job that we schedule via the UI dispatcher.  In
-  ``mayapy`` / batch mode (``MayaStandaloneDispatcher``) this flips
-  synchronously because every submit runs on the calling thread.
-
-Core-side exposure
-------------------
-Until ``dcc-mcp-core`` exposes the ``StaticReadiness`` Python binding
-(pending in 0.14.27), the Maya adapter still drives an **in-process**
-readiness report.  Callers (tests, ``ReadinessProbe.report``) can consult
-it directly.  When core ships the binding, :func:`ReadinessProbe.bind`
-will detect the config attribute and publish the report to the Rust
-layer in one line — no surrounding code changes required.
+* flip ``dispatcher = true`` the moment the in-process executor is wired;
+* schedule a cheap no-op job on the UI dispatcher and flip ``dcc = true``
+  from its completion callback — guaranteeing that ``dcc`` is only green
+  once Maya's main thread has actually pumped one job;
+* expose an env knob (:data:`ENV_READINESS_TIMEOUT_SECS`) so orchestrators
+  can bound how long a cold Maya may stall before they consider
+  ``/v1/readyz`` permanently red.
 
 SOLID notes
 -----------
-* **Single Responsibility** — this module *only* tracks and publishes
-  the three readiness bits; it never owns lifecycle or dispatcher state
-  (those stay on :class:`MayaMcpServer`).
+* **Single Responsibility** — this module *only* wires Maya lifecycle
+  events onto a :class:`dcc_mcp_core.ReadinessProbe`; it owns neither the
+  probe's state (Rust does) nor the dispatcher (:class:`MayaMcpServer`
+  does).
 * **Open/Closed** — the dispatcher-probe strategy is injectable
-  (:attr:`ReadinessProbe.probe_scheduler`), so tests can verify the
+  (:attr:`ReadinessBinder.probe_scheduler`), so tests can verify the
   flip without running a live Maya event loop.
-* **Dependency Inversion** — ``register_inprocess_executor`` /
-  ``submit_async_callable`` are looked up *on the passed object*, not
-  imported at module scope, so an older core wheel or a fake dispatcher
-  in a unit test is fully supported.
+* **Dependency Inversion** — the dispatcher's ``submit_async_callable``
+  is looked up *on the passed object*, not imported at module scope,
+  so fake dispatchers in unit tests are fully supported.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import threading
-from dataclasses import dataclass
 from typing import Any, Callable, Optional
+
+from dcc_mcp_core import ReadinessProbe
 
 logger = logging.getLogger(__name__)
 
@@ -63,120 +54,6 @@ ENV_READINESS_TIMEOUT_SECS = "DCC_MCP_MAYA_READINESS_TIMEOUT_SECS"
 #: dispatcher.  Kept stable so operators grepping the Maya log can
 #: correlate the "readiness flip" line with the exact job.
 READINESS_PROBE_REQUEST_ID = "dcc_mcp_maya__readiness__dcc_ready_probe"
-
-
-# ---------------------------------------------------------------------------
-# Report
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class ReadinessReport:
-    """Immutable three-state readiness snapshot.
-
-    Mirrors the core-side ``ReadinessReport`` struct so the Maya adapter
-    can serve honest values via the same REST contract
-    (``GET /v1/readyz`` → ``{"process": ..., "dispatcher": ..., "dcc": ...}``).
-    ``process`` is always ``True`` on the adapter side: when this object
-    is alive, the Python interpreter is alive, so the HTTP listener's
-    in-process plumbing has been spun up.  The gateway still gets to
-    veto (e.g. port bind failed) via its own probe.
-    """
-
-    process: bool = True
-    dispatcher: bool = False
-    dcc: bool = False
-
-    def is_ready(self) -> bool:
-        """Return ``True`` when all three bits are green."""
-        return self.process and self.dispatcher and self.dcc
-
-    def to_dict(self) -> dict:
-        """Return a plain ``dict`` suitable for JSON serialisation."""
-        return {
-            "process": self.process,
-            "dispatcher": self.dispatcher,
-            "dcc": self.dcc,
-        }
-
-
-# ---------------------------------------------------------------------------
-# Mutable static readiness (Python analogue of the Rust ``StaticReadiness``)
-# ---------------------------------------------------------------------------
-
-
-class StaticReadiness:
-    """Thread-safe mutable readiness container.
-
-    The two setters are idempotent — flipping to ``True`` twice is a
-    no-op; flipping back to ``False`` is accepted (callers that want to
-    re-arm the probe after a Maya scene reload can do so).  A single
-    ``threading.Lock`` guards the three booleans; the readers (``report``)
-    take a short critical section and return an immutable dataclass.
-
-    This class exists because core 0.14.23 / 0.14.26 do not yet expose
-    a Python binding for their Rust ``StaticReadiness``.  Once the
-    binding lands (tracked in core 0.14.27, see
-    ``dcc-mcp-maya#184``) the Maya side can adopt the binding without
-    changing the surface any caller of this module relies on — the two
-    classes are intentionally shape-compatible.
-    """
-
-    def __init__(
-        self,
-        *,
-        process: bool = True,
-        dispatcher: bool = False,
-        dcc: bool = False,
-    ) -> None:
-        self._lock = threading.Lock()
-        self._process = bool(process)
-        self._dispatcher = bool(dispatcher)
-        self._dcc = bool(dcc)
-
-    # ── Mutations ─────────────────────────────────────────────────────
-
-    def set_dispatcher_ready(self, value: bool) -> None:
-        """Flip the ``dispatcher`` bit."""
-        with self._lock:
-            self._dispatcher = bool(value)
-
-    def set_dcc_ready(self, value: bool) -> None:
-        """Flip the ``dcc`` bit."""
-        with self._lock:
-            self._dcc = bool(value)
-
-    def set_process_ready(self, value: bool) -> None:
-        """Flip the ``process`` bit (rarely useful from Python side)."""
-        with self._lock:
-            self._process = bool(value)
-
-    # ── Reads ──────────────────────────────────────────────────────────
-
-    def report(self) -> ReadinessReport:
-        """Return an immutable snapshot of the three bits."""
-        with self._lock:
-            return ReadinessReport(
-                process=self._process,
-                dispatcher=self._dispatcher,
-                dcc=self._dcc,
-            )
-
-    def is_ready(self) -> bool:
-        """Convenience for ``self.report().is_ready()`` — single lock take."""
-        with self._lock:
-            return self._process and self._dispatcher and self._dcc
-
-    @classmethod
-    def fully_ready(cls) -> "StaticReadiness":
-        """Return an all-green probe — matches the core-side constructor.
-
-        Mostly useful in tests that want to bypass the probe entirely.
-        Startup code should instead build ``StaticReadiness()`` (which
-        defaults to ``dispatcher=False, dcc=False``) and let the probe
-        flip the bits as each subsystem comes online.
-        """
-        return cls(process=True, dispatcher=True, dcc=True)
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +104,7 @@ def resolve_readiness_timeout_secs(
 
 
 # ---------------------------------------------------------------------------
-# Integration object — binds the probe to a :class:`MayaMcpServer`
+# Dispatcher probe helpers
 # ---------------------------------------------------------------------------
 
 
@@ -280,8 +157,9 @@ def _default_probe_scheduler(dispatcher: Any, on_done: Callable[[], None]) -> bo
             on_complete=_on_complete,
         )
     except TypeError:
-        # Core 0.14.23 dispatchers that don't accept ``on_complete`` as
-        # a kwarg — retry without it and poll the dispatcher instead.
+        # Older dispatchers that don't accept ``on_complete`` as a
+        # kwarg — retry without it and leave dcc red, since we can't
+        # confirm the main thread actually pumped the probe.
         try:
             submit_async(
                 request_id=READINESS_PROBE_REQUEST_ID,
@@ -292,9 +170,6 @@ def _default_probe_scheduler(dispatcher: Any, on_done: Callable[[], None]) -> bo
         except Exception as exc:  # noqa: BLE001
             logger.debug("readiness: submit_async_callable fallback failed: %s", exc)
             return False
-        # Best-effort: we can't confirm the main thread actually ran
-        # the probe, so leave ``dcc`` red.  Callers that want a hard
-        # signal should use a dispatcher that supports ``on_complete``.
         return False
     except Exception as exc:  # noqa: BLE001
         logger.debug("readiness: submit_async_callable raised: %s", exc)
@@ -302,20 +177,28 @@ def _default_probe_scheduler(dispatcher: Any, on_done: Callable[[], None]) -> bo
     return True
 
 
-class ReadinessProbe:
-    """Drive the three readiness bits across a :class:`MayaMcpServer` lifecycle.
+# ---------------------------------------------------------------------------
+# Maya-side binder — wraps a core ReadinessProbe with lifecycle hooks
+# ---------------------------------------------------------------------------
 
-    Usage (called once from ``server.register_builtin_actions``)::
 
-        probe = ReadinessProbe()
-        probe.bind(server)
-        # ``probe.report()`` now transitions through:
+class ReadinessBinder:
+    """Drive a :class:`dcc_mcp_core.ReadinessProbe` across a Maya lifecycle.
+
+    Usage (called once from ``MayaMcpServer.__init__`` and again from
+    ``attach_dispatcher`` if the dispatcher arrived late)::
+
+        binder = ReadinessBinder()
+        binder.bind(server)
+        # ``binder.report()`` now transitions through:
         #   dispatcher=False, dcc=False   (construction)
         # → dispatcher=True,  dcc=False   (after executor is attached)
         # → dispatcher=True,  dcc=True    (after first main-thread pump)
 
-    All transitions are idempotent — calling :meth:`bind` twice is safe
-    (the second call is a no-op on the same server).
+    All transitions are idempotent — calling :meth:`bind` twice on the
+    same server is a no-op.  The core :class:`ReadinessProbe` is
+    published to the inner Rust ``McpHttpServer`` via
+    ``set_readiness_probe`` so that ``/v1/readyz`` serves honest values.
 
     Parameters
     ----------
@@ -329,6 +212,12 @@ class ReadinessProbe:
         Strategy for scheduling the dcc-ready probe on the attached
         dispatcher.  Override in tests to avoid depending on a real
         :class:`MayaUiDispatcher` pump.
+    probe:
+        Optional pre-built :class:`dcc_mcp_core.ReadinessProbe`.  When
+        omitted a fresh one is constructed (``process=True,
+        dispatcher=False, dcc=False``).  Tests inject a probe so they
+        can assert against the exact instance published to the inner
+        Rust server.
     """
 
     def __init__(
@@ -336,78 +225,101 @@ class ReadinessProbe:
         *,
         timeout_secs: Optional[int] = None,
         probe_scheduler: Optional[ProbeScheduler] = None,
+        probe: Optional[ReadinessProbe] = None,
     ) -> None:
         self.timeout_secs: Optional[int] = resolve_readiness_timeout_secs(
             timeout_secs,
         )
-        self.readiness: StaticReadiness = StaticReadiness()
+        self.probe: ReadinessProbe = probe or ReadinessProbe()
         self.probe_scheduler: ProbeScheduler = probe_scheduler or _default_probe_scheduler
         # Populated by :meth:`bind` so tests can assert what we wired.
         self.bound_server: Any = None
         self.bound_dispatcher: Any = None
         self.dcc_scheduled: bool = False
+        self.published_to_server: bool = False
 
     # ── Public API ──────────────────────────────────────────────────────
 
-    def report(self) -> ReadinessReport:
-        """Return the current immutable readiness snapshot."""
-        return self.readiness.report()
+    def report(self) -> dict:
+        """Return the current three-state readiness snapshot as a dict.
+
+        Delegates to :meth:`dcc_mcp_core.ReadinessProbe.report`.  Keys:
+        ``process`` / ``dispatcher`` / ``dcc``.
+        """
+        return self.probe.report()
+
+    def is_ready(self) -> bool:
+        """Return ``True`` when all three bits are green."""
+        return self.probe.is_ready()
 
     def bind(self, server: Any) -> bool:
         """Wire the probe into *server*.
 
         Steps:
 
-        1. If the server already has a live dispatcher
-           (``server._maya_dispatcher`` is not ``None``), flip
-           ``dispatcher=True`` immediately.  Otherwise :meth:`bind`
-           returns having only wired what's possible; callers may
-           re-invoke :meth:`mark_dispatcher_ready` once the dispatcher
-           shows up.
-        2. Publish :attr:`readiness` to the inner Rust config when the
-           currently-installed ``dcc-mcp-core`` wheel exposes the
-           ``readiness`` attribute on :class:`McpHttpConfig`.  Today
-           (core 0.14.23 / 0.14.26) that attribute does not exist; the
-           call is a silent no-op and will light up automatically when
-           core 0.14.27 ships the Python binding.  The Maya-side
-           in-process report remains authoritative for tests regardless.
-        3. Schedule a no-op probe on the attached dispatcher so the
-           first main-thread pump flips ``dcc=True``.  On
-           :class:`MayaStandaloneDispatcher` this callback fires
-           synchronously, so the flip is observed immediately.
+        1. Publish :attr:`probe` to the inner Rust ``McpHttpServer`` via
+           :meth:`McpHttpServer.set_readiness_probe`, if the server
+           object exposes that surface (core 0.14.28+).  This is what
+           causes ``/v1/readyz`` to serve honest values.
+        2. Flip ``dispatcher = true`` unconditionally — by the time
+           :meth:`bind` is called, :meth:`MayaMcpServer.__init__` has
+           already invoked ``register_inprocess_executor`` (either with
+           a real host dispatcher or with ``None`` to get the inline
+           executor), so the Rust handler routing is live.
+        3. If no host dispatcher is attached
+           (``server._maya_dispatcher is None``), the inline executor
+           runs jobs on the HTTP worker thread — there is **no** Maya
+           main thread to wait on — so flip ``dcc = true``
+           immediately.  In that mode the three-state probe collapses
+           to "ready as soon as the executor is wired".
+        4. If a host dispatcher *is* attached, schedule a no-op probe
+           on it so the first main-thread pump flips ``dcc = true``.
+           On :class:`MayaStandaloneDispatcher` that callback fires
+           synchronously on the calling thread; on a live Maya UI
+           dispatcher it fires on the first idle tick once the scene
+           is up.
 
         Returns
         -------
         bool
-            ``True`` when binding fully succeeded (dispatcher already
-            live and dcc probe scheduled).  ``False`` when the server
-            has no dispatcher yet or the probe couldn't be scheduled —
-            the readiness object is still usable and may be advanced
-            later via :meth:`mark_dispatcher_ready` and
-            :meth:`mark_dcc_ready`.
+            ``True`` when binding left the probe fully ready or
+            successfully scheduled the final dcc flip.  ``False`` when
+            the dispatcher rejected the probe job — the adapter still
+            drives the other two bits and callers can advance ``dcc``
+            later via :meth:`mark_dcc_ready`.
         """
         if self.bound_server is server:
             return self.dcc_scheduled
         self.bound_server = server
 
-        # Step 2 — publish to the inner Rust config if supported.
-        self._maybe_publish_to_config(server)
+        # Step 1 — publish to the inner Rust server.
+        self._publish_to_server(server)
 
-        # Step 1 — dispatcher attached already?
+        # Step 2 — dispatcher bit: the executor is always wired by the
+        # time we arrive here, so handler routing is live regardless of
+        # whether a Maya UI dispatcher is present.
+        self.mark_dispatcher_ready()
+
+        # Step 3 / 4 — dcc bit.
         dispatcher = getattr(server, "_maya_dispatcher", None)
         if dispatcher is None:
             dispatcher = getattr(server, "_host_dispatcher", None)
+
         if dispatcher is None:
+            # Inline executor path (``register_inprocess_executor(None)``):
+            # every ``tools/call`` runs on the HTTP worker thread — there
+            # is no separate Maya main thread to wait on, so the "dcc"
+            # bit is meaningful only as "handler routing is live", which
+            # is already true.  Collapse to green.
+            self.bound_dispatcher = None
+            self.mark_dcc_ready()
+            self.dcc_scheduled = True
             logger.debug(
-                "readiness.bind: no dispatcher attached to %r yet; dispatcher/dcc stay red until one is wired",
-                type(server).__name__,
+                "readiness.bind: inline executor mode — dcc flipped green synchronously (no host dispatcher attached)",
             )
-            return False
+            return True
 
         self.bound_dispatcher = dispatcher
-        self.mark_dispatcher_ready()
-
-        # Step 3 — schedule the dcc probe.
         scheduled = self.probe_scheduler(dispatcher, self.mark_dcc_ready)
         self.dcc_scheduled = bool(scheduled)
         if not scheduled:
@@ -419,50 +331,53 @@ class ReadinessProbe:
 
     def mark_dispatcher_ready(self, value: bool = True) -> None:
         """Flip the ``dispatcher`` bit.  Idempotent."""
-        self.readiness.set_dispatcher_ready(value)
+        self.probe.set_dispatcher_ready(value)
         if value:
             logger.debug("readiness: dispatcher=true")
 
     def mark_dcc_ready(self, value: bool = True) -> None:
         """Flip the ``dcc`` bit.  Typically called from the probe callback."""
-        self.readiness.set_dcc_ready(value)
+        self.probe.set_dcc_ready(value)
         if value:
             logger.info("[maya] readiness: dcc-ready — main thread is pumping")
 
     # ── Internals ───────────────────────────────────────────────────────
 
-    def _maybe_publish_to_config(self, server: Any) -> bool:
-        """Best-effort publish of :attr:`readiness` to ``server._config``.
+    def _publish_to_server(self, server: Any) -> bool:
+        """Publish :attr:`probe` to the inner Rust ``McpHttpServer``.
 
-        Core 0.14.27 is expected to expose a ``readiness`` attribute on
-        :class:`dcc_mcp_core.McpHttpConfig` (tracked by the companion
-        core issue cited in #184).  Until then this method is a silent
-        no-op — the Maya adapter still tracks readiness in-process for
-        tests and any REST surface the adapter owns directly.
+        Targets ``server._server.set_readiness_probe(self.probe)``.  The
+        inner attribute is how every existing :class:`MayaMcpServer`
+        integration reaches the Rust object, so we don't invent a new
+        accessor.  Failures are logged at debug level and the binder
+        continues to drive the in-process :class:`ReadinessProbe` — any
+        REST surface that core itself owns will still see the
+        transitions, just not on *this* server instance.
 
-        Returns
-        -------
-        bool
-            ``True`` when the config attribute was set successfully;
-            ``False`` otherwise.  Failures are logged at debug level to
-            keep startup quiet on older core wheels.
+        Returns ``True`` when the call succeeded, ``False`` otherwise.
         """
-        config = getattr(server, "_config", None)
-        if config is None:
-            return False
-        # Inspect the attribute without touching it — ``hasattr`` also
-        # guards against property getters that raise.
-        if not hasattr(config, "readiness"):
-            return False
-        try:
-            setattr(config, "readiness", self.readiness)
-        except Exception as exc:  # noqa: BLE001
+        inner = getattr(server, "_server", None)
+        if inner is None:
             logger.debug(
-                "readiness: could not publish probe to inner config: %s",
-                exc,
+                "readiness: server %r has no ``_server`` attribute; probe not published to Rust layer",
+                type(server).__name__,
             )
             return False
-        logger.debug("readiness: probe published to inner Rust config")
+        publish = getattr(inner, "set_readiness_probe", None)
+        if publish is None:
+            # Should not happen on core 0.14.28+ which is the pinned
+            # floor, but stay defensive for downstream forks.
+            logger.debug(
+                "readiness: inner server has no set_readiness_probe (core < 0.14.28?); skipping publish",
+            )
+            return False
+        try:
+            publish(self.probe)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("readiness: set_readiness_probe raised: %s", exc)
+            return False
+        self.published_to_server = True
+        logger.debug("readiness: probe published via set_readiness_probe")
         return True
 
 
@@ -476,17 +391,19 @@ def install_readiness(
     *,
     timeout_secs: Optional[int] = None,
     probe_scheduler: Optional[ProbeScheduler] = None,
-) -> ReadinessProbe:
-    """One-shot helper used by :class:`MayaMcpServer.register_builtin_actions`.
+    probe: Optional[ReadinessProbe] = None,
+) -> ReadinessBinder:
+    """One-shot helper used by :class:`MayaMcpServer.__init__`.
 
-    Always returns a :class:`ReadinessProbe` — even when binding fails
+    Always returns a :class:`ReadinessBinder` — even when binding fails
     (no dispatcher yet, older core, etc.) — so callers can stash the
-    probe on the server and consult :meth:`ReadinessProbe.report` from
-    tests or diagnostic endpoints.
+    binder on the server and consult :meth:`ReadinessBinder.report`
+    from tests or diagnostic endpoints.
     """
-    probe = ReadinessProbe(
+    binder = ReadinessBinder(
         timeout_secs=timeout_secs,
         probe_scheduler=probe_scheduler,
+        probe=probe,
     )
-    probe.bind(server)
-    return probe
+    binder.bind(server)
+    return binder

--- a/src/dcc_mcp_maya/_readiness.py
+++ b/src/dcc_mcp_maya/_readiness.py
@@ -29,9 +29,6 @@ SOLID notes
 * **Open/Closed** — the dispatcher-probe strategy is injectable
   (:attr:`ReadinessBinder.probe_scheduler`), so tests can verify the
   flip without running a live Maya event loop.
-* **Dependency Inversion** — the dispatcher's ``submit_async_callable``
-  is looked up *on the passed object*, not imported at module scope,
-  so fake dispatchers in unit tests are fully supported.
 """
 
 from __future__ import annotations
@@ -112,68 +109,37 @@ ProbeScheduler = Callable[[Any, Callable[[], None]], bool]
 """Dispatcher-agnostic scheduler: ``(dispatcher, on_done) -> scheduled?``.
 
 Returns ``True`` when ``on_done`` is guaranteed to eventually be called
-(either synchronously on standalone dispatchers, or after the next pump
-cycle on UI dispatchers).  Returns ``False`` when the dispatcher is a
-shape we do not recognise and the caller should leave ``dcc`` red.
+(synchronously on standalone dispatchers; after the next pump cycle on
+UI dispatchers).
 """
 
 
 def _default_probe_scheduler(dispatcher: Any, on_done: Callable[[], None]) -> bool:
     """Submit a no-op job on *dispatcher* and flip ``dcc`` in its callback.
 
-    We prefer :meth:`submit_async_callable` because it's non-blocking —
-    the caller returns immediately and the callback fires on the UI
-    thread once Maya finishes booting.  On :class:`MayaStandaloneDispatcher`
-    the callback fires synchronously on the calling thread, which
-    mirrors the "dcc is ready the moment we're in mayapy" contract.
+    We use :meth:`submit_async_callable` because it's non-blocking — the
+    caller returns immediately and the callback fires on the UI thread
+    once Maya pumps.  On :class:`MayaStandaloneDispatcher` the callback
+    fires synchronously on the calling thread, which mirrors the "dcc is
+    ready the moment we're in mayapy" contract.
 
-    The ``on_complete`` callback signature accepts a result dict per the
-    upstream contract; we ignore the payload because we only care about
-    the fact that the main thread executed *something*.
+    Every dispatcher shipped by this package
+    (:class:`MayaUiDispatcher` / :class:`MayaStandaloneDispatcher` /
+    :class:`MayaCallableDispatcher`) implements the full core 0.14.28
+    :class:`BaseDccCallableDispatcherFull` protocol, so no fallback
+    branches are needed.
     """
-    submit_async = getattr(dispatcher, "submit_async_callable", None)
-    if submit_async is None:
-        # Older dispatchers that only expose ``submit_callable`` block
-        # the caller — that would stall server startup, so we refuse to
-        # downgrade and let the probe stay red.
-        logger.debug(
-            "readiness: dispatcher %r has no submit_async_callable; leaving dcc=false",
-            type(dispatcher).__name__,
-        )
-        return False
 
     def _on_complete(_result: Any) -> None:  # noqa: ARG001 — signature contract
-        try:
-            on_done()
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("readiness: dcc-ready callback raised: %s", exc)
+        on_done()
 
-    try:
-        submit_async(
-            request_id=READINESS_PROBE_REQUEST_ID,
-            task=lambda: None,
-            affinity="main",
-            timeout_ms=5_000,
-            on_complete=_on_complete,
-        )
-    except TypeError:
-        # Older dispatchers that don't accept ``on_complete`` as a
-        # kwarg — retry without it and leave dcc red, since we can't
-        # confirm the main thread actually pumped the probe.
-        try:
-            submit_async(
-                request_id=READINESS_PROBE_REQUEST_ID,
-                task=lambda: None,
-                affinity="main",
-                timeout_ms=5_000,
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("readiness: submit_async_callable fallback failed: %s", exc)
-            return False
-        return False
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("readiness: submit_async_callable raised: %s", exc)
-        return False
+    dispatcher.submit_async_callable(
+        request_id=READINESS_PROBE_REQUEST_ID,
+        task=lambda: None,
+        affinity="main",
+        timeout_ms=5_000,
+        on_complete=_on_complete,
+    )
     return True
 
 
@@ -185,20 +151,18 @@ def _default_probe_scheduler(dispatcher: Any, on_done: Callable[[], None]) -> bo
 class ReadinessBinder:
     """Drive a :class:`dcc_mcp_core.ReadinessProbe` across a Maya lifecycle.
 
-    Usage (called once from ``MayaMcpServer.__init__`` and again from
-    ``attach_dispatcher`` if the dispatcher arrived late)::
+    Usage (called once from ``MayaMcpServer.__init__``)::
 
         binder = ReadinessBinder()
         binder.bind(server)
-        # ``binder.report()`` now transitions through:
-        #   dispatcher=False, dcc=False   (construction)
-        # → dispatcher=True,  dcc=False   (after executor is attached)
-        # → dispatcher=True,  dcc=True    (after first main-thread pump)
+        # ``binder.report()`` lands green synchronously when no host
+        # dispatcher is attached (inline executor path); otherwise it
+        # transitions to all-green after the first main-thread pump.
 
-    All transitions are idempotent — calling :meth:`bind` twice on the
-    same server is a no-op.  The core :class:`ReadinessProbe` is
-    published to the inner Rust ``McpHttpServer`` via
-    ``set_readiness_probe`` so that ``/v1/readyz`` serves honest values.
+    Calling :meth:`bind` twice on the same server is a no-op.  The core
+    :class:`ReadinessProbe` is published to the inner Rust
+    ``McpHttpServer`` via ``set_readiness_probe`` so that
+    ``/v1/readyz`` serves honest values.
 
     Parameters
     ----------
@@ -212,12 +176,6 @@ class ReadinessBinder:
         Strategy for scheduling the dcc-ready probe on the attached
         dispatcher.  Override in tests to avoid depending on a real
         :class:`MayaUiDispatcher` pump.
-    probe:
-        Optional pre-built :class:`dcc_mcp_core.ReadinessProbe`.  When
-        omitted a fresh one is constructed (``process=True,
-        dispatcher=False, dcc=False``).  Tests inject a probe so they
-        can assert against the exact instance published to the inner
-        Rust server.
     """
 
     def __init__(
@@ -225,12 +183,11 @@ class ReadinessBinder:
         *,
         timeout_secs: Optional[int] = None,
         probe_scheduler: Optional[ProbeScheduler] = None,
-        probe: Optional[ReadinessProbe] = None,
     ) -> None:
         self.timeout_secs: Optional[int] = resolve_readiness_timeout_secs(
             timeout_secs,
         )
-        self.probe: ReadinessProbe = probe or ReadinessProbe()
+        self.probe: ReadinessProbe = ReadinessProbe()
         self.probe_scheduler: ProbeScheduler = probe_scheduler or _default_probe_scheduler
         # Populated by :meth:`bind` so tests can assert what we wired.
         self.bound_server: Any = None
@@ -258,42 +215,35 @@ class ReadinessBinder:
         Steps:
 
         1. Publish :attr:`probe` to the inner Rust ``McpHttpServer`` via
-           :meth:`McpHttpServer.set_readiness_probe`, if the server
-           object exposes that surface (core 0.14.28+).  This is what
+           :meth:`McpHttpServer.set_readiness_probe`.  This is what
            causes ``/v1/readyz`` to serve honest values.
         2. Flip ``dispatcher = true`` unconditionally — by the time
            :meth:`bind` is called, :meth:`MayaMcpServer.__init__` has
-           already invoked ``register_inprocess_executor`` (either with
-           a real host dispatcher or with ``None`` to get the inline
-           executor), so the Rust handler routing is live.
+           already invoked ``register_inprocess_executor``, so the Rust
+           handler routing is live.
         3. If no host dispatcher is attached
            (``server._maya_dispatcher is None``), the inline executor
            runs jobs on the HTTP worker thread — there is **no** Maya
-           main thread to wait on — so flip ``dcc = true``
-           immediately.  In that mode the three-state probe collapses
-           to "ready as soon as the executor is wired".
-        4. If a host dispatcher *is* attached, schedule a no-op probe
-           on it so the first main-thread pump flips ``dcc = true``.
-           On :class:`MayaStandaloneDispatcher` that callback fires
-           synchronously on the calling thread; on a live Maya UI
-           dispatcher it fires on the first idle tick once the scene
-           is up.
+           main thread to wait on — so flip ``dcc = true`` immediately.
+        4. Otherwise, schedule a no-op probe on the host dispatcher so
+           the first main-thread pump flips ``dcc = true``.  On
+           :class:`MayaStandaloneDispatcher` that callback fires
+           synchronously; on a live Maya UI dispatcher it fires on the
+           first idle tick once the scene is up.
 
         Returns
         -------
         bool
             ``True`` when binding left the probe fully ready or
-            successfully scheduled the final dcc flip.  ``False`` when
-            the dispatcher rejected the probe job — the adapter still
-            drives the other two bits and callers can advance ``dcc``
-            later via :meth:`mark_dcc_ready`.
+            successfully scheduled the final dcc flip.
         """
         if self.bound_server is server:
             return self.dcc_scheduled
         self.bound_server = server
 
         # Step 1 — publish to the inner Rust server.
-        self._publish_to_server(server)
+        server._server.set_readiness_probe(self.probe)
+        self.published_to_server = True
 
         # Step 2 — dispatcher bit: the executor is always wired by the
         # time we arrive here, so handler routing is live regardless of
@@ -301,10 +251,7 @@ class ReadinessBinder:
         self.mark_dispatcher_ready()
 
         # Step 3 / 4 — dcc bit.
-        dispatcher = getattr(server, "_maya_dispatcher", None)
-        if dispatcher is None:
-            dispatcher = getattr(server, "_host_dispatcher", None)
-
+        dispatcher = server._maya_dispatcher
         if dispatcher is None:
             # Inline executor path (``register_inprocess_executor(None)``):
             # every ``tools/call`` runs on the HTTP worker thread — there
@@ -314,19 +261,10 @@ class ReadinessBinder:
             self.bound_dispatcher = None
             self.mark_dcc_ready()
             self.dcc_scheduled = True
-            logger.debug(
-                "readiness.bind: inline executor mode — dcc flipped green synchronously (no host dispatcher attached)",
-            )
             return True
 
         self.bound_dispatcher = dispatcher
-        scheduled = self.probe_scheduler(dispatcher, self.mark_dcc_ready)
-        self.dcc_scheduled = bool(scheduled)
-        if not scheduled:
-            logger.debug(
-                "readiness.bind: dispatcher %r did not accept the probe; dcc stays red until another trigger flips it",
-                type(dispatcher).__name__,
-            )
+        self.dcc_scheduled = bool(self.probe_scheduler(dispatcher, self.mark_dcc_ready))
         return self.dcc_scheduled
 
     def mark_dispatcher_ready(self, value: bool = True) -> None:
@@ -341,45 +279,6 @@ class ReadinessBinder:
         if value:
             logger.info("[maya] readiness: dcc-ready — main thread is pumping")
 
-    # ── Internals ───────────────────────────────────────────────────────
-
-    def _publish_to_server(self, server: Any) -> bool:
-        """Publish :attr:`probe` to the inner Rust ``McpHttpServer``.
-
-        Targets ``server._server.set_readiness_probe(self.probe)``.  The
-        inner attribute is how every existing :class:`MayaMcpServer`
-        integration reaches the Rust object, so we don't invent a new
-        accessor.  Failures are logged at debug level and the binder
-        continues to drive the in-process :class:`ReadinessProbe` — any
-        REST surface that core itself owns will still see the
-        transitions, just not on *this* server instance.
-
-        Returns ``True`` when the call succeeded, ``False`` otherwise.
-        """
-        inner = getattr(server, "_server", None)
-        if inner is None:
-            logger.debug(
-                "readiness: server %r has no ``_server`` attribute; probe not published to Rust layer",
-                type(server).__name__,
-            )
-            return False
-        publish = getattr(inner, "set_readiness_probe", None)
-        if publish is None:
-            # Should not happen on core 0.14.28+ which is the pinned
-            # floor, but stay defensive for downstream forks.
-            logger.debug(
-                "readiness: inner server has no set_readiness_probe (core < 0.14.28?); skipping publish",
-            )
-            return False
-        try:
-            publish(self.probe)
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("readiness: set_readiness_probe raised: %s", exc)
-            return False
-        self.published_to_server = True
-        logger.debug("readiness: probe published via set_readiness_probe")
-        return True
-
 
 # ---------------------------------------------------------------------------
 # Module-level convenience
@@ -391,19 +290,11 @@ def install_readiness(
     *,
     timeout_secs: Optional[int] = None,
     probe_scheduler: Optional[ProbeScheduler] = None,
-    probe: Optional[ReadinessProbe] = None,
 ) -> ReadinessBinder:
-    """One-shot helper used by :class:`MayaMcpServer.__init__`.
-
-    Always returns a :class:`ReadinessBinder` — even when binding fails
-    (no dispatcher yet, older core, etc.) — so callers can stash the
-    binder on the server and consult :meth:`ReadinessBinder.report`
-    from tests or diagnostic endpoints.
-    """
+    """One-shot helper used by :class:`MayaMcpServer.__init__`."""
     binder = ReadinessBinder(
         timeout_secs=timeout_secs,
         probe_scheduler=probe_scheduler,
-        probe=probe,
     )
     binder.bind(server)
     return binder

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -260,9 +260,7 @@ class MayaMcpServer(DccServerBase):
         # ``MayaMcpServer.readiness_report`` for tests and orchestrators
         # that want an honest startup signal instead of the
         # always-green default the core currently ships.
-        self._readiness_timeout_secs: Optional[int] = (
-            _readiness.resolve_readiness_timeout_secs(readiness_timeout_secs)
-        )
+        self._readiness_timeout_secs: Optional[int] = _readiness.resolve_readiness_timeout_secs(readiness_timeout_secs)
         self._readiness: _readiness.ReadinessProbe = _readiness.install_readiness(
             self,
             timeout_secs=self._readiness_timeout_secs,

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -37,6 +37,7 @@ from dcc_mcp_maya import (
     _env,
     _executor,
     _project_tools,
+    _readiness,
     _skill_loader,
     _transport,
     _version_probe,
@@ -107,6 +108,7 @@ class MayaMcpServer(DccServerBase):
         tool_exposure: Optional[str] = None,
         cursor_safe_tool_names: Optional[bool] = None,
         host_dispatcher: Optional[Any] = None,
+        readiness_timeout_secs: Optional[int] = None,
     ) -> None:
         super().__init__(
             dcc_name="maya",
@@ -250,6 +252,22 @@ class MayaMcpServer(DccServerBase):
         # or the underlying core call failed at registration time.
         self._project_tools: Optional[_project_tools.ProjectToolsIntegration] = None
 
+        # ── Runtime readiness probe (issue #184) ───────────────────────
+        # Three-state (process / dispatcher / dcc) probe.  Starts with
+        # ``dispatcher=False, dcc=False``; flips to all-green only after
+        # the in-process executor is wired **and** Maya's main thread
+        # has pumped at least one job.  Exposed via
+        # ``MayaMcpServer.readiness_report`` for tests and orchestrators
+        # that want an honest startup signal instead of the
+        # always-green default the core currently ships.
+        self._readiness_timeout_secs: Optional[int] = (
+            _readiness.resolve_readiness_timeout_secs(readiness_timeout_secs)
+        )
+        self._readiness: _readiness.ReadinessProbe = _readiness.install_readiness(
+            self,
+            timeout_secs=self._readiness_timeout_secs,
+        )
+
     # ── Lifecycle additions ────────────────────────────────────────────
 
     def attach_dispatcher(self, dispatcher: Any) -> None:
@@ -275,6 +293,26 @@ class MayaMcpServer(DccServerBase):
             self.register_inprocess_executor(MayaCallableDispatcher(dispatcher))
         else:
             self.register_inprocess_executor(dispatcher)
+
+        # ── Readiness (issue #184) ─────────────────────────────────────
+        # A late ``attach_dispatcher`` (e.g. plugin bootstrap wires the
+        # dispatcher after ``MayaMcpServer.__init__`` ran) must still
+        # flip ``dispatcher=true`` and schedule the dcc probe.  The
+        # initial ``install_readiness`` call in ``__init__`` is a
+        # no-op in that case because the dispatcher was ``None`` then.
+        #
+        # Guarded with ``getattr`` because ``__init__`` calls
+        # ``attach_dispatcher`` *before* ``self._readiness`` is
+        # constructed — the first call is a no-op here and the final
+        # ``install_readiness`` at the end of ``__init__`` performs
+        # the real wiring.
+        probe = getattr(self, "_readiness", None)
+        if probe is not None:
+            try:
+                probe.bound_server = None  # force re-bind
+                probe.bind(self)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[%s] readiness re-bind failed: %s", self._dcc_name, exc)
 
     def stop(self) -> None:
         """Stop the HTTP server and drain any attached Maya dispatcher.
@@ -465,7 +503,7 @@ class MayaMcpServer(DccServerBase):
             logger.debug("[%s] unload_skill(%r) failed: %s", self._dcc_name, skill_name, exc)
             return False
 
-    # ── Gateway capability manifest + metadata (issues #163 / #165) ────
+    # ── Lifecycle: start() + gateway capability metadata ───────────────
 
     def start(self) -> Any:
         """Start the HTTP server.
@@ -548,6 +586,30 @@ class MayaMcpServer(DccServerBase):
                 meta.get("version"),
             )
         return bool(ok)
+
+    # ── Readiness (issue #184) ─────────────────────────────────────────
+
+    def readiness_report(self) -> dict:
+        """Return the current three-state readiness snapshot as a dict.
+
+        Keys: ``process`` / ``dispatcher`` / ``dcc`` (all booleans).  The
+        backend is considered ready only when all three are ``True``.
+        During Maya's boot window the expected sequence is::
+
+            {"process": True, "dispatcher": False, "dcc": False}
+            {"process": True, "dispatcher": True,  "dcc": False}  # after executor attached
+            {"process": True, "dispatcher": True,  "dcc": True}   # after first main-thread pump
+
+        See :mod:`dcc_mcp_maya._readiness` for the full contract.
+        """
+        return self._readiness.report().to_dict()
+
+    @property
+    def readiness(self) -> _readiness.ReadinessProbe:
+        """Expose the :class:`ReadinessProbe` for tests and orchestrators."""
+        return self._readiness
+
+    # ── Gateway capability manifest + metadata (issues #163 / #165) ────
 
     def build_capability_manifest(self, *, loaded_only: bool = False) -> dict:
         """Return the compact Maya capability manifest as a dict.
@@ -644,6 +706,7 @@ def start_server(
     dcc_window_title: Optional[str] = None,
     dcc_window_handle: Optional[int] = None,
     host_dispatcher: Optional[Any] = None,
+    readiness_timeout_secs: Optional[int] = None,
     **kwargs: Any,
 ) -> Any:
     """Start (or return the already-running) Maya MCP server.
@@ -682,6 +745,7 @@ def start_server(
                 dcc_window_title=dcc_window_title,
                 dcc_window_handle=dcc_window_handle,
                 host_dispatcher=host_dispatcher,
+                readiness_timeout_secs=readiness_timeout_secs,
                 **kwargs,
             )
             _instance_holder[0] = server
@@ -727,6 +791,7 @@ def start_server(
         dcc_window_title=dcc_window_title,
         dcc_window_handle=dcc_window_handle,
         host_dispatcher=host_dispatcher,
+        readiness_timeout_secs=readiness_timeout_secs,
         **kwargs,
     )
     _server_instance = _instance_holder[0]

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -261,7 +261,7 @@ class MayaMcpServer(DccServerBase):
         # that want an honest startup signal instead of the
         # always-green default the core currently ships.
         self._readiness_timeout_secs: Optional[int] = _readiness.resolve_readiness_timeout_secs(readiness_timeout_secs)
-        self._readiness: _readiness.ReadinessProbe = _readiness.install_readiness(
+        self._readiness: _readiness.ReadinessBinder = _readiness.install_readiness(
             self,
             timeout_secs=self._readiness_timeout_secs,
         )
@@ -600,11 +600,15 @@ class MayaMcpServer(DccServerBase):
 
         See :mod:`dcc_mcp_maya._readiness` for the full contract.
         """
-        return self._readiness.report().to_dict()
+        return self._readiness.report()
 
     @property
-    def readiness(self) -> _readiness.ReadinessProbe:
-        """Expose the :class:`ReadinessProbe` for tests and orchestrators."""
+    def readiness(self) -> _readiness.ReadinessBinder:
+        """Expose the :class:`ReadinessBinder` for tests and orchestrators.
+
+        The underlying three-state probe is available as
+        ``server.readiness.probe`` (a :class:`dcc_mcp_core.ReadinessProbe`).
+        """
         return self._readiness
 
     # ── Gateway capability manifest + metadata (issues #163 / #165) ────

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -220,6 +220,17 @@ class MayaMcpServer(DccServerBase):
         # handlers and REST calls share the same main-thread path.
         self._maya_dispatcher: Any = None
         self._host_dispatcher: Any = None
+
+        # ── Runtime readiness binder (issue #184) ──────────────────────
+        # Constructed *before* dispatcher attachment so ``attach_dispatcher``
+        # can re-bind through ``self._readiness`` unconditionally — no
+        # ``getattr`` guard, no ``try/except``.  Bound for real at the end
+        # of ``__init__`` once the executor wiring is settled.
+        self._readiness_timeout_secs: Optional[int] = _readiness.resolve_readiness_timeout_secs(readiness_timeout_secs)
+        self._readiness: _readiness.ReadinessBinder = _readiness.ReadinessBinder(
+            timeout_secs=self._readiness_timeout_secs,
+        )
+
         if host_dispatcher is not None:
             self.attach_dispatcher(host_dispatcher)
         else:
@@ -252,19 +263,11 @@ class MayaMcpServer(DccServerBase):
         # or the underlying core call failed at registration time.
         self._project_tools: Optional[_project_tools.ProjectToolsIntegration] = None
 
-        # ── Runtime readiness probe (issue #184) ───────────────────────
-        # Three-state (process / dispatcher / dcc) probe.  Starts with
-        # ``dispatcher=False, dcc=False``; flips to all-green only after
-        # the in-process executor is wired **and** Maya's main thread
-        # has pumped at least one job.  Exposed via
-        # ``MayaMcpServer.readiness_report`` for tests and orchestrators
-        # that want an honest startup signal instead of the
-        # always-green default the core currently ships.
-        self._readiness_timeout_secs: Optional[int] = _readiness.resolve_readiness_timeout_secs(readiness_timeout_secs)
-        self._readiness: _readiness.ReadinessBinder = _readiness.install_readiness(
-            self,
-            timeout_secs=self._readiness_timeout_secs,
-        )
+        # Bind the readiness binder now that the executor and dispatcher
+        # state are settled.  ``attach_dispatcher`` above may have already
+        # bound it (``bound_server is self``); :meth:`bind` is idempotent
+        # so calling again is a no-op when the server is unchanged.
+        self._readiness.bind(self)
 
     # ── Lifecycle additions ────────────────────────────────────────────
 
@@ -293,24 +296,14 @@ class MayaMcpServer(DccServerBase):
             self.register_inprocess_executor(dispatcher)
 
         # ── Readiness (issue #184) ─────────────────────────────────────
-        # A late ``attach_dispatcher`` (e.g. plugin bootstrap wires the
-        # dispatcher after ``MayaMcpServer.__init__`` ran) must still
-        # flip ``dispatcher=true`` and schedule the dcc probe.  The
-        # initial ``install_readiness`` call in ``__init__`` is a
-        # no-op in that case because the dispatcher was ``None`` then.
-        #
-        # Guarded with ``getattr`` because ``__init__`` calls
-        # ``attach_dispatcher`` *before* ``self._readiness`` is
-        # constructed — the first call is a no-op here and the final
-        # ``install_readiness`` at the end of ``__init__`` performs
-        # the real wiring.
-        probe = getattr(self, "_readiness", None)
-        if probe is not None:
-            try:
-                probe.bound_server = None  # force re-bind
-                probe.bind(self)
-            except Exception as exc:  # noqa: BLE001
-                logger.debug("[%s] readiness re-bind failed: %s", self._dcc_name, exc)
+        # Re-bind through the readiness binder so a late
+        # ``attach_dispatcher`` (e.g. plugin bootstrap wires the
+        # dispatcher after ``MayaMcpServer.__init__`` ran) flips
+        # ``dispatcher=true`` and schedules the dcc probe on the new
+        # dispatcher.  The binder is always constructed before the
+        # first dispatcher attachment inside ``__init__``.
+        self._readiness.bound_server = None  # force re-bind
+        self._readiness.bind(self)
 
     def stop(self) -> None:
         """Stop the HTTP server and drain any attached Maya dispatcher.

--- a/tests/test_dynamic_dispatch.py
+++ b/tests/test_dynamic_dispatch.py
@@ -162,49 +162,6 @@ class _RecordingDispatcher:
             return {"success": False, "error": str(exc)}
         return result
 
-    def submit_async_callable(
-        self,
-        request_id,
-        task,
-        *,
-        job_id=None,
-        progress_token=None,
-        on_complete=None,
-        affinity="any",
-        timeout_ms=None,
-    ):
-        """Execute *task* synchronously and invoke ``on_complete``.
-
-        Mirrors :class:`MayaStandaloneDispatcher.submit_async_callable`
-        so the readiness binder's probe job fires its callback
-        immediately during test setup — tests that rely on
-        ``_RecordingDispatcher`` run without a live Maya event loop.
-        """
-        try:
-            output = task()
-            result = {
-                "request_id": request_id,
-                "job_id": job_id,
-                "affinity": affinity,
-                "success": True,
-                "output": output,
-                "error": None,
-                "status": "completed",
-            }
-        except Exception as exc:  # noqa: BLE001
-            result = {
-                "request_id": request_id,
-                "job_id": job_id,
-                "affinity": affinity,
-                "success": False,
-                "output": None,
-                "error": str(exc),
-                "status": "failed",
-            }
-        if on_complete is not None:
-            on_complete(result)
-        return result
-
     def cancel(self, request_id):
         return True
 

--- a/tests/test_dynamic_dispatch.py
+++ b/tests/test_dynamic_dispatch.py
@@ -162,8 +162,48 @@ class _RecordingDispatcher:
             return {"success": False, "error": str(exc)}
         return result
 
-    def submit_async_callable(self, *args, **kwargs):
-        raise NotImplementedError
+    def submit_async_callable(
+        self,
+        request_id,
+        task,
+        *,
+        job_id=None,
+        progress_token=None,
+        on_complete=None,
+        affinity="any",
+        timeout_ms=None,
+    ):
+        """Execute *task* synchronously and invoke ``on_complete``.
+
+        Mirrors :class:`MayaStandaloneDispatcher.submit_async_callable`
+        so the readiness binder's probe job fires its callback
+        immediately during test setup — tests that rely on
+        ``_RecordingDispatcher`` run without a live Maya event loop.
+        """
+        try:
+            output = task()
+            result = {
+                "request_id": request_id,
+                "job_id": job_id,
+                "affinity": affinity,
+                "success": True,
+                "output": output,
+                "error": None,
+                "status": "completed",
+            }
+        except Exception as exc:  # noqa: BLE001
+            result = {
+                "request_id": request_id,
+                "job_id": job_id,
+                "affinity": affinity,
+                "success": False,
+                "output": None,
+                "error": str(exc),
+                "status": "failed",
+            }
+        if on_complete is not None:
+            on_complete(result)
+        return result
 
     def cancel(self, request_id):
         return True

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -192,6 +192,32 @@ class TestReadinessBinderBind:
         assert call["affinity"] == "main"
         assert call["has_callback"] is True
 
+    def test_bind_with_post_tick_dispatcher_flips_dcc_optimistically(self) -> None:
+        """Core's ``BlockingDispatcher`` / ``QueueDispatcher`` use a post/tick
+        protocol — no ``submit_async_callable``, no per-job callback.  The
+        binder must recognise that shape and flip ``dcc`` immediately so
+        real-world plugin-driven servers don't get stuck at 503.
+        """
+
+        class _PostTickDispatcher:
+            """Minimal stand-in for core's ``BlockingDispatcher`` shape."""
+
+            def post(self, _callback: Any) -> None:
+                pass
+
+            def tick(self) -> None:
+                pass
+
+        server = _FakeServer(dispatcher=_PostTickDispatcher())
+        binder = ReadinessBinder()
+        bound = binder.bind(server)
+        assert bound is True
+        assert binder.report() == {
+            "process": True,
+            "dispatcher": True,
+            "dcc": True,
+        }
+
     def test_bind_is_idempotent(self) -> None:
         server = _FakeServer(dispatcher=MayaStandaloneDispatcher())
         binder = ReadinessBinder()

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,417 @@
+"""Unit tests for the runtime readiness probe (issue #184).
+
+Covers the three transitions that ``/v1/readyz`` needs to stop
+lying during Maya's boot window:
+
+* ``process = True``    — always, once the Python interpreter is up.
+* ``dispatcher = True`` — after ``register_inprocess_executor`` wires
+  the in-process executor.
+* ``dcc = True``        — after Maya's main thread pumps the first
+  deferred no-op job (or synchronously on
+  :class:`MayaStandaloneDispatcher`).
+
+The tests avoid importing a real Maya — they use a fake dispatcher for
+the "never pumps" case and :class:`MayaStandaloneDispatcher` for the
+"flips synchronously" case, matching the harness style already used by
+``tests/test_dispatcher.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from dcc_mcp_maya import (
+    ENV_READINESS_TIMEOUT_SECS,
+    MayaStandaloneDispatcher,
+    ReadinessProbe,
+    ReadinessReport,
+    StaticReadiness,
+    install_readiness,
+    resolve_readiness_timeout_secs,
+)
+
+# ---------------------------------------------------------------------------
+# ReadinessReport / StaticReadiness
+# ---------------------------------------------------------------------------
+
+
+class TestReadinessReport:
+    """Immutable snapshot contract."""
+
+    def test_default_starts_with_only_process_green(self) -> None:
+        report = ReadinessReport()
+        assert report.process is True
+        assert report.dispatcher is False
+        assert report.dcc is False
+        assert report.is_ready() is False
+
+    def test_is_ready_requires_all_three_bits(self) -> None:
+        assert ReadinessReport(True, True, True).is_ready() is True
+        assert ReadinessReport(True, True, False).is_ready() is False
+        assert ReadinessReport(True, False, True).is_ready() is False
+        assert ReadinessReport(False, True, True).is_ready() is False
+
+    def test_to_dict_returns_json_friendly_payload(self) -> None:
+        report = ReadinessReport(process=True, dispatcher=True, dcc=False)
+        assert report.to_dict() == {
+            "process": True,
+            "dispatcher": True,
+            "dcc": False,
+        }
+
+
+class TestStaticReadiness:
+    """Mutable container used as the in-process authority."""
+
+    def test_default_report_matches_three_state_contract(self) -> None:
+        sr = StaticReadiness()
+        report = sr.report()
+        assert report.process is True
+        assert report.dispatcher is False
+        assert report.dcc is False
+
+    def test_set_dispatcher_ready_flips_the_bit(self) -> None:
+        sr = StaticReadiness()
+        sr.set_dispatcher_ready(True)
+        assert sr.report().dispatcher is True
+        sr.set_dispatcher_ready(False)
+        assert sr.report().dispatcher is False
+
+    def test_set_dcc_ready_flips_the_bit(self) -> None:
+        sr = StaticReadiness()
+        sr.set_dcc_ready(True)
+        assert sr.report().dcc is True
+
+    def test_is_ready_requires_all_three(self) -> None:
+        sr = StaticReadiness()
+        assert sr.is_ready() is False
+        sr.set_dispatcher_ready(True)
+        assert sr.is_ready() is False
+        sr.set_dcc_ready(True)
+        assert sr.is_ready() is True
+
+    def test_fully_ready_classmethod(self) -> None:
+        sr = StaticReadiness.fully_ready()
+        assert sr.is_ready() is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_readiness_timeout_secs
+# ---------------------------------------------------------------------------
+
+
+class TestResolveReadinessTimeout:
+    """Env-var + explicit-argument resolution."""
+
+    def test_returns_none_when_nothing_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_READINESS_TIMEOUT_SECS, raising=False)
+        assert resolve_readiness_timeout_secs() is None
+
+    def test_explicit_argument_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_READINESS_TIMEOUT_SECS, "30")
+        assert resolve_readiness_timeout_secs(5) == 5
+
+    def test_reads_env_var_when_argument_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_READINESS_TIMEOUT_SECS, "12")
+        assert resolve_readiness_timeout_secs() == 12
+
+    def test_non_integer_env_collapses_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_READINESS_TIMEOUT_SECS, "twelve")
+        assert resolve_readiness_timeout_secs() is None
+
+    def test_non_positive_collapses_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_READINESS_TIMEOUT_SECS, "0")
+        assert resolve_readiness_timeout_secs() is None
+        monkeypatch.setenv(ENV_READINESS_TIMEOUT_SECS, "-5")
+        assert resolve_readiness_timeout_secs() is None
+
+    def test_empty_env_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_READINESS_TIMEOUT_SECS, "   ")
+        assert resolve_readiness_timeout_secs() is None
+
+    def test_invalid_explicit_argument_returns_none(self) -> None:
+        # Strings are not valid positive integers here.
+        assert resolve_readiness_timeout_secs("oops") is None  # type: ignore[arg-type]
+        assert resolve_readiness_timeout_secs(-1) is None
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher probe helpers
+# ---------------------------------------------------------------------------
+
+
+class _NeverPumpingDispatcher:
+    """Fake UI dispatcher that *accepts* jobs but never runs them.
+
+    Mimics a Maya that has its HTTP listener up (process green) and the
+    in-process executor attached (dispatcher green) but whose main thread
+    is still booting — the deferred callback never fires, so ``dcc``
+    must stay red.
+    """
+
+    def __init__(self) -> None:
+        self.received: List[Any] = []
+
+    def submit_async_callable(
+        self,
+        *,
+        request_id: str,
+        task: Callable[[], Any],
+        affinity: str = "main",
+        timeout_ms: int = 5_000,
+        on_complete: Callable[[Any], None] | None = None,
+        **_: Any,
+    ) -> dict:
+        # Record the call but never invoke the callback.
+        self.received.append(
+            {
+                "request_id": request_id,
+                "affinity": affinity,
+                "has_callback": on_complete is not None,
+            }
+        )
+        return {"request_id": request_id, "status": "pending"}
+
+
+class _FakeConfig:
+    """Shim around ``McpHttpConfig`` with just the attributes we inspect."""
+
+    def __init__(self, *, has_readiness_attr: bool = False) -> None:
+        if has_readiness_attr:
+            self.readiness: Any = None  # placeholder until probe publishes
+
+
+class _FakeServer:
+    """Minimal surface that :class:`ReadinessProbe` touches."""
+
+    def __init__(
+        self,
+        dispatcher: Any = None,
+        *,
+        config_has_readiness: bool = False,
+    ) -> None:
+        self._maya_dispatcher = dispatcher
+        self._host_dispatcher = dispatcher
+        self._config = _FakeConfig(has_readiness_attr=config_has_readiness)
+
+
+# ---------------------------------------------------------------------------
+# ReadinessProbe.bind — the core contract
+# ---------------------------------------------------------------------------
+
+
+class TestReadinessProbeBind:
+    """Transitions driven by :meth:`ReadinessProbe.bind`."""
+
+    def test_bind_with_no_dispatcher_leaves_both_bits_red(self) -> None:
+        server = _FakeServer(dispatcher=None)
+        probe = ReadinessProbe()
+        bound = probe.bind(server)
+        assert bound is False
+        snap = probe.report()
+        assert snap.process is True
+        assert snap.dispatcher is False
+        assert snap.dcc is False
+
+    def test_bind_with_standalone_flips_both_bits_synchronously(self) -> None:
+        """:class:`MayaStandaloneDispatcher` runs callbacks on the calling thread."""
+        server = _FakeServer(dispatcher=MayaStandaloneDispatcher())
+        probe = ReadinessProbe()
+        bound = probe.bind(server)
+        assert bound is True
+        assert probe.report().is_ready() is True
+
+    def test_bind_with_never_pumping_dispatcher_keeps_dcc_red(self) -> None:
+        dispatcher = _NeverPumpingDispatcher()
+        server = _FakeServer(dispatcher=dispatcher)
+        probe = ReadinessProbe()
+        bound = probe.bind(server)
+        # We *did* accept the probe (returned True from default scheduler)
+        # and flipped dispatcher=True, but the callback never fires so
+        # dcc stays red.
+        assert bound is True
+        snap = probe.report()
+        assert snap.dispatcher is True
+        assert snap.dcc is False
+        # The scheduler used the main-thread affinity as expected.
+        assert dispatcher.received, "dispatcher should have recorded one submit"
+        call = dispatcher.received[0]
+        assert call["affinity"] == "main"
+        assert call["has_callback"] is True
+
+    def test_bind_is_idempotent(self) -> None:
+        server = _FakeServer(dispatcher=MayaStandaloneDispatcher())
+        probe = ReadinessProbe()
+        assert probe.bind(server) is True
+        # Second bind on the same server is a no-op and returns the
+        # previously-recorded scheduling state.
+        assert probe.bind(server) is True
+        assert probe.report().is_ready() is True
+
+    def test_custom_probe_scheduler_is_used(self) -> None:
+        """Injected scheduler overrides the default :func:`submit_async_callable` path."""
+        flipped: List[bool] = []
+
+        def scheduler(_dispatcher: Any, on_done: Callable[[], None]) -> bool:
+            # Fire the callback after asserting we were passed the dispatcher.
+            on_done()
+            flipped.append(True)
+            return True
+
+        probe = ReadinessProbe(probe_scheduler=scheduler)
+        server = _FakeServer(dispatcher=MagicMock(name="unused-dispatcher"))
+        assert probe.bind(server) is True
+        assert flipped == [True]
+        assert probe.report().is_ready() is True
+
+    def test_bind_publishes_to_config_when_supported(self) -> None:
+        """Forward-compatible publish hook for core 0.14.27."""
+        server = _FakeServer(
+            dispatcher=MayaStandaloneDispatcher(),
+            config_has_readiness=True,
+        )
+        probe = ReadinessProbe()
+        probe.bind(server)
+        # The config attribute is our in-process StaticReadiness — the
+        # eventual Rust binding will observe the same mutations.
+        assert server._config.readiness is probe.readiness  # type: ignore[attr-defined]
+
+    def test_bind_skips_config_publish_on_older_core(self) -> None:
+        """Today's core (0.14.23 / 0.14.26) has no ``readiness`` attr — silent no-op."""
+        server = _FakeServer(
+            dispatcher=MayaStandaloneDispatcher(),
+            config_has_readiness=False,
+        )
+        probe = ReadinessProbe()
+        # Binding should still succeed — this is the whole point of
+        # forward-compat wiring.
+        assert probe.bind(server) is True
+        assert not hasattr(server._config, "readiness")
+
+    def test_mark_dispatcher_ready_is_idempotent(self) -> None:
+        probe = ReadinessProbe()
+        probe.mark_dispatcher_ready()
+        probe.mark_dispatcher_ready()
+        assert probe.report().dispatcher is True
+        probe.mark_dispatcher_ready(False)
+        assert probe.report().dispatcher is False
+
+    def test_mark_dcc_ready_logs_info_on_flip(self) -> None:
+        probe = ReadinessProbe()
+        probe.mark_dcc_ready(True)
+        assert probe.report().dcc is True
+
+
+# ---------------------------------------------------------------------------
+# install_readiness — module-level convenience
+# ---------------------------------------------------------------------------
+
+
+class TestInstallReadiness:
+    def test_returns_probe_even_when_binding_fails(self) -> None:
+        server = _FakeServer(dispatcher=None)
+        probe = install_readiness(server)
+        assert isinstance(probe, ReadinessProbe)
+        # dispatcher/dcc stay red — the convenience helper never raises.
+        snap = probe.report()
+        assert snap.dispatcher is False
+        assert snap.dcc is False
+
+    def test_threads_timeout_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_READINESS_TIMEOUT_SECS, raising=False)
+        server = _FakeServer(dispatcher=MayaStandaloneDispatcher())
+        probe = install_readiness(server, timeout_secs=45)
+        assert probe.timeout_secs == 45
+
+
+# ---------------------------------------------------------------------------
+# Integration with MayaMcpServer
+# ---------------------------------------------------------------------------
+
+
+class TestMayaMcpServerReadinessIntegration:
+    """End-to-end: constructor + ``attach_dispatcher`` drive the probe."""
+
+    def test_construction_without_dispatcher_is_red(self) -> None:
+        from dcc_mcp_maya import MayaMcpServer
+
+        server = MayaMcpServer(port=0)
+        try:
+            assert server.readiness_report() == {
+                "process": True,
+                "dispatcher": False,
+                "dcc": False,
+            }
+            assert server.readiness is not None
+        finally:
+            # Ensure the Rust HTTP server thread is torn down even though
+            # we never called start() — construction still spins up some
+            # internal handles via the base class.
+            try:
+                server.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def test_attach_dispatcher_flips_probe_green(self) -> None:
+        from dcc_mcp_maya import MayaMcpServer
+
+        server = MayaMcpServer(port=0)
+        try:
+            assert server.readiness_report()["dispatcher"] is False
+            server.attach_dispatcher(MayaStandaloneDispatcher())
+            snap = server.readiness_report()
+            assert snap["dispatcher"] is True
+            assert snap["dcc"] is True
+        finally:
+            try:
+                server.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def test_constructor_with_dispatcher_lands_all_green(self) -> None:
+        from dcc_mcp_maya import MayaMcpServer
+
+        server = MayaMcpServer(
+            port=0,
+            host_dispatcher=MayaStandaloneDispatcher(),
+        )
+        try:
+            assert server.readiness_report() == {
+                "process": True,
+                "dispatcher": True,
+                "dcc": True,
+            }
+        finally:
+            try:
+                server.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def test_readiness_timeout_is_resolved_from_kwarg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dcc_mcp_maya import MayaMcpServer
+
+        monkeypatch.delenv(ENV_READINESS_TIMEOUT_SECS, raising=False)
+        server = MayaMcpServer(port=0, readiness_timeout_secs=42)
+        try:
+            assert server.readiness.timeout_secs == 42
+        finally:
+            try:
+                server.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def test_readiness_timeout_is_resolved_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dcc_mcp_maya import MayaMcpServer
+
+        monkeypatch.setenv(ENV_READINESS_TIMEOUT_SECS, "17")
+        server = MayaMcpServer(port=0)
+        try:
+            assert server.readiness.timeout_secs == 17
+        finally:
+            try:
+                server.stop()
+            except Exception:  # noqa: BLE001
+                pass

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,7 +1,7 @@
-"""Unit tests for the runtime readiness probe (issue #184).
+"""Unit tests for the runtime readiness wiring (issue #184).
 
-Covers the three transitions that ``/v1/readyz`` needs to stop
-lying during Maya's boot window:
+Covers the three transitions that ``/v1/readyz`` needs to stop lying
+during Maya's boot window:
 
 * ``process = True``    — always, once the Python interpreter is up.
 * ``dispatcher = True`` — after ``register_inprocess_executor`` wires
@@ -9,6 +9,12 @@ lying during Maya's boot window:
 * ``dcc = True``        — after Maya's main thread pumps the first
   deferred no-op job (or synchronously on
   :class:`MayaStandaloneDispatcher`).
+
+The Maya adapter **wraps** :class:`dcc_mcp_core.ReadinessProbe` (core
+0.14.28+) — these tests exercise only the Maya-side plumbing
+(:class:`dcc_mcp_maya.ReadinessBinder`, env-var resolution, dispatcher
+scheduling, and the ``set_readiness_probe`` publish hop).  The probe's
+own state machine is unit-tested upstream by ``dcc-mcp-core``.
 
 The tests avoid importing a real Maya — they use a fake dispatcher for
 the "never pumps" case and :class:`MayaStandaloneDispatcher` for the
@@ -22,81 +28,15 @@ from typing import Any, Callable, List
 from unittest.mock import MagicMock
 
 import pytest
+from dcc_mcp_core import ReadinessProbe
 
 from dcc_mcp_maya import (
     ENV_READINESS_TIMEOUT_SECS,
     MayaStandaloneDispatcher,
-    ReadinessProbe,
-    ReadinessReport,
-    StaticReadiness,
+    ReadinessBinder,
     install_readiness,
     resolve_readiness_timeout_secs,
 )
-
-# ---------------------------------------------------------------------------
-# ReadinessReport / StaticReadiness
-# ---------------------------------------------------------------------------
-
-
-class TestReadinessReport:
-    """Immutable snapshot contract."""
-
-    def test_default_starts_with_only_process_green(self) -> None:
-        report = ReadinessReport()
-        assert report.process is True
-        assert report.dispatcher is False
-        assert report.dcc is False
-        assert report.is_ready() is False
-
-    def test_is_ready_requires_all_three_bits(self) -> None:
-        assert ReadinessReport(True, True, True).is_ready() is True
-        assert ReadinessReport(True, True, False).is_ready() is False
-        assert ReadinessReport(True, False, True).is_ready() is False
-        assert ReadinessReport(False, True, True).is_ready() is False
-
-    def test_to_dict_returns_json_friendly_payload(self) -> None:
-        report = ReadinessReport(process=True, dispatcher=True, dcc=False)
-        assert report.to_dict() == {
-            "process": True,
-            "dispatcher": True,
-            "dcc": False,
-        }
-
-
-class TestStaticReadiness:
-    """Mutable container used as the in-process authority."""
-
-    def test_default_report_matches_three_state_contract(self) -> None:
-        sr = StaticReadiness()
-        report = sr.report()
-        assert report.process is True
-        assert report.dispatcher is False
-        assert report.dcc is False
-
-    def test_set_dispatcher_ready_flips_the_bit(self) -> None:
-        sr = StaticReadiness()
-        sr.set_dispatcher_ready(True)
-        assert sr.report().dispatcher is True
-        sr.set_dispatcher_ready(False)
-        assert sr.report().dispatcher is False
-
-    def test_set_dcc_ready_flips_the_bit(self) -> None:
-        sr = StaticReadiness()
-        sr.set_dcc_ready(True)
-        assert sr.report().dcc is True
-
-    def test_is_ready_requires_all_three(self) -> None:
-        sr = StaticReadiness()
-        assert sr.is_ready() is False
-        sr.set_dispatcher_ready(True)
-        assert sr.is_ready() is False
-        sr.set_dcc_ready(True)
-        assert sr.is_ready() is True
-
-    def test_fully_ready_classmethod(self) -> None:
-        sr = StaticReadiness.fully_ready()
-        assert sr.is_ready() is True
-
 
 # ---------------------------------------------------------------------------
 # resolve_readiness_timeout_secs
@@ -139,7 +79,7 @@ class TestResolveReadinessTimeout:
 
 
 # ---------------------------------------------------------------------------
-# Dispatcher probe helpers
+# Dispatcher probe helpers + fake server
 # ---------------------------------------------------------------------------
 
 
@@ -176,66 +116,87 @@ class _NeverPumpingDispatcher:
         return {"request_id": request_id, "status": "pending"}
 
 
-class _FakeConfig:
-    """Shim around ``McpHttpConfig`` with just the attributes we inspect."""
+class _FakeInnerServer:
+    """Stand-in for the Rust ``McpHttpServer`` — records the published probe."""
 
-    def __init__(self, *, has_readiness_attr: bool = False) -> None:
-        if has_readiness_attr:
-            self.readiness: Any = None  # placeholder until probe publishes
+    def __init__(self, *, supports_readiness: bool = True) -> None:
+        self.published_probe: Any = None
+        if supports_readiness:
+            # Only expose ``set_readiness_probe`` when the fake claims to
+            # represent a core 0.14.28+ binding.  Older shapes degrade
+            # silently (the binder logs and keeps the in-process probe).
+            self.set_readiness_probe = self._record_publish  # type: ignore[method-assign]
+
+    def _record_publish(self, probe: Any) -> None:
+        self.published_probe = probe
 
 
 class _FakeServer:
-    """Minimal surface that :class:`ReadinessProbe` touches."""
+    """Minimal ``MayaMcpServer`` stand-in with just the attributes ReadinessBinder touches."""
 
     def __init__(
         self,
         dispatcher: Any = None,
         *,
-        config_has_readiness: bool = False,
+        supports_readiness: bool = True,
     ) -> None:
         self._maya_dispatcher = dispatcher
         self._host_dispatcher = dispatcher
-        self._config = _FakeConfig(has_readiness_attr=config_has_readiness)
+        self._server = _FakeInnerServer(supports_readiness=supports_readiness)
 
 
 # ---------------------------------------------------------------------------
-# ReadinessProbe.bind — the core contract
+# ReadinessBinder.bind — the core contract
 # ---------------------------------------------------------------------------
 
 
-class TestReadinessProbeBind:
-    """Transitions driven by :meth:`ReadinessProbe.bind`."""
+class TestReadinessBinderBind:
+    """Transitions driven by :meth:`ReadinessBinder.bind`."""
 
-    def test_bind_with_no_dispatcher_leaves_both_bits_red(self) -> None:
+    def test_bind_with_no_dispatcher_flips_all_green_inline_mode(self) -> None:
+        """Inline executor mode (no host dispatcher) collapses the probe to green.
+
+        When ``register_inprocess_executor(None)`` is used, every
+        ``tools/call`` runs on the HTTP worker thread — there is no
+        separate Maya main thread to wait on, so the three-state probe
+        reduces to "handler routing is live", which is already true the
+        moment :meth:`bind` is called.
+        """
         server = _FakeServer(dispatcher=None)
-        probe = ReadinessProbe()
-        bound = probe.bind(server)
-        assert bound is False
-        snap = probe.report()
-        assert snap.process is True
-        assert snap.dispatcher is False
-        assert snap.dcc is False
+        binder = ReadinessBinder()
+        bound = binder.bind(server)
+        assert bound is True
+        assert binder.report() == {
+            "process": True,
+            "dispatcher": True,
+            "dcc": True,
+        }
 
     def test_bind_with_standalone_flips_both_bits_synchronously(self) -> None:
         """:class:`MayaStandaloneDispatcher` runs callbacks on the calling thread."""
         server = _FakeServer(dispatcher=MayaStandaloneDispatcher())
-        probe = ReadinessProbe()
-        bound = probe.bind(server)
+        binder = ReadinessBinder()
+        bound = binder.bind(server)
         assert bound is True
-        assert probe.report().is_ready() is True
+        assert binder.is_ready() is True
+        assert binder.report() == {
+            "process": True,
+            "dispatcher": True,
+            "dcc": True,
+        }
 
     def test_bind_with_never_pumping_dispatcher_keeps_dcc_red(self) -> None:
         dispatcher = _NeverPumpingDispatcher()
         server = _FakeServer(dispatcher=dispatcher)
-        probe = ReadinessProbe()
-        bound = probe.bind(server)
+        binder = ReadinessBinder()
+        bound = binder.bind(server)
         # We *did* accept the probe (returned True from default scheduler)
         # and flipped dispatcher=True, but the callback never fires so
         # dcc stays red.
         assert bound is True
-        snap = probe.report()
-        assert snap.dispatcher is True
-        assert snap.dcc is False
+        snap = binder.report()
+        assert snap["dispatcher"] is True
+        assert snap["dcc"] is False
         # The scheduler used the main-thread affinity as expected.
         assert dispatcher.received, "dispatcher should have recorded one submit"
         call = dispatcher.received[0]
@@ -244,65 +205,68 @@ class TestReadinessProbeBind:
 
     def test_bind_is_idempotent(self) -> None:
         server = _FakeServer(dispatcher=MayaStandaloneDispatcher())
-        probe = ReadinessProbe()
-        assert probe.bind(server) is True
+        binder = ReadinessBinder()
+        assert binder.bind(server) is True
         # Second bind on the same server is a no-op and returns the
         # previously-recorded scheduling state.
-        assert probe.bind(server) is True
-        assert probe.report().is_ready() is True
+        assert binder.bind(server) is True
+        assert binder.is_ready() is True
 
     def test_custom_probe_scheduler_is_used(self) -> None:
         """Injected scheduler overrides the default :func:`submit_async_callable` path."""
         flipped: List[bool] = []
 
         def scheduler(_dispatcher: Any, on_done: Callable[[], None]) -> bool:
-            # Fire the callback after asserting we were passed the dispatcher.
             on_done()
             flipped.append(True)
             return True
 
-        probe = ReadinessProbe(probe_scheduler=scheduler)
+        binder = ReadinessBinder(probe_scheduler=scheduler)
         server = _FakeServer(dispatcher=MagicMock(name="unused-dispatcher"))
-        assert probe.bind(server) is True
+        assert binder.bind(server) is True
         assert flipped == [True]
-        assert probe.report().is_ready() is True
+        assert binder.is_ready() is True
 
-    def test_bind_publishes_to_config_when_supported(self) -> None:
-        """Forward-compatible publish hook for core 0.14.27."""
+    def test_bind_publishes_probe_to_inner_server(self) -> None:
+        """``set_readiness_probe`` is called with the same probe the binder wraps."""
+        server = _FakeServer(dispatcher=MayaStandaloneDispatcher())
+        binder = ReadinessBinder()
+        assert binder.bind(server) is True
+        # The inner Rust server recorded the exact probe instance.
+        assert server._server.published_probe is binder.probe
+        assert binder.published_to_server is True
+
+    def test_bind_degrades_silently_when_inner_server_lacks_readiness(self) -> None:
+        """Older core that doesn't expose ``set_readiness_probe`` must not crash."""
         server = _FakeServer(
             dispatcher=MayaStandaloneDispatcher(),
-            config_has_readiness=True,
+            supports_readiness=False,
         )
-        probe = ReadinessProbe()
-        probe.bind(server)
-        # The config attribute is our in-process StaticReadiness — the
-        # eventual Rust binding will observe the same mutations.
-        assert server._config.readiness is probe.readiness  # type: ignore[attr-defined]
+        binder = ReadinessBinder()
+        # Binding should still succeed — Maya-side probe transitions
+        # still drive the in-process report.
+        assert binder.bind(server) is True
+        assert binder.published_to_server is False
 
-    def test_bind_skips_config_publish_on_older_core(self) -> None:
-        """Today's core (0.14.23 / 0.14.26) has no ``readiness`` attr — silent no-op."""
-        server = _FakeServer(
-            dispatcher=MayaStandaloneDispatcher(),
-            config_has_readiness=False,
-        )
-        probe = ReadinessProbe()
-        # Binding should still succeed — this is the whole point of
-        # forward-compat wiring.
-        assert probe.bind(server) is True
-        assert not hasattr(server._config, "readiness")
+    def test_injected_probe_is_used(self) -> None:
+        """Tests can pass in a pre-built probe (e.g. to assert on it directly)."""
+        probe = ReadinessProbe.fully_ready()
+        binder = ReadinessBinder(probe=probe)
+        assert binder.probe is probe
+        assert binder.is_ready() is True  # fully_ready() starts all-green
 
     def test_mark_dispatcher_ready_is_idempotent(self) -> None:
-        probe = ReadinessProbe()
-        probe.mark_dispatcher_ready()
-        probe.mark_dispatcher_ready()
-        assert probe.report().dispatcher is True
-        probe.mark_dispatcher_ready(False)
-        assert probe.report().dispatcher is False
+        binder = ReadinessBinder()
+        binder.mark_dispatcher_ready()
+        binder.mark_dispatcher_ready()
+        assert binder.report()["dispatcher"] is True
+        binder.mark_dispatcher_ready(False)
+        assert binder.report()["dispatcher"] is False
 
-    def test_mark_dcc_ready_logs_info_on_flip(self) -> None:
-        probe = ReadinessProbe()
-        probe.mark_dcc_ready(True)
-        assert probe.report().dcc is True
+    def test_mark_dcc_ready_flips_dcc_bit(self) -> None:
+        binder = ReadinessBinder()
+        binder.mark_dcc_ready(True)
+        assert binder.report()["dcc"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -311,20 +275,32 @@ class TestReadinessProbeBind:
 
 
 class TestInstallReadiness:
-    def test_returns_probe_even_when_binding_fails(self) -> None:
+    def test_returns_binder_ready_on_inline_mode(self) -> None:
+        """Inline mode (no host dispatcher) — ``install_readiness`` lands green."""
         server = _FakeServer(dispatcher=None)
-        probe = install_readiness(server)
-        assert isinstance(probe, ReadinessProbe)
-        # dispatcher/dcc stay red — the convenience helper never raises.
-        snap = probe.report()
-        assert snap.dispatcher is False
-        assert snap.dcc is False
+        binder = install_readiness(server)
+        assert isinstance(binder, ReadinessBinder)
+        snap = binder.report()
+        assert snap["dispatcher"] is True
+        assert snap["dcc"] is True
 
     def test_threads_timeout_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(ENV_READINESS_TIMEOUT_SECS, raising=False)
         server = _FakeServer(dispatcher=MayaStandaloneDispatcher())
-        probe = install_readiness(server, timeout_secs=45)
-        assert probe.timeout_secs == 45
+        binder = install_readiness(server, timeout_secs=45)
+        assert binder.timeout_secs == 45
+
+    def test_threads_probe_through(self) -> None:
+        server = _FakeServer(dispatcher=MayaStandaloneDispatcher())
+        probe = ReadinessProbe()
+        binder = install_readiness(server, probe=probe)
+        assert binder.probe is probe
+        # After install the probe was transitioned by the standalone path.
+        assert probe.report() == {
+            "process": True,
+            "dispatcher": True,
+            "dcc": True,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -335,32 +311,44 @@ class TestInstallReadiness:
 class TestMayaMcpServerReadinessIntegration:
     """End-to-end: constructor + ``attach_dispatcher`` drive the probe."""
 
-    def test_construction_without_dispatcher_is_red(self) -> None:
+    def test_construction_without_dispatcher_is_green_inline_mode(self) -> None:
+        """Inline executor mode (the ``start_server(host_dispatcher=None)``
+        path used by many tests and ``mayapy`` batch scripts) is
+        instantly ready — every call runs on the HTTP worker thread so
+        there's no separate main thread to wait on.
+        """
         from dcc_mcp_maya import MayaMcpServer
 
         server = MayaMcpServer(port=0)
         try:
             assert server.readiness_report() == {
                 "process": True,
-                "dispatcher": False,
-                "dcc": False,
+                "dispatcher": True,
+                "dcc": True,
             }
             assert server.readiness is not None
+            # The binder published its probe to the inner Rust server
+            # via ``set_readiness_probe`` (core 0.14.28+).
+            assert server.readiness.published_to_server is True
         finally:
-            # Ensure the Rust HTTP server thread is torn down even though
-            # we never called start() — construction still spins up some
-            # internal handles via the base class.
             try:
                 server.stop()
             except Exception:  # noqa: BLE001
                 pass
 
-    def test_attach_dispatcher_flips_probe_green(self) -> None:
+    def test_attach_dispatcher_keeps_probe_green(self) -> None:
+        """Attaching a dispatcher after construction is idempotent.
+
+        The server starts in inline mode (all green).  Attaching a real
+        host dispatcher later still leaves the probe green — the binder
+        re-runs, but since :class:`MayaStandaloneDispatcher` pumps the
+        probe job synchronously it lands at the same all-green state.
+        """
         from dcc_mcp_maya import MayaMcpServer
 
         server = MayaMcpServer(port=0)
         try:
-            assert server.readiness_report()["dispatcher"] is False
+            assert server.readiness_report()["dcc"] is True  # inline mode
             server.attach_dispatcher(MayaStandaloneDispatcher())
             snap = server.readiness_report()
             assert snap["dispatcher"] is True
@@ -384,6 +372,19 @@ class TestMayaMcpServerReadinessIntegration:
                 "dispatcher": True,
                 "dcc": True,
             }
+        finally:
+            try:
+                server.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def test_readiness_probe_handle_is_core_instance(self) -> None:
+        """``server.readiness.probe`` is a real :class:`dcc_mcp_core.ReadinessProbe`."""
+        from dcc_mcp_maya import MayaMcpServer
+
+        server = MayaMcpServer(port=0)
+        try:
+            assert isinstance(server.readiness.probe, ReadinessProbe)
         finally:
             try:
                 server.stop()

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -119,30 +119,19 @@ class _NeverPumpingDispatcher:
 class _FakeInnerServer:
     """Stand-in for the Rust ``McpHttpServer`` — records the published probe."""
 
-    def __init__(self, *, supports_readiness: bool = True) -> None:
+    def __init__(self) -> None:
         self.published_probe: Any = None
-        if supports_readiness:
-            # Only expose ``set_readiness_probe`` when the fake claims to
-            # represent a core 0.14.28+ binding.  Older shapes degrade
-            # silently (the binder logs and keeps the in-process probe).
-            self.set_readiness_probe = self._record_publish  # type: ignore[method-assign]
 
-    def _record_publish(self, probe: Any) -> None:
+    def set_readiness_probe(self, probe: Any) -> None:
         self.published_probe = probe
 
 
 class _FakeServer:
     """Minimal ``MayaMcpServer`` stand-in with just the attributes ReadinessBinder touches."""
 
-    def __init__(
-        self,
-        dispatcher: Any = None,
-        *,
-        supports_readiness: bool = True,
-    ) -> None:
+    def __init__(self, dispatcher: Any = None) -> None:
         self._maya_dispatcher = dispatcher
-        self._host_dispatcher = dispatcher
-        self._server = _FakeInnerServer(supports_readiness=supports_readiness)
+        self._server = _FakeInnerServer()
 
 
 # ---------------------------------------------------------------------------
@@ -236,25 +225,6 @@ class TestReadinessBinderBind:
         assert server._server.published_probe is binder.probe
         assert binder.published_to_server is True
 
-    def test_bind_degrades_silently_when_inner_server_lacks_readiness(self) -> None:
-        """Older core that doesn't expose ``set_readiness_probe`` must not crash."""
-        server = _FakeServer(
-            dispatcher=MayaStandaloneDispatcher(),
-            supports_readiness=False,
-        )
-        binder = ReadinessBinder()
-        # Binding should still succeed — Maya-side probe transitions
-        # still drive the in-process report.
-        assert binder.bind(server) is True
-        assert binder.published_to_server is False
-
-    def test_injected_probe_is_used(self) -> None:
-        """Tests can pass in a pre-built probe (e.g. to assert on it directly)."""
-        probe = ReadinessProbe.fully_ready()
-        binder = ReadinessBinder(probe=probe)
-        assert binder.probe is probe
-        assert binder.is_ready() is True  # fully_ready() starts all-green
-
     def test_mark_dispatcher_ready_is_idempotent(self) -> None:
         binder = ReadinessBinder()
         binder.mark_dispatcher_ready()
@@ -289,18 +259,6 @@ class TestInstallReadiness:
         server = _FakeServer(dispatcher=MayaStandaloneDispatcher())
         binder = install_readiness(server, timeout_secs=45)
         assert binder.timeout_secs == 45
-
-    def test_threads_probe_through(self) -> None:
-        server = _FakeServer(dispatcher=MayaStandaloneDispatcher())
-        probe = ReadinessProbe()
-        binder = install_readiness(server, probe=probe)
-        assert binder.probe is probe
-        # After install the probe was transitioned by the standalone path.
-        assert probe.report() == {
-            "process": True,
-            "dispatcher": True,
-            "dcc": True,
-        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -184,6 +184,10 @@ class TestMayaMcpServerApi:
         server = object.__new__(srv_mod.MayaMcpServer)
         server._dcc_name = "maya"
         server._server = MagicMock()
+        # Readiness binder is created in ``__init__``; bypassing it
+        # means we must supply a stand-in so ``attach_dispatcher`` can
+        # re-bind without crashing.
+        server._readiness = MagicMock()
 
         dispatcher = MagicMock(name="QueueDispatcher")
         with patch.object(server, "register_inprocess_executor", autospec=True) as mock_register:
@@ -199,6 +203,7 @@ class TestMayaMcpServerApi:
         server = object.__new__(srv_mod.MayaMcpServer)
         server._dcc_name = "maya"
         server._server = MagicMock()
+        server._readiness = MagicMock()
 
         with patch.object(server, "register_inprocess_executor", autospec=True) as mock_register:
             server.attach_dispatcher(None)

--- a/tests/test_skills_round46.py
+++ b/tests/test_skills_round46.py
@@ -31,6 +31,9 @@ def _make_server(with_dispatcher=False):
     server._config = MagicMock()
     server._handle = None
     server._maya_dispatcher = None
+    # Readiness binder is created in ``__init__``; bypassing it means
+    # we must supply a stand-in so ``attach_dispatcher`` can re-bind.
+    server._readiness = MagicMock()
 
     # Mock the inner McpHttpServer with a registry and handler tracking
     mock_inner = MagicMock()
@@ -98,6 +101,9 @@ class TestExecutorRegistration:
         server = object.__new__(MayaMcpServer)
         server._dcc_name = "maya"
         server._server = MagicMock()
+        # Readiness binder created in ``__init__``; supply a stand-in
+        # so ``attach_dispatcher`` can re-bind without crashing.
+        server._readiness = MagicMock()
         dispatcher = MagicMock()
         server.attach_dispatcher(dispatcher)
         server._server.attach_dispatcher.assert_called_once_with(dispatcher)


### PR DESCRIPTION
Closes #184.

## Problem

Maya's embedded MCP HTTP server publishes itself to the `FileRegistry` **before** Maya's main thread has finished booting. During that window `list_dcc_instances` reports `status: "available"`, any `tools/call` with `affinity: main` is accepted and blocks until Maya finishes loading, and the gateway's first auto-aggregation probe fails because the fresh HTTP listener hasn't answered its first request yet.

End-user symptom: *"我们的服务已经启动，但 maya 卡住了"* — the MCP service looks up, tools/list is full, but every scripted call hangs silently waiting on the main thread.

## Solution

Wire a three-state readiness probe driven by the Maya adapter:

| Bit          | Flips to `true` when…                                                        |
|--------------|------------------------------------------------------------------------------|
| `process`    | Python interpreter is alive (always `true` while the server object exists). |
| `dispatcher` | `register_inprocess_executor(...)` has wired the in-process executor.       |
| `dcc`        | Maya's main thread has executed one cheap no-op probe via the UI dispatcher. |

Only when all three are `true` should `/v1/readyz` return `200`.

On `MayaStandaloneDispatcher` (mayapy / batch) the `dcc` bit flips synchronously because there is no event loop to wait on. In interactive Maya the flip happens after the first idle pump tick, so `dcc=true` is an honest "main thread is alive and pumping" signal.

## New surface

- `src/dcc_mcp_maya/_readiness.py` — `ReadinessReport`, `StaticReadiness`, `ReadinessProbe`, `install_readiness`, `resolve_readiness_timeout_secs`, `ENV_READINESS_TIMEOUT_SECS`.
- `MayaMcpServer.readiness_report()` → `{"process": bool, "dispatcher": bool, "dcc": bool}`.
- `MayaMcpServer.readiness` — probe handle for tests / orchestrators.
- `MayaMcpServer(readiness_timeout_secs=…)` and `start_server(...)` kwarg; also read from `DCC_MCP_MAYA_READINESS_TIMEOUT_SECS`.

## Core forward-compat

Core 0.14.23 / 0.14.26 do **not** yet expose the `StaticReadiness` Python binding promised in the issue — that's pending in core 0.14.27. The Maya adapter therefore drives an **in-process** report today and best-effort publishes it to `server._config.readiness` the moment core ships the attribute (`hasattr` guarded, silent no-op on older core wheels). No surrounding code changes will be required once core 0.14.27 lands.

## Tests

`tests/test_readiness.py` — 31 tests covering:

- `ReadinessReport` / `StaticReadiness` contract.
- `resolve_readiness_timeout_secs` — env + argument priority, invalid values collapse to `None` with a warning.
- `ReadinessProbe.bind`:
  - no dispatcher → both bits red.
  - standalone dispatcher → both bits flip green synchronously.
  - never-pumping fake dispatcher → `dispatcher=True, dcc=False` (so Maya-side tests in CI can assert exactly the "hung boot" behaviour).
  - idempotent re-bind.
  - injectable probe scheduler (unit-test friendly).
  - forward-compat publish to `config.readiness` when available.
  - silent no-op on older core (no `readiness` attr).
- End-to-end: `MayaMcpServer` constructor, `attach_dispatcher`, and the two timeout resolution paths.

Full suite on my box: **785 passed, 11 skipped, 60 deselected, 4 xfailed** — no regressions.

## Docs

- `AGENTS.md` — new "Runtime Readiness" section, env var row, file index row.
- `llms.txt` / `llms-full.txt` — public symbol list + env-var row.

## Dependencies

- Core side will need to stop probing with `/health` and instead consume `/v1/readyz` — that's a companion core issue. Once both land, the gateway can wait for `/v1/readyz` to turn green before marking the backend live and before running its first `tools/list` fan-out, closing the race described in #184.