### PR TITLE
refactor: narrow typed output exception handling

### DIFF
--- a/src/dcc_mcp_maya/api.py
+++ b/src/dcc_mcp_maya/api.py
@@ -74,6 +74,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import logging
+from dataclasses import asdict, is_dataclass
 from typing import Any, Callable, Dict, Generator, List, Optional, TypeVar
 
 # Import third-party modules
@@ -786,7 +787,8 @@ def _default_schema_deriver(tp: Any) -> Optional[Dict[str, Any]]:
     """Default schema deriver using core's ``derive_schema``."""
     try:
         schema = derive_schema(tp)
-    except Exception:  # noqa: BLE001 — never fail a skill over schema derivation
+    except (TypeError, ValueError, AttributeError) as exc:
+        logger.debug("typed output schema derivation failed for %r: %s", tp, exc)
         return None
     return schema if isinstance(schema, dict) else None
 
@@ -800,18 +802,13 @@ def _default_as_plain_dict(value: Any) -> Dict[str, Any]:
     """
     if isinstance(value, dict):
         return dict(value)
-    try:
-        from dataclasses import asdict, is_dataclass  # noqa: PLC0415
-
-        if is_dataclass(value):
-            return asdict(value)
-    except Exception:  # noqa: BLE001
-        pass
+    if is_dataclass(value):
+        return asdict(value)
     if hasattr(value, "_asdict"):  # namedtuple
         try:
             return dict(value._asdict())
-        except Exception:  # noqa: BLE001
-            pass
+        except (TypeError, ValueError) as exc:
+            logger.debug("typed output namedtuple serialisation failed for %r: %s", type(value), exc)
     if hasattr(value, "__dict__"):
         return {k: v for k, v in vars(value).items() if not k.startswith("_")}
     return {"value": value}

--- a/src/dcc_mcp_maya/capability_manifest.py
+++ b/src/dcc_mcp_maya/capability_manifest.py
@@ -585,8 +585,8 @@ def _as_dict(value: Any) -> Dict[str, Any]:
             result = to_dict()
             if isinstance(result, dict):
                 return result
-        except Exception:  # noqa: BLE001
-            pass
+        except (TypeError, ValueError, AttributeError) as exc:
+            logger.debug("capability manifest: to_dict(%r) failed: %s", type(value), exc)
     # Best-effort: pull public attributes.
     out: Dict[str, Any] = {}
     for attr in dir(value):
@@ -594,7 +594,8 @@ def _as_dict(value: Any) -> Dict[str, Any]:
             continue
         try:
             candidate = getattr(value, attr)
-        except Exception:  # noqa: BLE001
+        except (AttributeError, TypeError) as exc:
+            logger.debug("capability manifest: getattr(%r, %s) failed: %s", type(value), attr, exc)
             continue
         if callable(candidate):
             continue

--- a/tests/test_capability_manifest.py
+++ b/tests/test_capability_manifest.py
@@ -27,9 +27,38 @@ from unittest.mock import MagicMock
 from dcc_mcp_maya.capability_manifest import (
     CapabilityRecord,
     MayaCapabilityManifestBuilder,
+    _as_dict,
     build_manifest_payload,
     register_capability_mcp_tool,
 )
+
+# ---------------------------------------------------------------------------
+# _as_dict fallback conversion
+# ---------------------------------------------------------------------------
+
+
+class _BadToDict:
+    keep = "visible"
+
+    def to_dict(self):
+        raise ValueError("bad conversion")
+
+
+class _BadAttr:
+    ok = "yes"
+
+    @property
+    def broken(self):
+        raise AttributeError("not available")
+
+
+def test_as_dict_falls_back_when_to_dict_raises_expected_error():
+    assert _as_dict(_BadToDict())["keep"] == "visible"
+
+
+def test_as_dict_skips_expected_attribute_errors():
+    assert _as_dict(_BadAttr()) == {"ok": "yes"}
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_typed_api_output.py
+++ b/tests/test_typed_api_output.py
@@ -226,14 +226,15 @@ def test_default_deriver_swallows_upstream_crash(monkeypatch):
         _boom(SphereResult)
 
 
-def test_real_default_deriver_returns_none_when_core_schema_breaks(monkeypatch):
+@pytest.mark.parametrize("exc_type", [TypeError, ValueError, AttributeError])
+def test_real_default_deriver_returns_none_when_core_schema_breaks(monkeypatch, exc_type):
     # Simulate the ``from dcc_mcp_core.schema import derive_schema`` call
     # raising inside ``_default_schema_deriver``.  The helper must NOT
-    # propagate the exception.
+    # propagate expected schema-derivation failures.
     import dcc_mcp_maya.api as api_mod
 
     def _broken(tp):
-        raise ValueError("schema derivation broken")
+        raise exc_type("schema derivation broken")
 
     monkeypatch.setattr(api_mod, "derive_schema", _broken, raising=True)
     assert api_mod._default_schema_deriver(SphereResult) is None


### PR DESCRIPTION
## Summary
- narrow typed output schema derivation exceptions to expected schema/attribute failures
- remove broad exception swallowing from typed-result serialization fallbacks
- add debug logging for expected fallback conversions
- cover capability manifest and typed API fallback behavior with tests

## Tests
- python -m ruff check src tests maya/plugin/dcc_mcp_maya_plugin.py
- python -m ruff format --check src/ tests/
- python -m pytest tests/test_typed_api_output.py tests/test_capability_manifest.py -q

Closes #195