### PR TITLE
refactor: split Maya registration into phases

### DIFF
--- a/src/dcc_mcp_maya/_registration.py
+++ b/src/dcc_mcp_maya/_registration.py
@@ -1,0 +1,139 @@
+"""Registration phases for MayaMcpServer builtin actions."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Sequence
+
+
+@dataclass
+class RegistrationContext:
+    """Input shared by every registration phase."""
+
+    server: Any
+    extra_skill_paths: Optional[List[str]] = None
+    include_bundled: bool = True
+    minimal: Optional[bool] = None
+    strict_scan: Optional[bool] = None
+
+
+@dataclass
+class PhaseOutcome:
+    """Result for one registration phase."""
+
+    name: str
+    success: bool
+    elapsed_secs: float
+    error: Optional[str] = None
+
+
+@dataclass
+class RegistrationReport:
+    """Summary emitted after builtin-action registration completes."""
+
+    outcomes: List[PhaseOutcome] = field(default_factory=list)
+
+    @property
+    def success(self) -> bool:
+        return all(outcome.success for outcome in self.outcomes)
+
+    @property
+    def elapsed_secs(self) -> float:
+        return sum(outcome.elapsed_secs for outcome in self.outcomes)
+
+
+class RegistrationPhase:
+    """Base class for one side-effect in Maya builtin registration."""
+
+    name = "registration"
+    fatal_exceptions = ()
+
+    def run(self, context: RegistrationContext) -> None:
+        raise NotImplementedError
+
+
+class CoreBuiltinActionsPhase(RegistrationPhase):
+    name = "core_builtin_actions"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._register_core_builtin_actions(context)  # noqa: SLF001
+
+
+class StrictSkillScanPhase(RegistrationPhase):
+    name = "strict_skill_scan"
+    fatal_exceptions = (ValueError,)
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._run_strict_skill_scan_if_enabled(  # noqa: SLF001
+            context.strict_scan,
+            context.extra_skill_paths,
+            context.include_bundled,
+        )
+
+
+class CapabilityManifestPhase(RegistrationPhase):
+    name = "capability_manifest"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._register_capability_manifest_tool()  # noqa: SLF001
+
+
+class ProjectToolsPhase(RegistrationPhase):
+    name = "project_tools"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._attach_project_tools()  # noqa: SLF001
+
+
+class ResourcesPhase(RegistrationPhase):
+    name = "resources"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._attach_resources()  # noqa: SLF001
+
+
+def default_registration_phases() -> Sequence[RegistrationPhase]:
+    return (
+        CoreBuiltinActionsPhase(),
+        StrictSkillScanPhase(),
+        CapabilityManifestPhase(),
+        ProjectToolsPhase(),
+        ResourcesPhase(),
+    )
+
+
+def run_registration_phases(phases: Sequence[RegistrationPhase], context: RegistrationContext) -> RegistrationReport:
+    report = RegistrationReport()
+    for phase in phases:
+        started = time.monotonic()
+        try:
+            phase.run(context)
+        except phase.fatal_exceptions as exc:
+            report.outcomes.append(
+                PhaseOutcome(
+                    name=phase.name,
+                    success=False,
+                    elapsed_secs=time.monotonic() - started,
+                    error=str(exc),
+                )
+            )
+            raise
+        except Exception as exc:  # noqa: BLE001 - phase loop localizes optional integration failures
+            report.outcomes.append(
+                PhaseOutcome(
+                    name=phase.name,
+                    success=False,
+                    elapsed_secs=time.monotonic() - started,
+                    error=str(exc),
+                )
+            )
+        else:
+            report.outcomes.append(
+                PhaseOutcome(
+                    name=phase.name,
+                    success=True,
+                    elapsed_secs=time.monotonic() - started,
+                )
+            )
+    return report

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -40,6 +40,7 @@ from dcc_mcp_maya import (
     _executor,
     _project_tools,
     _readiness,
+    _registration,
     _resources,
     _skill_loader,
     _transport,
@@ -396,16 +397,30 @@ class MayaMcpServer(DccServerBase):
         strict_scan: Optional[bool] = None,
     ) -> "MayaMcpServer":
         """Discover Maya skills and attach Maya-specific core integrations."""
-        super().register_builtin_actions(
+        context = _registration.RegistrationContext(
+            server=self,
             extra_skill_paths=extra_skill_paths,
             include_bundled=include_bundled,
-            minimal_mode=self._build_minimal_mode_config(minimal),
+            minimal=minimal,
+            strict_scan=strict_scan,
         )
-        self._run_strict_skill_scan_if_enabled(strict_scan, extra_skill_paths, include_bundled)
-        self._register_capability_manifest_tool()
-        self._attach_project_tools()
-        self._attach_resources()
+        report = _registration.run_registration_phases(_registration.default_registration_phases(), context)
+        self._registration_report = report
+        logger.info(
+            "[%s] builtin action registration completed success=%s phases=%s elapsed=%.3fs",
+            self._dcc_name,
+            report.success,
+            len(report.outcomes),
+            report.elapsed_secs,
+        )
         return self
+
+    def _register_core_builtin_actions(self, context: _registration.RegistrationContext) -> None:
+        super().register_builtin_actions(
+            extra_skill_paths=context.extra_skill_paths,
+            include_bundled=context.include_bundled,
+            minimal_mode=self._build_minimal_mode_config(context.minimal),
+        )
 
     def _build_minimal_mode_config(self, minimal: Optional[bool]) -> Any:
         """Return Maya's core MinimalModeConfig or ``None`` for full mode."""

