### PR TITLE
fix: prune Maya log files on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,10 +72,15 @@ uv.lock
 /0.14.*
 /0.15.*
 
-# Local documentation (development reference only)
+# Local documentation and agent scratch files (development reference only)
 DOCKER_CHANGES.md
 DOCKER_QUICK_START.md
-.codebuddy/automations/
+.codebuddy/
+/MCP_Usage_Feedback_Report.md
+/REVIEW_REPORTS/
+/create_dynamics_animation.py
+/task_completion_report.md
+/test_maya_commands.py
 
 # Mock artefacts occasionally produced by tests that patch `cmds.file`
 /MagicMock/

--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -353,6 +353,12 @@ def _post_start(cfg: dict) -> None:
     _print_startup_info(cfg)
     _install_shutdown_safety()
     try:
+        from dcc_mcp_maya._log_hygiene import prune_maya_logs  # noqa: PLC0415
+
+        prune_maya_logs()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("log pruning skipped: %s", exc)
+    try:
         from dcc_mcp_maya._stale_cleanup import warn_if_too_many_stale  # noqa: PLC0415
 
         warn_if_too_many_stale(

--- a/src/dcc_mcp_maya/_log_hygiene.py
+++ b/src/dcc_mcp_maya/_log_hygiene.py
@@ -1,0 +1,38 @@
+"""Best-effort cleanup for dcc-mcp log files."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RETENTION_DAYS = 14
+DEFAULT_MAX_TOTAL_SIZE_MB = 200
+
+
+def prune_maya_logs(
+    *,
+    retention_days: int = DEFAULT_RETENTION_DAYS,
+    max_total_size_mb: int = DEFAULT_MAX_TOTAL_SIZE_MB,
+) -> Optional[object]:
+    """Prune old dcc-mcp log files when core exposes log retention.
+
+    ``dcc-mcp-core`` 0.15.8 exports ``prune_old_logs``.  Older local test
+    environments may not have it yet, so this helper is intentionally a no-op
+    when the symbol is absent.
+    """
+    try:
+        from dcc_mcp_core import prune_old_logs  # noqa: PLC0415
+    except ImportError:
+        logger.debug("log pruning unavailable: dcc_mcp_core.prune_old_logs missing")
+        return None
+
+    try:
+        return prune_old_logs(
+            retention_days=retention_days,
+            max_total_size_mb=max_total_size_mb,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("log pruning failed: %s", exc)
+        return None

--- a/tests/test_log_hygiene.py
+++ b/tests/test_log_hygiene.py
@@ -1,0 +1,35 @@
+"""Tests for Maya log hygiene helpers."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from dcc_mcp_maya._log_hygiene import prune_maya_logs
+
+
+def test_prune_maya_logs_calls_core_pruner_when_available():
+    core = MagicMock()
+    core.prune_old_logs.return_value = {"removed": 2}
+
+    with patch.dict(sys.modules, {"dcc_mcp_core": core}):
+        result = prune_maya_logs(retention_days=7, max_total_size_mb=50)
+
+    assert result == {"removed": 2}
+    core.prune_old_logs.assert_called_once_with(retention_days=7, max_total_size_mb=50)
+
+
+def test_prune_maya_logs_noops_when_core_symbol_missing():
+    core = MagicMock()
+    del core.prune_old_logs
+
+    with patch.dict(sys.modules, {"dcc_mcp_core": core}):
+        assert prune_maya_logs() is None
+
+
+def test_prune_maya_logs_swallows_core_failures():
+    core = MagicMock()
+    core.prune_old_logs.side_effect = RuntimeError("disk busy")
+
+    with patch.dict(sys.modules, {"dcc_mcp_core": core}):
+        assert prune_maya_logs() is None

--- a/tests/test_plugin_uninit_cleanup.py
+++ b/tests/test_plugin_uninit_cleanup.py
@@ -93,19 +93,22 @@ class TestUninitializePluginCleanup:
 
 
 class TestInitializePluginStaleScan:
-    """At startup, plugin best-effort warns about pre-existing stale entries."""
+    """At startup, plugin best-effort runs hygiene checks."""
 
-    def test_stale_scan_invoked_after_start(self, plugin_module):
+    def test_stale_scan_and_log_prune_invoked_after_start(self, plugin_module):
         module, _ = plugin_module
         with patch.object(module, "_print_startup_info"), patch.object(module, "_install_shutdown_safety"):
-            with patch("dcc_mcp_maya._stale_cleanup.warn_if_too_many_stale") as warn:
+            with patch("dcc_mcp_maya._log_hygiene.prune_maya_logs") as prune, patch(
+                "dcc_mcp_maya._stale_cleanup.warn_if_too_many_stale"
+            ) as warn:
                 module._post_start({})
+        prune.assert_called_once()
         warn.assert_called_once()
 
     def test_stale_scan_failure_does_not_break_init(self, plugin_module):
         module, _ = plugin_module
         with patch.object(module, "_print_startup_info"), patch.object(module, "_install_shutdown_safety"):
-            with patch(
+            with patch("dcc_mcp_maya._log_hygiene.prune_maya_logs"), patch(
                 "dcc_mcp_maya._stale_cleanup.warn_if_too_many_stale",
                 side_effect=RuntimeError("scan boom"),
             ):


### PR DESCRIPTION
## Summary
- ignore local CodeBuddy scratch/report files in .gitignore
- call dcc-mcp-core prune_old_logs during plugin post-start when available
- keep pruning best-effort for older local core versions

## Tests
- python -m ruff check src tests maya/plugin/dcc_mcp_maya_plugin.py
- python -m ruff format --check src/ tests/
- python -m pytest tests/test_log_hygiene.py tests/test_plugin_uninit_cleanup.py tests/test_pyexec_autocorrect.py -q

Closes #204