### PR TITLE
fix(docs): validate VitePress build on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+      - "examples/mcp/**"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "examples/mcp/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -42,11 +49,13 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/guide/local-mcp-debug.md
+++ b/docs/guide/local-mcp-debug.md
@@ -34,7 +34,7 @@ If the connection fails: confirm Maya is running, the plugin is loaded, no other
 
 ## 3. Connect Claude Desktop (reference)
 
-Add to `claude_desktop_config.json` (see [CLAUDE.md](../../CLAUDE.md)):
+Add to `claude_desktop_config.json` (see the repository root `CLAUDE.md`):
 
 ```json
 {

--- a/docs/zh/guide/local-mcp-debug.md
+++ b/docs/zh/guide/local-mcp-debug.md
@@ -34,7 +34,7 @@
 
 ## 3. 连接 Claude Desktop（参考）
 
-在 `claude_desktop_config.json` 中加入（详见 [CLAUDE.md](../../CLAUDE.md)）：
+在 `claude_desktop_config.json` 中加入（详见仓库根目录 `CLAUDE.md`）：
 
 ```json
 {


### PR DESCRIPTION
## Summary
- remove dead VitePress links to root CLAUDE.md from local MCP debug docs
- run the docs VitePress build on pull requests that touch docs/examples docs inputs
- keep Pages artifact upload and deploy push-only so PRs only validate build output

## Validation
- git diff --check
- npm ci --prefix docs && npm run build --prefix docs (Windows local reaches VitePress render phase; original dead-link failure is gone, CI validates on Ubuntu)

Fixes docs release failure from run 25838421174.