### PR TITLE
feat(sidecar): Maya-side wire-frame dispatcher \u2014 closes sidecar \u2192 DCC loop (RFC #998 Phase 2)

### DIFF
--- a/src/dcc_mcp_maya/_sidecar.py
+++ b/src/dcc_mcp_maya/_sidecar.py
@@ -1,0 +1,25 @@
+"""Wire-format entry point for the ``dcc-mcp-server sidecar`` binary.
+
+The sidecar binary (RFC #998 Phase 2) reaches Maya by sending a single
+Python expression over the host's ``commandPort``::
+
+    __import__('dcc_mcp_maya._sidecar', fromlist=['dispatch']).dispatch(
+        {"action": ..., "args": ..., "request_id": ...}
+    )
+
+That import path is **pinned** in the Rust client (see
+``dcc-mcp-host-rpc`` ``commandport.rs``) so we must keep the module
+name and ``dispatch`` symbol exactly as the binary expects. This file
+is intentionally a one-line shim — the real implementation lives in
+:mod:`dcc_mcp_maya.sidecar._dispatcher` alongside the rest of the
+sidecar support code.
+
+Skill authors should never import this module directly. The leading
+underscore is the canonical "internal API" marker.
+"""
+
+from __future__ import annotations
+
+from dcc_mcp_maya.sidecar._dispatcher import dispatch, dispatch_payload
+
+__all__ = ["dispatch", "dispatch_payload"]

--- a/src/dcc_mcp_maya/sidecar/__init__.py
+++ b/src/dcc_mcp_maya/sidecar/__init__.py
@@ -59,6 +59,7 @@ from dcc_mcp_maya.sidecar._commandport import (
     allocate_free_port,
     build_host_rpc_uri,
 )
+from dcc_mcp_maya.sidecar._dispatcher import dispatch, dispatch_payload
 from dcc_mcp_maya.sidecar._resolver import (
     ENV_SIDECAR_BINARY,
     SidecarBinaryError,
@@ -82,6 +83,8 @@ __all__ = [
     "SidecarSpawnError",
     "allocate_free_port",
     "build_host_rpc_uri",
+    "dispatch",
+    "dispatch_payload",
     "is_sidecar_mode_enabled",
     "resolve_sidecar_binary",
     "start_sidecar",

--- a/src/dcc_mcp_maya/sidecar/_dispatcher.py
+++ b/src/dcc_mcp_maya/sidecar/_dispatcher.py
@@ -1,0 +1,339 @@
+"""Maya-side dispatcher for the sidecar wire frame (RFC #998 Phase 2).
+
+The sidecar Rust binary (``dcc-mcp-server sidecar`` shipped from
+``dcc-mcp-core``) connects to Maya's ``commandPort`` and sends a
+single-line Python expression per ``tools/call``::
+
+    __import__('dcc_mcp_maya._sidecar', fromlist=['dispatch']).dispatch(
+        {"action": "<backend_tool>", "args": {...}, "request_id": "..."}
+    )
+
+Maya's ``commandPort`` (opened with ``sourceType='python'``) evaluates
+that expression on the **main thread**, so this dispatcher inherits
+the same thread-affinity guarantees the in-process MCP HTTP server
+provides today. No cross-thread marshalling, no `executeDeferred`
+games — `cmds.*` is safe to call directly from the body of the skill
+script invoked by :func:`dispatch`.
+
+Returns
+-------
+
+The function returns a single-line **JSON string** that Maya's
+commandPort sends straight back to the sidecar. The Rust client parses
+it as a :class:`serde_json::Value`. Newlines and tabs are explicitly
+escaped (``ensure_ascii=False``) so a multi-line traceback does not
+break the line-oriented wire protocol.
+
+Error envelope
+--------------
+
+Any failure between "we received the wire frame" and "we have a real
+return value" is wrapped in a structured envelope (still single line)
+with ``success: false`` and an ``error`` discriminator the gateway can
+surface verbatim to MCP clients:
+
+* ``server-not-running`` — :class:`MayaMcpServer` was never started in
+  this Maya session, or has already been torn down. Operator should
+  load the dcc-mcp-maya plug-in.
+* ``payload-malformed`` — the wire frame failed shape validation
+  (missing ``action`` key, wrong types, etc.).
+* ``unknown-action`` — the action name is not in the running server's
+  action registry. May happen when the gateway has cached a tool from
+  a skill that was subsequently unloaded.
+* ``no-source-file`` — the action exists but its :class:`ToolMeta`
+  carries no ``source_file``. Usually means it is a Rust-implemented
+  built-in (e.g. ``search_tools``) that does not go through the
+  Python skill runner.
+* ``dispatch-failed`` — anything else (skill script raised, import
+  failed, etc.). Carries the formatted traceback in ``traceback``.
+
+The error envelope mirrors :func:`dcc_mcp_maya.api.maya_error` so
+gateway-side ranking heuristics (which already know that shape) keep
+working.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import traceback
+from typing import Any, Callable, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["dispatch", "dispatch_payload"]
+
+
+def dispatch(payload: Mapping[str, Any] | str) -> str:
+    """Entry point invoked by the sidecar binary's wire expression.
+
+    Always returns a single-line JSON string — never raises, never
+    returns ``None`` — so the line-oriented commandPort protocol stays
+    intact. Exceptions become structured envelopes carrying the
+    traceback for postmortem audit.
+
+    Args:
+        payload: The decoded wire frame from the sidecar. Accepts the
+            already-parsed mapping the wire expression hands us. A
+            JSON string is also tolerated to make manual smoke tests
+            from Maya's script editor easier (``dispatch('{"action":
+            "..."}')``).
+
+    Returns:
+        Single-line JSON string. Either the action's own return value
+        (re-serialised with ``ensure_ascii=False``) or one of the
+        structured error envelopes documented in the module docstring.
+    """
+    try:
+        return _dispatch_inner(payload, server_lookup=_default_server_lookup)
+    except Exception as exc:  # noqa: BLE001 — last-resort safety net
+        logger.exception("dcc-mcp-maya sidecar dispatch raised unexpectedly")
+        return _envelope(
+            success=False,
+            error="dispatch-failed",
+            message=f"unexpected dispatcher error: {exc}",
+            traceback=traceback.format_exc(),
+            request_id=_safe_request_id(payload),
+        )
+
+
+def dispatch_payload(
+    payload: Mapping[str, Any] | str,
+    *,
+    server_lookup: Optional[Callable[[], Any]] = None,
+) -> str:
+    """Like :func:`dispatch` but with an injectable server-lookup hook.
+
+    Exposed for unit tests that need to stub the running
+    :class:`MayaMcpServer` (which itself depends on ``maya.cmds``).
+    Production code always calls :func:`dispatch`.
+    """
+    lookup = server_lookup or _default_server_lookup
+    try:
+        return _dispatch_inner(payload, server_lookup=lookup)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("dcc-mcp-maya sidecar dispatch_payload raised unexpectedly")
+        return _envelope(
+            success=False,
+            error="dispatch-failed",
+            message=f"unexpected dispatcher error: {exc}",
+            traceback=traceback.format_exc(),
+            request_id=_safe_request_id(payload),
+        )
+
+
+# ── internals ──────────────────────────────────────────────────────
+
+
+def _dispatch_inner(
+    payload: Mapping[str, Any] | str,
+    *,
+    server_lookup: Callable[[], Any],
+) -> str:
+    parsed = _coerce_payload(payload)
+    if parsed is None:
+        return _envelope(
+            success=False,
+            error="payload-malformed",
+            message="payload must be a JSON object or dict with `action` key",
+            request_id="",
+        )
+    action_name = parsed.get("action")
+    if not isinstance(action_name, str) or not action_name.strip():
+        return _envelope(
+            success=False,
+            error="payload-malformed",
+            message="payload.action must be a non-empty string",
+            request_id=str(parsed.get("request_id") or ""),
+        )
+    args = parsed.get("args") or {}
+    if not isinstance(args, Mapping):
+        return _envelope(
+            success=False,
+            error="payload-malformed",
+            message="payload.args must be a JSON object (got "
+            f"{type(args).__name__})",
+            request_id=str(parsed.get("request_id") or ""),
+            action=action_name,
+        )
+    request_id = str(parsed.get("request_id") or "")
+
+    server = server_lookup()
+    if server is None:
+        return _envelope(
+            success=False,
+            error="server-not-running",
+            message=(
+                "MayaMcpServer is not initialised; load the dcc-mcp-maya "
+                "plug-in or call dcc_mcp_maya.start_server() before "
+                "dispatching"
+            ),
+            request_id=request_id,
+            action=action_name,
+        )
+
+    script_path = _resolve_script_path(server, action_name)
+    if script_path is None:
+        return _envelope(
+            success=False,
+            error="unknown-action",
+            message=f"action {action_name!r} is not registered with this Maya MCP server",
+            request_id=request_id,
+            action=action_name,
+        )
+    if not script_path:
+        return _envelope(
+            success=False,
+            error="no-source-file",
+            message=(
+                f"action {action_name!r} carries no source_file (likely "
+                "a Rust-implemented built-in); the sidecar cannot dispatch it"
+            ),
+            request_id=request_id,
+            action=action_name,
+        )
+
+    # ── execute the skill script on the current (main) thread ────
+    #
+    # We pull `run_skill_script` lazily so this module stays importable
+    # from CI / pytest where the local _executor module's lazy
+    # `maya.cmds` import would fire eagerly.
+    #
+    # ``run_skill_script`` already implements the full exception-to-
+    # envelope contract (catches every script-level exception, routes
+    # ``SystemExit`` through ``__mcp_result__``, wraps non-dict
+    # returns).  We do **not** wrap it in another try/except because
+    # the only thing that escapes is a programming error in our own
+    # dispatcher path — and that is caught by the outer safety net
+    # in :func:`dispatch` / :func:`dispatch_payload`.
+    from dcc_mcp_maya._executor import run_skill_script  # noqa: PLC0415
+
+    result = run_skill_script(script_path, dict(args))
+    if not isinstance(result, Mapping):
+        # Defensive: ``run_skill_script`` always returns a dict today,
+        # but if a future refactor relaxes that contract we still want
+        # a valid envelope on the wire.
+        result = {"success": True, "data": result}
+
+    # Enrich with correlation IDs from the wire frame so the gateway
+    # can match an async response to its request.  ``setdefault`` keeps
+    # any value the skill already produced (rare, but happens with
+    # the ``request_id`` echo pattern some pipeline skills use).
+    enriched = dict(result)
+    enriched.setdefault("request_id", request_id)
+    enriched.setdefault("action", action_name)
+    return _to_single_line_json(enriched)
+
+
+def _coerce_payload(payload: Mapping[str, Any] | str) -> Optional[Mapping[str, Any]]:
+    """Accept either an already-parsed dict or a JSON string."""
+    if isinstance(payload, Mapping):
+        return payload
+    if isinstance(payload, str):
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+        return obj if isinstance(obj, Mapping) else None
+    return None
+
+
+def _resolve_script_path(server: Any, action_name: str) -> Optional[str]:
+    """Return the script file backing the named action, or ``None``.
+
+    ``None`` distinguishes "action unknown" from "action exists but
+    has no source_file" — the latter returns an empty string so the
+    caller can surface ``no-source-file`` rather than ``unknown-action``.
+    """
+    try:
+        actions = server.list_actions()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "sidecar dispatch: server.list_actions() raised — treating action "
+            "%r as unknown. cause: %s",
+            action_name,
+            exc,
+        )
+        return None
+    for action in actions or ():
+        name = _attr_or_item(action, "name")
+        if name != action_name:
+            continue
+        source = _attr_or_item(action, "source_file")
+        if source is None:
+            return ""
+        return str(source)
+    return None
+
+
+def _attr_or_item(obj: Any, key: str) -> Any:
+    """Read ``obj.<key>`` if it exists, else ``obj[key]`` if mapping-like.
+
+    ``server.list_actions()`` returns Rust-backed objects with attribute
+    access; test stubs return dicts.  Supporting both keeps the test
+    surface unencumbered.
+    """
+    if hasattr(obj, key):
+        return getattr(obj, key)
+    if isinstance(obj, Mapping):
+        return obj.get(key)
+    return None
+
+
+def _default_server_lookup() -> Any:
+    """Return the currently-running :class:`MayaMcpServer`, if any.
+
+    The lookup is deferred so the dispatcher module can be imported in
+    test contexts that have never instantiated a MayaMcpServer (and
+    that therefore cannot tolerate the `maya.cmds` import the server
+    module's globals would otherwise trigger).
+    """
+    try:
+        from dcc_mcp_maya import server as _server_mod  # noqa: PLC0415
+    except ImportError:
+        return None
+    return getattr(_server_mod, "_server_instance", None)
+
+
+def _envelope(
+    *,
+    success: bool,
+    request_id: str,
+    error: str | None = None,
+    message: str | None = None,
+    traceback: str | None = None,
+    action: str | None = None,
+) -> str:
+    """Build a single-line JSON error / minimal-success envelope."""
+    body: dict[str, Any] = {"success": success, "request_id": request_id}
+    if action:
+        body["action"] = action
+    if error:
+        body["error"] = error
+    if message:
+        body["message"] = message
+    if traceback:
+        body["traceback"] = traceback
+    return _to_single_line_json(body)
+
+
+def _to_single_line_json(obj: Mapping[str, Any]) -> str:
+    """Serialise ``obj`` to JSON guaranteed to fit on one line.
+
+    Maya's ``commandPort`` is line-oriented: every ``\\n`` in the
+    response would be interpreted as "end of reply" by the sidecar's
+    ``read_line`` loop and any subsequent bytes would corrupt the
+    next request/response pair. We serialise with explicit separators
+    plus ``str.replace`` for the (rare) embedded newline / tab inside
+    string values.
+    """
+    encoded = json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
+    return encoded.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+
+
+def _safe_request_id(payload: Mapping[str, Any] | str) -> str:
+    if isinstance(payload, Mapping):
+        rid = payload.get("request_id")
+        if isinstance(rid, str):
+            return rid
+    return ""

--- a/tests/test_sidecar_dispatcher.py
+++ b/tests/test_sidecar_dispatcher.py
@@ -1,0 +1,425 @@
+"""Unit tests for :mod:`dcc_mcp_maya.sidecar._dispatcher`.
+
+The dispatcher is the Maya-side counterpart to the Rust ``CommandPortClient``
+(see dcc-mcp-core PR #1006). It accepts a wire frame from the sidecar
+binary, looks up the action in the running ``MayaMcpServer``, runs the
+backing skill script on the (commandPort-supplied) main thread, and
+returns a single-line JSON envelope.
+
+These tests stub ``server_lookup`` so we never need a real Maya — every
+permutation of the dispatcher's contract is covered without importing
+``maya.cmds``.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import os
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+from typing import Any, Callable, Iterator, Mapping, Optional
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_maya.sidecar._dispatcher import dispatch, dispatch_payload
+
+
+# ── server stubs ─────────────────────────────────────────────────
+
+
+class _StubAction:
+    """ToolMeta-shaped attribute access; mirrors the live registry entry."""
+
+    def __init__(self, name: str, source_file: Optional[str]) -> None:
+        self.name = name
+        self.source_file = source_file
+
+
+class _StubServer:
+    """Pretends to be the running :class:`MayaMcpServer`.
+
+    Records ``list_actions`` calls so tests can assert the dispatcher
+    really delegated. Raises whatever the test prepared so we can pin
+    the error-handling branches.
+    """
+
+    def __init__(
+        self,
+        actions: list[_StubAction] | None = None,
+        *,
+        raise_on_list: Exception | None = None,
+    ) -> None:
+        self._actions = actions or []
+        self._raise_on_list = raise_on_list
+        self.list_actions_call_count = 0
+
+    def list_actions(self) -> list[_StubAction]:
+        self.list_actions_call_count += 1
+        if self._raise_on_list is not None:
+            raise self._raise_on_list
+        return list(self._actions)
+
+
+def _server_lookup_returning(server: Any) -> Callable[[], Any]:
+    return lambda: server
+
+
+# ── skill-script fixtures ───────────────────────────────────────
+
+
+@pytest.fixture
+def skill_script_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+def _write_skill(script_dir: Path, name: str, body: str) -> Path:
+    """Write a tiny skill script that exposes ``main(**params)`` and
+    return its absolute path. ``body`` is the *function body* — it
+    gets indented and parameters from the wire frame are available as
+    ``params``.
+    """
+    src = textwrap.dedent(
+        f"""
+        def main(**params):
+{textwrap.indent(textwrap.dedent(body), "            ")}
+        """
+    )
+    script_path = script_dir / f"{name}.py"
+    script_path.write_text(src, encoding="utf-8")
+    return script_path
+
+
+# ── tests: payload validation ───────────────────────────────────
+
+
+class TestPayloadValidation:
+    """Pin the structured errors the dispatcher emits for malformed
+    wire frames. Each shape collapses to a single-line JSON envelope
+    even when the payload itself is nonsense."""
+
+    def test_non_dict_payload_returns_payload_malformed(self):
+        envelope = json.loads(dispatch_payload(42, server_lookup=lambda: None))
+        assert envelope["success"] is False
+        assert envelope["error"] == "payload-malformed"
+        assert "JSON object" in envelope["message"]
+
+    def test_missing_action_key_returns_payload_malformed(self):
+        envelope = json.loads(
+            dispatch_payload({"args": {}}, server_lookup=lambda: None)
+        )
+        assert envelope["success"] is False
+        assert envelope["error"] == "payload-malformed"
+
+    def test_empty_action_string_returns_payload_malformed(self):
+        envelope = json.loads(
+            dispatch_payload(
+                {"action": "   ", "args": {}, "request_id": "r"},
+                server_lookup=lambda: None,
+            )
+        )
+        assert envelope["error"] == "payload-malformed"
+        assert envelope["request_id"] == "r"
+
+    def test_non_object_args_returns_payload_malformed(self):
+        envelope = json.loads(
+            dispatch_payload(
+                {"action": "ok", "args": [1, 2], "request_id": "r"},
+                server_lookup=lambda: None,
+            )
+        )
+        assert envelope["error"] == "payload-malformed"
+        assert "JSON object" in envelope["message"]
+        assert envelope["action"] == "ok"
+
+    def test_string_payload_is_parsed_as_json(self):
+        envelope = json.loads(
+            dispatch_payload('{"action": "ok"}', server_lookup=lambda: None)
+        )
+        # The server lookup returns None, so we expect the
+        # `server-not-running` envelope — not a parse error.
+        assert envelope["error"] == "server-not-running"
+
+    def test_invalid_json_string_returns_payload_malformed(self):
+        envelope = json.loads(
+            dispatch_payload("{ not even close to json", server_lookup=lambda: None)
+        )
+        assert envelope["error"] == "payload-malformed"
+
+
+# ── tests: server lookup branches ──────────────────────────────
+
+
+class TestServerLookup:
+    def test_server_not_running_when_lookup_returns_none(self):
+        envelope = json.loads(
+            dispatch_payload(
+                {"action": "x", "args": {}, "request_id": "r1"},
+                server_lookup=lambda: None,
+            )
+        )
+        assert envelope["success"] is False
+        assert envelope["error"] == "server-not-running"
+        assert envelope["request_id"] == "r1"
+        assert envelope["action"] == "x"
+
+    def test_unknown_action_returns_structured_envelope(self):
+        server = _StubServer(actions=[_StubAction("known", "/tmp/known.py")])
+        envelope = json.loads(
+            dispatch_payload(
+                {"action": "mystery", "args": {}, "request_id": "r2"},
+                server_lookup=_server_lookup_returning(server),
+            )
+        )
+        assert envelope["error"] == "unknown-action"
+        assert envelope["action"] == "mystery"
+        assert envelope["request_id"] == "r2"
+        # The dispatcher must actually have asked the server for the
+        # action list — not just guessed.
+        assert server.list_actions_call_count == 1
+
+    def test_action_without_source_file_returns_no_source_file(self):
+        server = _StubServer(actions=[_StubAction("rust_builtin", None)])
+        envelope = json.loads(
+            dispatch_payload(
+                {"action": "rust_builtin", "args": {}, "request_id": "r3"},
+                server_lookup=_server_lookup_returning(server),
+            )
+        )
+        assert envelope["error"] == "no-source-file"
+        assert envelope["action"] == "rust_builtin"
+
+    def test_list_actions_raising_collapses_to_unknown_action(self):
+        # If the server's own list_actions blows up, we cannot know
+        # whether the action exists — collapse to `unknown-action`
+        # rather than masquerading as `dispatch-failed`.  The agent
+        # will see `unknown-action` and either retry or load_skill.
+        server = _StubServer(raise_on_list=RuntimeError("registry on fire"))
+        envelope = json.loads(
+            dispatch_payload(
+                {"action": "x", "args": {}, "request_id": "r4"},
+                server_lookup=_server_lookup_returning(server),
+            )
+        )
+        assert envelope["error"] == "unknown-action"
+
+
+# ── tests: real skill-script execution ──────────────────────────
+
+
+class TestDispatchExecution:
+    def test_happy_path_forwards_skill_return(self, skill_script_dir: Path):
+        script = _write_skill(
+            skill_script_dir,
+            "echo",
+            'return {"success": True, "echoed": params}',
+        )
+        server = _StubServer(actions=[_StubAction("echo_action", str(script))])
+
+        envelope = json.loads(
+            dispatch_payload(
+                {
+                    "action": "echo_action",
+                    "args": {"x": 1, "y": "hello"},
+                    "request_id": "r-happy",
+                },
+                server_lookup=_server_lookup_returning(server),
+            )
+        )
+
+        assert envelope["success"] is True
+        assert envelope["echoed"] == {"x": 1, "y": "hello"}
+
+    def test_skill_exception_returns_skill_exception_envelope(
+        self, skill_script_dir: Path
+    ):
+        # ``run_skill_script`` catches the RuntimeError and wraps it
+        # through ``dcc_mcp_core.skill.skill_exception``, producing a
+        # ``success: False`` envelope that includes the formatted
+        # exception. The dispatcher forwards it verbatim — same shape
+        # as the in-process path — and enriches with correlation IDs.
+        script = _write_skill(
+            skill_script_dir,
+            "exploder",
+            "raise RuntimeError('boom')",
+        )
+        server = _StubServer(actions=[_StubAction("exploder", str(script))])
+
+        envelope = json.loads(
+            dispatch_payload(
+                {"action": "exploder", "args": {}, "request_id": "r-fail"},
+                server_lookup=_server_lookup_returning(server),
+            )
+        )
+
+        assert envelope["success"] is False
+        # `error` carries `repr(exc)` per skill_exception's contract.
+        assert "RuntimeError" in envelope["error"]
+        assert "boom" in envelope["error"]
+        # Correlation IDs are enriched by the dispatcher itself, not
+        # by the skill.
+        assert envelope["request_id"] == "r-fail"
+        assert envelope["action"] == "exploder"
+
+    def test_non_dict_return_wrapped_as_success_message(
+        self, skill_script_dir: Path
+    ):
+        # ``run_skill_script`` already wraps non-dict returns into
+        # ``{"success": True, "message": str(value)}`` — the
+        # dispatcher passes that through and adds correlation IDs.
+        script = _write_skill(skill_script_dir, "primitive", "return 42")
+        server = _StubServer(actions=[_StubAction("primitive", str(script))])
+
+        envelope = json.loads(
+            dispatch_payload(
+                {"action": "primitive", "args": {}, "request_id": "r-int"},
+                server_lookup=_server_lookup_returning(server),
+            )
+        )
+        assert envelope["success"] is True
+        assert envelope["message"] == "42"
+        assert envelope["request_id"] == "r-int"
+        assert envelope["action"] == "primitive"
+
+    def test_skill_system_exit_is_silent_success(
+        self, skill_script_dir: Path
+    ):
+        # ``run_skill_script`` intercepts ``SystemExit`` and returns
+        # the script's ``__mcp_result__`` if present, else a default
+        # ``{"success": True, "message": "Script executed"}``.  The
+        # dispatcher then enriches with correlation IDs.
+        script = _write_skill(
+            skill_script_dir,
+            "bailer",
+            "raise SystemExit(0)",
+        )
+        server = _StubServer(actions=[_StubAction("bailer", str(script))])
+
+        envelope = json.loads(
+            dispatch_payload(
+                {"action": "bailer", "args": {}, "request_id": "r-bail"},
+                server_lookup=_server_lookup_returning(server),
+            )
+        )
+        assert envelope["success"] is True
+        assert envelope["request_id"] == "r-bail"
+        assert envelope["action"] == "bailer"
+
+
+# ── tests: wire-format guarantees ───────────────────────────────
+
+
+class TestWireFormatGuarantees:
+    """The Rust ``CommandPortClient`` reads exactly one line per call.
+    Multi-line JSON would corrupt the next request's response.  These
+    tests pin that contract."""
+
+    def test_response_is_always_single_line(self, skill_script_dir: Path):
+        script = _write_skill(
+            skill_script_dir,
+            "multiliner",
+            'return {"success": True, "log": "line1\\nline2\\nline3"}',
+        )
+        server = _StubServer(actions=[_StubAction("multiliner", str(script))])
+
+        response = dispatch_payload(
+            {"action": "multiliner", "args": {}, "request_id": "r-ml"},
+            server_lookup=_server_lookup_returning(server),
+        )
+        assert "\n" not in response, (
+            f"response must not contain literal LF; got: {response!r}"
+        )
+        # JSON-decoded value still has the escape preserved so the
+        # gateway / MCP client sees the original newline.
+        envelope = json.loads(response)
+        assert envelope["log"] == "line1\nline2\nline3"
+
+    def test_traceback_envelope_is_single_line(self):
+        # A failing skill produces a multi-line traceback — the most
+        # common newline-corrupting case.  This explicit test guards
+        # against regressions where someone forgets to call
+        # `_to_single_line_json` on the error path.
+        server = _StubServer(actions=[_StubAction("boom", "/does/not/exist.py")])
+        response = dispatch_payload(
+            {"action": "boom", "args": {}, "request_id": "r-tb"},
+            server_lookup=_server_lookup_returning(server),
+        )
+        assert "\n" not in response
+        envelope = json.loads(response)
+        assert envelope["success"] is False
+
+    def test_response_is_valid_utf8_json(self, skill_script_dir: Path):
+        # Confirm we don't ASCII-mangle multi-byte characters in
+        # localised skill names / messages.
+        script = _write_skill(
+            skill_script_dir,
+            "i18n",
+            'return {"success": True, "message": "已完成 (done)"}',
+        )
+        server = _StubServer(actions=[_StubAction("i18n", str(script))])
+        response = dispatch_payload(
+            {"action": "i18n", "args": {}, "request_id": "r-i18n"},
+            server_lookup=_server_lookup_returning(server),
+        )
+        envelope = json.loads(response)
+        assert envelope["message"] == "已完成 (done)"
+        # Confirm the raw line is NOT pre-escaped to ASCII (`\u5df2`
+        # would mean we lost ensure_ascii=False).  Either form is
+        # technically valid JSON, but we choose the smaller wire form.
+        assert "已" in response, (
+            f"i18n chars should ship as UTF-8 on the wire, got: {response!r}"
+        )
+
+
+# ── tests: top-level _sidecar shim ──────────────────────────────
+
+
+class TestTopLevelShim:
+    """The Rust client's wire frame imports
+    ``dcc_mcp_maya._sidecar.dispatch``.  Pin that module exists and
+    its ``dispatch`` symbol resolves to the same callable the
+    sidecar package exports — a wire-format compat smoke test."""
+
+    def test_underscored_sidecar_module_is_importable(self):
+        import dcc_mcp_maya._sidecar as wire_entry
+
+        from dcc_mcp_maya.sidecar import dispatch as canonical_dispatch
+
+        assert wire_entry.dispatch is canonical_dispatch
+
+    def test_dispatch_via_top_level_module(self):
+        import dcc_mcp_maya._sidecar as wire_entry
+
+        envelope = json.loads(
+            wire_entry.dispatch({"action": "any", "args": {}, "request_id": "r"})
+        )
+        # Without a stub server in place we reach the
+        # ``server-not-running`` branch — proves the shim is
+        # forwarding to the real dispatcher.
+        assert envelope["error"] == "server-not-running"
+
+
+# ── tests: catch-all safety ─────────────────────────────────────
+
+
+def test_dispatcher_never_raises_to_caller():
+    """The commandPort wire is single-line and synchronous.  Any
+    exception escaping the dispatcher would corrupt Maya's reply
+    handler, so the outer entry point MUST always return a string."""
+
+    def boom_lookup() -> Any:
+        raise RuntimeError("server_lookup itself raised")
+
+    response = dispatch_payload(
+        {"action": "x", "args": {}, "request_id": "r-catch"},
+        server_lookup=boom_lookup,
+    )
+    envelope = json.loads(response)
+    assert envelope["success"] is False
+    assert envelope["error"] == "dispatch-failed"
+    assert "server_lookup itself raised" in envelope["message"]


### PR DESCRIPTION
## Summary

Closes the **Maya half** of the sidecar dispatch loop (RFC #998 Phase 2).

The sidecar Rust binary (dcc-mcp-core PR loonghao/dcc-mcp-core#1006) ships single-line Python expressions over Maya's `commandPort`:

```python
__import__('dcc_mcp_maya._sidecar', fromlist=['dispatch']).dispatch(
    {"action": "...", "args": {...}, "request_id": "..."}
)
```

Before this PR there was no Python helper to receive that frame — the binary could dial Maya's commandPort but Maya's `eval` would fail with `ModuleNotFoundError: No module named 'dcc_mcp_maya._sidecar'`. This PR adds the receiver and the full envelope contract.

## What's new

### `src/dcc_mcp_maya/_sidecar.py` (24 lines)

Top-level shim whose import path matches the wire-frame literal pinned by dcc-mcp-core. Single line of re-exports; the real code lives in the sidecar sub-package alongside the supervisor / resolver / commandport helpers.

### `src/dcc_mcp_maya/sidecar/_dispatcher.py` (339 lines)

`dispatch(payload)` / `dispatch_payload(payload, server_lookup=...)` with the full contract:

| Behaviour | Detail |
|---|---|
| **Payload validation** | `payload-malformed` envelope for non-dict, missing `action`, empty action string, non-object `args`, invalid JSON string. |
| **Server lookup** | Pulls running `MayaMcpServer` lazily via `dcc_mcp_maya.server._server_instance`. `server-not-running` envelope when None. |
| **Action lookup** | `server.list_actions()` → match by `name` → read `source_file` from the `ToolMeta`. Distinguishes `unknown-action` from `no-source-file` (Rust-implemented built-ins). |
| **Execution** | Delegates to `dcc_mcp_maya._executor.run_skill_script` — same code path as in-process flow, so sidecar and in-process produce **identical envelopes** for the same input. |
| **Correlation** | Enriches the response with `request_id` + `action` via `setdefault`, so the gateway can match async responses to requests without overwriting any echo pattern skills already use. |
| **Wire-format guarantee** | Always single-line JSON via `ensure_ascii=False` + explicit `\n`/`\r`/`\t` escape. Commandport's line-oriented reply protocol stays intact even when responses contain tracebacks. |
| **Catch-all safety** | `dispatch` and `dispatch_payload` **never raise** — even `server_lookup` blowing up becomes a structured `dispatch-failed` envelope. |

### Error envelope discriminators (`error` field)

| `error` | When |
|---|---|
| `payload-malformed` | Wire frame failed shape validation. |
| `server-not-running` | `MayaMcpServer` not initialised in this Maya session. |
| `unknown-action` | Action not in `list_actions()`. May happen when a skill was unloaded after the gateway cached its tool. |
| `no-source-file` | Action exists but is a Rust built-in (e.g. `search_tools`) — sidecar dispatch doesn't apply. |
| `dispatch-failed` | Catch-all for anything else (server_lookup raised, etc.). Carries `traceback`. |

## Thread model

Maya's `commandPort` with `sourceType='python'` evaluates incoming expressions on the **main thread**. The dispatcher therefore inherits the same thread-affinity guarantees as the in-process MCP HTTP path — no cross-thread marshalling, no `executeDeferred` games. `cmds.*` is safe to call directly from inside any skill script the dispatcher invokes.

## Test plan

- [x] `pytest tests/test_sidecar_dispatcher.py` — **20 tests pass**:
  - Payload validation (6): non-dict, missing action, empty action, non-object args, string payload parsed, invalid JSON.
  - Server lookup (4): server-not-running, unknown-action, no-source-file, list_actions raising → unknown-action.
  - Real skill execution (4): happy path forwards skill return, exception → skill_exception envelope, non-dict return wrapped, `SystemExit` → silent success.
  - Wire-format guarantees (3): single-line response, single-line traceback envelope, UTF-8 preserved.
  - Top-level shim (2): `_sidecar.dispatch` is the same callable as `sidecar.dispatch`; round-trips.
  - Catch-all (1): never raises even when server_lookup raises.
- [x] `pytest tests/test_sidecar_dispatcher.py tests/test_sidecar_shim_lifecycle.py` — combined **35 tests pass** in 2.73 s.
- [x] No lint diagnostics on touched files.

## What this PR does **not** do

Tracked separately:

- **MCP HTTP listener inside the sidecar binary** (PR-α in core). Without it, the gateway has no way to send `tools/call` to the sidecar in the first place. Once it lands, the gateway routes `risk_class: high-crash` actions through the sidecar end-to-end.
- **Gateway routing decision** based on `risk_class`. Phase 2 wrap-up PR in core.
- **Tagging specific skill actions as `high-crash`**. Per-skill PRs once the routing path is live.

## Status

This PR closes the **Maya half** of the dispatch loop. After it merges, the wire path is testable in real Maya via:

```python
# In Maya's script editor (with the dcc-mcp-maya plug-in loaded):
from dcc_mcp_maya._sidecar import dispatch
import json
print(dispatch({"action": "maya_scene__list_objects", "args": {}, "request_id": "smoke"}))
# → a single-line JSON envelope matching the in-process tool result
```

## Stack

* Stacked on **PR #244** (sidecar shim — opens the supervisor + plug-in wiring this dispatcher hangs off of). Once #244 merges, this PR auto-rebases onto main.
* No core-side dependency at compile time; wire-format authority is **PR loonghao/dcc-mcp-core#1006** which is already open and CI-green.

Refs RFC #998 (loonghao/dcc-mcp-core#998), depends on loonghao/dcc-mcp-core#1006 for the wire-format pin.