--- a/tests/test_registration_phases.py
+++ b/tests/test_registration_phases.py
@@ -1,0 +1,81 @@
+"""Tests for Maya builtin registration phases."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dcc_mcp_maya import _registration
+
+
+class _RecordingPhase(_registration.RegistrationPhase):
+    def __init__(self, name: str, calls: list, fail: bool = False) -> None:
+        self.name = name
+        self._calls = calls
+        self._fail = fail
+
+    def run(self, context: _registration.RegistrationContext) -> None:
+        self._calls.append((self.name, context.server))
+        if self._fail:
+            raise RuntimeError("boom")
+
+
+def test_default_registration_phases_are_ordered() -> None:
+    names = [phase.name for phase in _registration.default_registration_phases()]
+    assert names == [
+        "core_builtin_actions",
+        "strict_skill_scan",
+        "capability_manifest",
+        "project_tools",
+        "resources",
+    ]
+
+
+def test_run_registration_phases_records_success_and_failure() -> None:
+    calls = []
+    server = MagicMock()
+    context = _registration.RegistrationContext(server=server)
+
+    report = _registration.run_registration_phases(
+        [
+            _RecordingPhase("one", calls),
+            _RecordingPhase("two", calls, fail=True),
+            _RecordingPhase("three", calls),
+        ],
+        context,
+    )
+
+    assert [outcome.name for outcome in report.outcomes] == ["one", "two", "three"]
+    assert [outcome.success for outcome in report.outcomes] == [True, False, True]
+    assert report.success is False
+    assert report.outcomes[1].error == "boom"
+    assert [call[0] for call in calls] == ["one", "two", "three"]
+
+
+def test_strict_scan_value_error_remains_fatal() -> None:
+    server = MagicMock()
+    server._run_strict_skill_scan_if_enabled.side_effect = ValueError("bad skill")
+    context = _registration.RegistrationContext(server=server, strict_scan=True)
+
+    with pytest.raises(ValueError):
+        _registration.run_registration_phases([_registration.StrictSkillScanPhase()], context)
+
+
+def test_phase_methods_delegate_to_server() -> None:
+    server = MagicMock()
+    context = _registration.RegistrationContext(
+        server=server,
+        extra_skill_paths=["extras"],
+        include_bundled=False,
+        strict_scan=True,
+    )
+
+    for phase in _registration.default_registration_phases():
+        phase.run(context)
+
+    server._register_core_builtin_actions.assert_called_once_with(context)
+    server._run_strict_skill_scan_if_enabled.assert_called_once_with(True, ["extras"], False)
+    server._register_capability_manifest_tool.assert_called_once_with()
+    server._attach_project_tools.assert_called_once_with()
+    server._attach_resources.assert_called_once_with()


### PR DESCRIPTION
## Summary
- add RegistrationContext, PhaseOutcome, and RegistrationReport
- extract Maya builtin registration side effects into ordered RegistrationPhase classes
- keep strict scan ValueError fail-fast while optional integrations are localized to the phase loop
- store and log the registration report after phase execution

## Tests
- python -m ruff check src tests maya/plugin/dcc_mcp_maya_plugin.py
- python -m ruff format --check src/ tests/
- python -m pytest tests/test_registration_phases.py tests/test_server.py::TestStrictSkillScan -q
- python -m pytest -q

Closes #197