### PR TITLE
fix: harden maya small failure paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,7 @@ All other skills appear as `__skill__<name>` stubs (default behavior). Call `loa
 | `DCC_MCP_MAYA_PROCESS_SENTINEL` | `1` | `0` = disable the crash-resilient sentinel file that lets sweepers detect `kill -9` / Task Manager exits (issue #186). |
 | `DCC_MCP_MAYA_DEFENSIVE_DEL` | `0` | `1` = enable the defensive `__del__` guard. Recommended only for `mayapy` / test fixtures — interactive Maya disables by default to avoid Tokio deadlocks (issue #186). |
 | `DCC_MCP_MAYA_RESOURCES` | `1` | `0` = disable Maya MCP resource publishing entirely (issue #187 / core 0.15.0). |
+| `DCC_MCP_MAYA_FAULTHANDLER` | `1` | `0` = disable plugin-installed Python fatal-signal traceback logging. Logs go under `DCC_MCP_LOG_DIR` or the OS temp directory. |
 | `DCC_MCP_GATEWAY_PORT` | `9765` | Multi-instance gateway election port. `0` = disable. |
 | `DCC_MCP_REGISTRY_DIR` | OS temp dir | Shared service-discovery registry directory. |
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | `1` = exclude ``__skill__*`` / ``__group__*`` stubs from ``tools/list`` (issue #174). Discovery still possible via capability manifest / ``/v1/search``. |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The server starts automatically when the plugin loads.
 | `DCC_MCP_DEFAULT_TOOLS` | _(none)_ | Comma-separated skill names to load at startup (overrides minimal default) |
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | `1` hides `__skill__*` / `__group__*` stubs from large `tools/list` syncs; use `dcc_capability_manifest` for discovery |
 | `DCC_MCP_MAYA_SIDECAR` | `0` | `1` starts the optional `dcc-mcp-server sidecar` process from the Maya plugin |
+| `DCC_MCP_MAYA_FAULTHANDLER` | `1` | `0` disables Python fatal-signal traceback logging from the Maya plugin |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | `1` / `true` / `yes` / `on` — refuse `execute_python` (skills-first enforcement) |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_MEL` | `0` | Same tokens — refuse `execute_mel` only |
 | `DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT` | `0` | Same tokens — refuse both `execute_python` and `execute_mel` |

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -3,7 +3,7 @@
 `dcc-mcp-maya` is designed to be extended. You can ship your own skill packages
 alongside the built-ins — without touching the core package.
 
-Cross-repo maintenance checklist (frontmatter, I/O copy, `skill-reference-docs`):
+Cross-repo maintenance checklist (frontmatter, I/O copy, reference wiring):
 [skill-maintenance.md](https://github.com/loonghao/dcc-mcp-core/blob/main/docs/guide/skill-maintenance.md)
 in **dcc-mcp-core**. Bundled reference skills live under
 `dcc-mcp-core/python/dcc_mcp_core/skills/`. Before opening a PR, run

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -462,6 +462,7 @@ tools:
 | `DCC_MCP_MAYA_PROCESS_SENTINEL` | `1` | per-process | `0`=disable the crash-resilient sentinel file used by sweepers (issue #186). |
 | `DCC_MCP_MAYA_DEFENSIVE_DEL` | `0` | per-process | `1`=enable defensive `__del__` guard. Off in interactive Maya (Tokio deadlock risk); recommended for `mayapy` / test fixtures (issue #186). |
 | `DCC_MCP_MAYA_RESOURCES` | `1` | per-process | `0`=disable Maya MCP resource publishing (`scene://current` snapshot + `maya-cmds://` / `maya-api://` / `maya-project://` producers).  Issue #187 / core 0.15.0. |
+| `DCC_MCP_MAYA_FAULTHANDLER` | `1` | per-process | `0`=disable plugin-installed Python fatal-signal traceback logging. Logs are written under `DCC_MCP_LOG_DIR` or the OS temp directory. |
 | `DCC_MCP_GATEWAY_PORT` | `9765` | per-host | Gateway election port. `0`=disable gateway mode. |
 | `DCC_MCP_REGISTRY_DIR` | OS temp dir | per-user | Shared FileRegistry directory. |
 | `DCC_MCP_PYTHON_EXECUTABLE` | `sys.executable` | per-process | Python interpreter for skill worker subprocesses. |

--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -69,17 +69,25 @@ Configuration
 ``DCC_MCP_PYTHON_INIT_SNIPPET``
     One-liner executed by each skill worker before running any tool script.
     Auto-set to ``import maya.standalone; maya.standalone.initialize(name='python')``.
+
+``DCC_MCP_MAYA_FAULTHANDLER``
+    Set to ``0`` to disable Python fatal-signal traceback logging. Crash logs
+    are written under ``DCC_MCP_LOG_DIR`` or the OS temp directory.
 """
 
 # Import future modules
 from __future__ import annotations
 
 # Import built-in modules
+import faulthandler
 import logging
 import os
+import signal
 import sys
+import tempfile
 import threading
 from pathlib import Path
+from typing import Optional
 
 import maya.api.OpenMaya as om  # Python API 2.0 — required for MFnPlugin on Maya 2020+
 import maya.cmds as cmds
@@ -90,6 +98,10 @@ VENDOR = "dcc-mcp"
 
 # Default gateway port — same as dcc-mcp-server binary default
 _DEFAULT_GATEWAY_PORT = 9765
+_faulthandler_file = None
+_faulthandler_path: Optional[Path] = None
+_faulthandler_enabled_by_plugin = False
+_faulthandler_registered_signal = None
 
 
 # ── ensure dcc_mcp_maya package is importable ────────────────────────────────
@@ -296,6 +308,10 @@ def uninitializePlugin(plugin):
             _stop_blocking()
         except Exception as exc:  # noqa: BLE001
             logger.warning("dcc-mcp-maya server stop error: %s", exc)
+        try:
+            _disable_faulthandler_for_plugin()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("dcc-mcp-maya faulthandler teardown error: %s", exc)
         logger.info("dcc-mcp-maya plugin unloaded")
 
 
@@ -390,6 +406,7 @@ def _start() -> None:
         import dcc_mcp_maya  # noqa: PLC0415
 
         _export_worker_env()
+        _enable_faulthandler_for_plugin()
         # Issue #148 — defuse the modal commandPort security warning that
         # would otherwise freeze Maya's main thread when a stray client
         # (or the gateway probe) connects to the legacy commandPort.
@@ -494,6 +511,72 @@ def _post_start(cfg: dict) -> None:
         logger.debug("stale-instance scan skipped: %s", exc)
 
     _maybe_spawn_sidecar()
+
+
+def _faulthandler_opted_out() -> bool:
+    return os.environ.get("DCC_MCP_MAYA_FAULTHANDLER", "1").strip().lower() in {"0", "false", "off", "no"}
+
+
+def _faulthandler_log_dir() -> Path:
+    base = os.environ.get("DCC_MCP_LOG_DIR")
+    if base:
+        return Path(base)
+    return Path(tempfile.gettempdir()) / "dcc-mcp-maya"
+
+
+def _enable_faulthandler_for_plugin() -> None:
+    """Enable Python fatal-signal tracebacks for Maya crash post-mortems."""
+    global _faulthandler_enabled_by_plugin, _faulthandler_file, _faulthandler_path, _faulthandler_registered_signal
+
+    if _faulthandler_opted_out():
+        logger.info("dcc-mcp-maya: faulthandler disabled via DCC_MCP_MAYA_FAULTHANDLER=0")
+        return
+    if faulthandler.is_enabled():
+        logger.debug("dcc-mcp-maya: faulthandler already enabled; leaving existing handler in place")
+        return
+    try:
+        log_dir = _faulthandler_log_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        _faulthandler_path = log_dir / "maya-faulthandler-{}.log".format(os.getpid())
+        _faulthandler_file = open(str(_faulthandler_path), "a", buffering=1)
+        faulthandler.enable(file=_faulthandler_file, all_threads=True)
+        sigusr1 = getattr(signal, "SIGUSR1", None)
+        if sigusr1 is not None:
+            try:
+                faulthandler.register(sigusr1, file=_faulthandler_file, all_threads=True)
+                _faulthandler_registered_signal = sigusr1
+            except (RuntimeError, ValueError, OSError) as exc:
+                logger.debug("dcc-mcp-maya: SIGUSR1 faulthandler registration skipped: %s", exc)
+        _faulthandler_enabled_by_plugin = True
+        logger.info("dcc-mcp-maya: faulthandler crash log enabled at %s", _faulthandler_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("dcc-mcp-maya: faulthandler setup failed: %s", exc)
+
+
+def _disable_faulthandler_for_plugin() -> None:
+    """Undo faulthandler setup when this plugin installed it."""
+    global _faulthandler_enabled_by_plugin, _faulthandler_file, _faulthandler_path, _faulthandler_registered_signal
+
+    if not _faulthandler_enabled_by_plugin:
+        return
+    if _faulthandler_registered_signal is not None:
+        try:
+            faulthandler.unregister(_faulthandler_registered_signal)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("dcc-mcp-maya: faulthandler signal unregister skipped: %s", exc)
+        _faulthandler_registered_signal = None
+    try:
+        faulthandler.disable()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("dcc-mcp-maya: faulthandler disable skipped: %s", exc)
+    try:
+        if _faulthandler_file is not None:
+            _faulthandler_file.close()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("dcc-mcp-maya: faulthandler log close skipped: %s", exc)
+    _faulthandler_file = None
+    _faulthandler_path = None
+    _faulthandler_enabled_by_plugin = False
 
 
 def _disable_autosave_for_session() -> None:

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -67,6 +67,31 @@ DEFAULT_SERVER_VERSION = __version__
 _BUILTIN_SKILLS_DIR = Path(__file__).resolve().parent / "skills"
 
 
+def _logger_has_closed_stream(target_logger: logging.Logger) -> bool:
+    """Return true when a handler in the propagation chain cannot write."""
+    current: Optional[logging.Logger] = target_logger
+    while current is not None:
+        for handler in current.handlers:
+            stream = getattr(handler, "stream", None)
+            if stream is not None and getattr(stream, "closed", False):
+                return True
+        if not current.propagate:
+            break
+        current = current.parent
+    return False
+
+
+def _log_dispatcher_shutdown(dcc_name: str, signalled: Any) -> None:
+    """Best-effort dispatcher shutdown log for late interpreter teardown."""
+    if _logger_has_closed_stream(logger):
+        return
+    logger.info(
+        "[%s] dispatcher.shutdown signalled %s job(s)",
+        dcc_name,
+        0 if signalled is None else signalled,
+    )
+
+
 @dataclass
 class MayaServerOptions:
     """Maya adapter options collapsed for the core 0.15.9 server contract."""
@@ -384,11 +409,7 @@ class MayaMcpServer(DccServerBase):
                         signalled = shutdown("Interrupted")
                     except TypeError:
                         signalled = shutdown()
-                    logger.info(
-                        "[%s] dispatcher.shutdown signalled %s job(s)",
-                        self._dcc_name,
-                        signalled,
-                    )
+                    _log_dispatcher_shutdown(self._dcc_name, signalled)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "[%s] Error draining Maya dispatcher during stop(): %s",

--- a/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
@@ -50,9 +50,10 @@ Full rationale: repo root `AGENTS.md` § *Bulk import, export, and naming*; exam
 | Create a three-point light rig and tweak intensity | `maya-light-rig` |
 | Snapshot the viewport | `maya-render` (`playblast`) |
 
-## Side-effect taxonomy
+## Side-Effect Taxonomy
 
-Each SKILL.md declares `metadata.dcc-mcp.side-effects` with one or more of:
+Tool-level `tools.yaml` entries declare execution and thread affinity. Treat
+the operation descriptions and tags as the source of truth for side effects:
 
 - `reads-scene` — calls `maya.cmds` queries; safe.
 - `writes-scene` — mutates DAG / DG state; should run on the main thread.
@@ -62,7 +63,7 @@ Each SKILL.md declares `metadata.dcc-mcp.side-effects` with one or more of:
 - `executes-arbitrary-code` — `maya-scripting` only.
 - `heavy-cpu` — long-running; set realistic `timeout_hint_secs`.
 
-An agent can use these to:
+An agent can use these signals to:
 
 * warn the user before destructive operations,
 * batch read-only queries,
@@ -99,9 +100,9 @@ the user dismisses the dialog inside Maya. Set
 `DCC_MCP_MAYA_SAFE_SESSION=0` to disable this for an interactive
 authoring session.
 
-## Aliases
+## Discovery Terms
 
-Each skill carries a `metadata.dcc-mcp.aliases` list so that future
-renames are non-breaking. For example, `maya-geometry` already advertises
-`maya-interchange`, `maya-io`, `maya-fbx` — searches for any of these
-should match.
+Skill discovery terms live in `metadata.dcc-mcp.search-hint` and `tags`, using
+only metadata keys accepted by the current gateway/core parser. For example,
+`maya-geometry` includes `maya-interchange`, `maya-io`, and `maya-fbx` in its
+search hint so legacy names still match without emitting unknown-key warnings.

--- a/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
@@ -23,11 +23,6 @@ metadata:
     search-hint: |-
       animate motion, keyframe, set key, timeline range, animation curve,
       curve tangent, bake constraint, bake simulation, anim file import export
-    aliases:
-    - maya-anim
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-attributes/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-attributes/SKILL.md
@@ -22,11 +22,6 @@ metadata:
     search-hint: |-
       get attribute, set attribute, add custom attribute, lock unlock attribute,
       list attributes, attribute value
-    aliases:
-    - maya-attrs
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-display/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-display/SKILL.md
@@ -21,11 +21,6 @@ metadata:
     search-hint: |-
       viewport visibility, display layer, show hide, layer assign,
       hide group, isolate selection
-    aliases:
-    - maya-display-layers
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-export-preset/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-export-preset/SKILL.md
@@ -23,11 +23,6 @@ metadata:
     search-hint: |-
       standardize export, export preset, FBX preset, Alembic preset,
       load export config, save export config, share export settings
-    aliases:
-    - maya-export-presets
-    side-effects:
-    - reads-disk
-    - writes-disk
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-expressions/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-expressions/SKILL.md
@@ -21,11 +21,6 @@ metadata:
     search-hint: |-
       procedural animation, expression node, drive attribute, expression node,
       expression-driven motion, drive translateX with sin
-    aliases:
-    - maya-expr
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-geometry/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-geometry/SKILL.md
@@ -27,27 +27,17 @@ metadata:
       export FBX, import FBX, export OBJ, file_exists, geometry round trip,
       scene interchange, FBXExport options, bake animation FBX. Use
       maya-scene save_scene for .ma/.mb scene saves.
-    aliases:
-    - maya-interchange
-    - maya-io
-    - maya-fbx
-    side-effects:
-    - reads-scene
-    - reads-disk
-    - writes-disk
-    - calls-fbx-plugin
     depends: []
     tools: tools.yaml
     groups: groups.yaml
-    skill-reference-docs:
-      - "references/*.md"
+    recipes: references/IO_CHECKLIST.md
 ---
 # maya-geometry (Interchange stage)
 
 Geometry interchange. Despite the legacy name `maya-geometry`, the
 responsibility is **interchange**, not modelling or native scene-file
-persistence — see the alias list in the frontmatter (`maya-interchange`,
-`maya-io`, `maya-fbx`).
+persistence. Search hints include `maya-interchange`, `maya-io`, and
+`maya-fbx` for legacy discovery paths.
 
 ## Why this stage exists
 

--- a/src/dcc_mcp_maya/skills/maya-light-rig/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-light-rig/SKILL.md
@@ -23,11 +23,6 @@ metadata:
     search-hint: |-
       lighting template, three point rig, key fill rim, HDRI dome,
       studio setup, environment light
-    aliases:
-    - maya-lighting-rig
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-material-library/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-material-library/SKILL.md
@@ -22,13 +22,6 @@ metadata:
     search-hint: |-
       reuse material, material preset, shader library, share material,
       load preset, save preset, JSON shader
-    aliases:
-    - maya-mat-lib
-    side-effects:
-    - reads-scene
-    - writes-scene
-    - reads-disk
-    - writes-disk
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-materials/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-materials/SKILL.md
@@ -23,11 +23,6 @@ metadata:
     search-hint: |-
       assign shader, basic material, surface shader, lambert blinn,
       create material, shading group, shadingEngine, sets surfaceShader
-    aliases:
-    - maya-shading
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/SKILL.md
@@ -26,12 +26,6 @@ metadata:
     search-hint: |-
       edit mesh, modify polygons, bevel edge, extrude face, bridge, combine,
       separate, cleanup, boolean, subdivide, smooth topology
-    aliases:
-    - maya-mesh
-    - maya-poly-edit
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-node-graph/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/SKILL.md
@@ -23,11 +23,6 @@ metadata:
     search-hint: |-
       node connection, attribute link, DG topology, construction history,
       list connections, transfer attributes, smooth subdivide
-    aliases:
-    - maya-dg
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-pipeline/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-pipeline/SKILL.md
@@ -23,13 +23,6 @@ metadata:
     search-hint: |-
       asset publish, production pipeline, metadata tagging, project workspace,
       versioned publish, set project, tag asset, get asset metadata
-    aliases:
-    - maya-publish
-    side-effects:
-    - reads-scene
-    - writes-scene
-    - reads-disk
-    - writes-disk
     depends:
     - maya-geometry
     tools: tools.yaml

--- a/src/dcc_mcp_maya/skills/maya-pose-library/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-pose-library/SKILL.md
@@ -21,13 +21,6 @@ metadata:
     search-hint: |-
       save pose, load pose, mirror pose, character pose preset, pose library,
       pose JSON, reuse pose
-    aliases:
-    - maya-poses
-    side-effects:
-    - reads-scene
-    - writes-scene
-    - reads-disk
-    - writes-disk
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
@@ -25,12 +25,6 @@ metadata:
       create sphere cube cylinder plane, set transform, get transform, rename,
       delete object, primitive geometry, basic shape, polySphere polyCube,
       batch primitives, random transforms, many cubes procedural
-    aliases:
-    - maya-primitive
-    - maya-shapes
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-render-farm/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-render-farm/SKILL.md
@@ -23,13 +23,6 @@ metadata:
     search-hint: |-
       submit render job, distributed render, deadline queue, farm submission,
       validate scene for farm, render job spec, render job status
-    aliases:
-    - maya-deadline
-    side-effects:
-    - reads-scene
-    - reads-disk
-    - writes-disk
-    - calls-external-service
     depends:
     - maya-render
     tools: tools.yaml

--- a/src/dcc_mcp_maya/skills/maya-render/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-render/SKILL.md
@@ -23,12 +23,6 @@ metadata:
     search-hint: |-
       final output, preview render, playblast, viewport capture, render globals,
       set render settings, image format, frame range render
-    aliases:
-    - maya-render-settings
-    side-effects:
-    - reads-scene
-    - writes-scene
-    - writes-disk
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-render/scripts/capture_viewport.py
+++ b/src/dcc_mcp_maya/skills/maya-render/scripts/capture_viewport.py
@@ -45,6 +45,15 @@ def _apply_view_fit(cmds) -> bool:
         return False
 
 
+def _read_nonempty_png(path: str) -> bytes:
+    """Read a playblast PNG and fail when Maya produced an empty file."""
+    with open(path, "rb") as fh:
+        img_bytes = fh.read()
+    if not img_bytes:
+        raise ValueError("EMPTY_PLAYBLAST")
+    return img_bytes
+
+
 def capture_viewport(
     width: int = 1920,
     height: int = 1080,
@@ -83,6 +92,7 @@ def capture_viewport(
 
     try:
         tmp_path: Optional[str] = None
+        img_path: Optional[str] = None
         if frame is None:
             frame = cmds.currentTime(query=True)
 
@@ -99,6 +109,8 @@ def capture_viewport(
         # produce a black frame or raise (issue #152).
         if off_screen is None:
             off_screen = bool(cmds.about(batch=True)) or _no_visible_panel(cmds)
+            if view_fit and not view_fit_applied:
+                off_screen = True
 
         # playblast writes  <prefix>.<frame_padded>.png
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
@@ -123,8 +135,7 @@ def capture_viewport(
         padded = "{}.{}.png".format(prefix, str(f0).zfill(4))
         img_path = padded if os.path.exists(padded) else prefix + ".png"
 
-        with open(img_path, "rb") as fh:
-            img_bytes = fh.read()
+        img_bytes = _read_nonempty_png(img_path)
         os.unlink(img_path)
 
         encoded = base64.b64encode(img_bytes).decode("ascii")
@@ -138,6 +149,31 @@ def capture_viewport(
             view_fit=bool(view_fit),
             view_fit_applied=view_fit_applied,
             prompt="Use capture_viewport with view_fit=True instead of execute_python viewFit(all=True).",
+        )
+    except ValueError as exc:
+        if str(exc) != "EMPTY_PLAYBLAST":
+            raise
+        for candidate in (tmp_path, img_path):
+            try:
+                if candidate and os.path.exists(candidate):
+                    os.unlink(candidate)
+            except OSError:
+                pass
+        return skill_error(
+            "Viewport capture produced an empty image",
+            "Maya playblast wrote a 0-byte PNG",
+            possible_solutions=[
+                "Pass off_screen=True if Maya is minimized or running in batch mode.",
+                "Ensure a model panel is visible before capturing.",
+                "Retry after using view_fit=True so the camera frames scene content.",
+            ],
+            error_code="EMPTY_PLAYBLAST",
+            width=width,
+            height=height,
+            frame=frame,
+            off_screen=bool(off_screen),
+            view_fit=bool(view_fit),
+            view_fit_applied=view_fit_applied,
         )
     except Exception as exc:
         if tmp_path is not None:

--- a/src/dcc_mcp_maya/skills/maya-render/scripts/playblast.py
+++ b/src/dcc_mcp_maya/skills/maya-render/scripts/playblast.py
@@ -26,6 +26,14 @@ def _playblast_frame_range(frame: float) -> Tuple[int, int]:
     return (fnum, fnum)
 
 
+def _read_nonempty_png(path: str) -> bytes:
+    with open(path, "rb") as fh:
+        img_bytes = fh.read()
+    if not img_bytes:
+        raise ValueError("EMPTY_PLAYBLAST")
+    return img_bytes
+
+
 def playblast(
     width: int = 1920,
     height: int = 1080,
@@ -51,6 +59,7 @@ def playblast(
     try:
         import maya.cmds as cmds  # noqa: PLC0415
 
+        img_path: Optional[str] = None
         if frame is None:
             frame = cmds.currentTime(query=True)
 
@@ -92,8 +101,7 @@ def playblast(
                 "Could not locate output PNG from playblast",
             )
 
-        with open(img_path, "rb") as fh:
-            img_bytes = fh.read()
+        img_bytes = _read_nonempty_png(img_path)
         os.unlink(img_path)
 
         img_b64 = base64.b64encode(img_bytes).decode("ascii")
@@ -102,6 +110,26 @@ def playblast(
             "Viewport captured at frame {} ({}×{})".format(f0, width, height),
             prompt="Image captured. For framing before capture, use capture_viewport with view_fit=True.",
             image=img_b64,
+            frame=frame,
+            width=width,
+            height=height,
+        )
+    except ValueError as exc:
+        if str(exc) != "EMPTY_PLAYBLAST":
+            raise
+        try:
+            if img_path and os.path.exists(img_path):
+                os.unlink(img_path)
+        except OSError:
+            pass
+        return skill_error(
+            "Playblast produced an empty image",
+            "Maya playblast wrote a 0-byte PNG",
+            possible_solutions=[
+                "Retry after ensuring a model panel exists.",
+                "Use capture_viewport with off_screen=True and view_fit=True for hidden or minimized Maya sessions.",
+            ],
+            error_code="EMPTY_PLAYBLAST",
             frame=frame,
             width=width,
             height=height,

--- a/src/dcc_mcp_maya/skills/maya-rigging/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-rigging/SKILL.md
@@ -23,11 +23,6 @@ metadata:
     search-hint: |-
       build character rig, skeleton setup, IK chain, skin bind, blendshape,
       control curve, deformer, joint hierarchy, weight paint
-    aliases:
-    - maya-rig
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-scene-assembly/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scene-assembly/SKILL.md
@@ -24,11 +24,6 @@ metadata:
     search-hint: |-
       assemble environment, large scene, assembly definition, assembly reference,
       LOD switch, representation swap, GPU cache representation
-    aliases:
-    - maya-assembly
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-scene/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scene/SKILL.md
@@ -22,12 +22,6 @@ metadata:
     search-hint: |-
       manage scene file, open save scene, hierarchy query, selection,
       camera list, frame rate, locator, group parent, freeze pivot, bounding box
-    aliases:
-    - maya-scene-mgmt
-    side-effects:
-    - reads-scene
-    - writes-scene
-    - writes-disk
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-scene/scripts/new_scene.py
+++ b/src/dcc_mcp_maya/skills/maya-scene/scripts/new_scene.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
-def new_scene(force: bool = False) -> dict:
+def new_scene(force: bool = False, safe_dirty_check: bool = True) -> dict:
     """Create a new Maya scene.
 
     Args:
         force: If True, discard unsaved changes without prompting.
+        safe_dirty_check: If True, return a structured error instead of
+            allowing Maya to show a save prompt for dirty scenes.
 
     Returns:
         ToolResult dict.
@@ -20,6 +22,17 @@ def new_scene(force: bool = False) -> dict:
     try:
         import maya.cmds as cmds  # noqa: PLC0415
 
+        if safe_dirty_check and not force and cmds.file(query=True, modified=True):
+            return skill_error(
+                "Scene has unsaved changes",
+                "Refusing to create a new scene without force=True because Maya would prompt to save changes.",
+                possible_solutions=[
+                    "Call save_scene before new_scene.",
+                    "Pass force=True to discard unsaved changes.",
+                    "Pass safe_dirty_check=False only for an interactive session where a Maya prompt is acceptable.",
+                ],
+                scene_modified=True,
+            )
         cmds.file(new=True, force=force)
         return skill_success(
             "New scene created", prompt="Check the result with list_scene or use related actions to continue."

--- a/src/dcc_mcp_maya/skills/maya-scene/scripts/open_scene.py
+++ b/src/dcc_mcp_maya/skills/maya-scene/scripts/open_scene.py
@@ -3,18 +3,21 @@
 # Import future modules
 from __future__ import annotations
 
+# Import built-in modules
+import os
+
 # Import local modules
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
-# Import built-in modules
 
-
-def open_scene(file_path: str, force: bool = False) -> dict:
+def open_scene(file_path: str, force: bool = False, safe_dirty_check: bool = True) -> dict:
     """Open a Maya scene file.
 
     Args:
         file_path: Path to the .ma / .mb file.
         force: If True, discard unsaved changes without prompting.
+        safe_dirty_check: If True, return a structured error instead of
+            allowing Maya to show a save prompt for dirty scenes.
 
     Returns:
         ToolResult dict.
@@ -23,6 +26,24 @@ def open_scene(file_path: str, force: bool = False) -> dict:
     try:
         import maya.cmds as cmds  # noqa: PLC0415
 
+        if not os.path.exists(file_path):
+            return skill_error(
+                "Scene file does not exist",
+                "No file found at {}".format(file_path),
+                file_path=file_path,
+            )
+        if safe_dirty_check and not force and cmds.file(query=True, modified=True):
+            return skill_error(
+                "Scene has unsaved changes",
+                "Refusing to open a scene without force=True because Maya would prompt to save changes.",
+                possible_solutions=[
+                    "Call save_scene before open_scene.",
+                    "Pass force=True to discard unsaved changes.",
+                    "Pass safe_dirty_check=False only for an interactive session where a Maya prompt is acceptable.",
+                ],
+                file_path=file_path,
+                scene_modified=True,
+            )
         cmds.file(file_path, open=True, force=force)
         return skill_success(
             f"Opened scene: {file_path}",

--- a/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
@@ -129,6 +129,17 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
+  inputSchema:
+    type: object
+    properties:
+      force:
+        type: boolean
+        default: false
+        description: Discard unsaved changes without prompting.
+      safe_dirty_check:
+        type: boolean
+        default: true
+        description: Return a structured error on dirty scenes instead of allowing a Maya save prompt.
 - name: open_scene
   description: Open a Maya scene file from disk
   execution: async
@@ -138,6 +149,22 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
+  inputSchema:
+    type: object
+    required:
+    - file_path
+    properties:
+      file_path:
+        type: string
+        description: Absolute or workspace-relative .ma/.mb file to open.
+      force:
+        type: boolean
+        default: false
+        description: Discard unsaved changes without prompting.
+      safe_dirty_check:
+        type: boolean
+        default: true
+        description: Return a structured error on dirty scenes instead of allowing a Maya save prompt.
 - name: parent_object
   execution: sync
   affinity: main

--- a/src/dcc_mcp_maya/skills/maya-scripting/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scripting/SKILL.md
@@ -25,20 +25,11 @@ metadata:
       last resort after load_skill, no-matching-tool, bulk loop in maya,
       MEL Python escape hatch, inspect api, cmds help, signature,
       flag list, introspect only
-    aliases:
-    - maya-script
-    - maya-fallthrough
-    side-effects:
-    - executes-arbitrary-code
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
     groups: groups.yaml
     recipes: references/RECIPES.md
     introspection: references/INTROSPECTION.md
-    skill-reference-docs:
-      - "references/*.md"
 ---
 # maya-scripting (Bootstrap stage)
 

--- a/src/dcc_mcp_maya/skills/maya-shot-export/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-shot-export/SKILL.md
@@ -25,13 +25,6 @@ metadata:
     search-hint: |-
       shot export, package shot, export frame range, editorial delivery,
       shot camera FBX, shot Alembic, shot info
-    aliases:
-    - maya-shot-io
-    side-effects:
-    - reads-scene
-    - reads-disk
-    - writes-disk
-    - calls-fbx-plugin
     depends:
     - maya-geometry
     tools: tools.yaml

--- a/src/dcc_mcp_maya/skills/maya-texture-bake/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-texture-bake/SKILL.md
@@ -23,13 +23,6 @@ metadata:
     search-hint: |-
       bake texture map, AO normal, ambient occlusion, high to low res,
       static map, transfer maps, bake lighting
-    aliases:
-    - maya-bake
-    side-effects:
-    - reads-scene
-    - writes-scene
-    - writes-disk
-    - heavy-cpu
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/SKILL.md
@@ -21,11 +21,6 @@ metadata:
     search-hint: |-
       layout UVs, unfold UV, texture coordinates, UV projection, automatic UV,
       planar projection, UV set, normalize UV
-    aliases:
-    - maya-uv
-    side-effects:
-    - reads-scene
-    - writes-scene
     depends: []
     tools: tools.yaml
     groups: groups.yaml

--- a/tests/e2e_standalone/test_maya_actions.py
+++ b/tests/e2e_standalone/test_maya_actions.py
@@ -20,6 +20,28 @@ class TestSceneActions:
         result = mod.new_scene(force=True)
         assert result["success"] is True
 
+    def test_new_scene_dirty_default_returns_error(self):
+        cmds.polyCube(name="dirtyBeforeNew")
+        mod = _load_script("maya-scene", "new_scene")
+        result = mod.new_scene()
+        assert result["success"] is False
+        assert result["context"]["scene_modified"] is True
+        assert cmds.objExists("dirtyBeforeNew")
+
+    def test_open_scene_dirty_default_returns_error(self, tmp_path):
+        save_mod = _load_script("maya-scene", "save_scene")
+        open_mod = _load_script("maya-scene", "open_scene")
+        source = tmp_path / "source.ma"
+
+        cmds.polyCube(name="savedCube")
+        assert save_mod.save_scene(file_path=str(source), file_type="mayaAscii")["success"] is True
+        cmds.polyCube(name="dirtyBeforeOpen")
+
+        result = open_mod.open_scene(file_path=str(source))
+        assert result["success"] is False
+        assert result["context"]["scene_modified"] is True
+        assert cmds.objExists("dirtyBeforeOpen")
+
     def test_list_objects_empty_scene(self):
         mod = _load_script("maya-scene", "list_objects")
         result = mod.list_objects()

--- a/tests/test_lint_skills.py
+++ b/tests/test_lint_skills.py
@@ -326,6 +326,20 @@ class TestCheckDependsExist:
         assert any(i.rule == "MISSING_DEPENDS" for i in issues)
 
 
+class TestCheckDccMcpMetadataKeys:
+    def test_known_nested_keys(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        fm = {"metadata": {"dcc-mcp": {"dcc": "maya", "tools": "tools.yaml", "recipes": "references/RECIPES.md"}}}
+        issues = lint_skills.check_dcc_mcp_metadata_keys(skill_dir, "maya-test", fm)
+        assert issues == []
+
+    def test_unknown_nested_key_warns(self, tmp_path):
+        skill_dir = make_skill_dir(tmp_path, "maya-test", CLEAN_FRONTMATTER)
+        fm = {"metadata": {"dcc-mcp": {"aliases": ["maya-old-name"]}}}
+        issues = lint_skills.check_dcc_mcp_metadata_keys(skill_dir, "maya-test", fm)
+        assert any(i.rule == "UNKNOWN_DCC_MCP_METADATA" for i in issues)
+
+
 # ---------------------------------------------------------------------------
 # check_duplicate_action_names (cross-skill)
 # ---------------------------------------------------------------------------

--- a/tests/test_plugin_faulthandler.py
+++ b/tests/test_plugin_faulthandler.py
@@ -1,0 +1,48 @@
+"""Tests for Maya plug-in faulthandler setup."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_plugin_faulthandler_writes_traceback_on_fatal_signal(tmp_path: Path) -> None:
+    plugin_path = Path(__file__).parent.parent / "maya" / "plugin" / "dcc_mcp_maya_plugin.py"
+    script = textwrap.dedent(
+        """
+        import importlib.util
+        import os
+        import sys
+        import types
+        from unittest.mock import MagicMock
+
+        maya = types.ModuleType("maya")
+        maya.cmds = MagicMock()
+        maya.api = types.ModuleType("maya.api")
+        maya.api.OpenMaya = MagicMock()
+        sys.modules["maya"] = maya
+        sys.modules["maya.cmds"] = maya.cmds
+        sys.modules["maya.api"] = maya.api
+        sys.modules["maya.api.OpenMaya"] = maya.api.OpenMaya
+
+        os.environ["DCC_MCP_LOG_DIR"] = r"{log_dir}"
+        spec = importlib.util.spec_from_file_location("_plugin", r"{plugin_path}")
+        plugin = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(plugin)
+        plugin._enable_faulthandler_for_plugin()
+
+        import faulthandler
+        faulthandler._sigsegv()
+        """
+    ).format(log_dir=str(tmp_path), plugin_path=str(plugin_path))
+
+    proc = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+
+    assert proc.returncode != 0
+    logs = list(tmp_path.glob("maya-faulthandler-*.log"))
+    assert logs, "faulthandler should create a crash log in DCC_MCP_LOG_DIR"
+    body = logs[0].read_text(errors="replace")
+    assert "Fatal Python error" in body
+    assert "Current thread" in body or "Thread" in body

--- a/tests/test_render_safety.py
+++ b/tests/test_render_safety.py
@@ -1,0 +1,37 @@
+"""Regression tests for render output validation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+
+
+def _load_render_script(script_name: str):
+    path = _ROOT / "src" / "dcc_mcp_maya" / "skills" / "maya-render" / "scripts" / "{}.py".format(script_name)
+    spec = importlib.util.spec_from_file_location("test_render_{}".format(script_name), str(path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize("script_name", ["capture_viewport", "playblast"])
+def test_empty_playblast_png_is_rejected(script_name: str, tmp_path: Path) -> None:
+    mod = _load_render_script(script_name)
+    empty_png = tmp_path / "empty.png"
+    empty_png.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="EMPTY_PLAYBLAST"):
+        mod._read_nonempty_png(str(empty_png))
+
+
+@pytest.mark.parametrize("script_name", ["capture_viewport", "playblast"])
+def test_nonempty_playblast_png_is_read(script_name: str, tmp_path: Path) -> None:
+    mod = _load_render_script(script_name)
+    png = tmp_path / "image.png"
+    png.write_bytes(b"not-really-a-png")
+
+    assert mod._read_nonempty_png(str(png)) == b"not-really-a-png"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 # Import built-in modules
+import io
 import json
+import logging
 import sys
 import urllib.request
 from unittest.mock import MagicMock, patch
@@ -45,6 +47,30 @@ def _import_server():
             del sys.modules[mod]
     srv = importlib.import_module("dcc_mcp_maya.server")
     return srv
+
+
+def test_dispatcher_shutdown_log_normalizes_missing_count(caplog):
+    srv_mod = _import_server()
+
+    with caplog.at_level(logging.INFO, logger=srv_mod.logger.name):
+        srv_mod._log_dispatcher_shutdown("maya", None)
+
+    assert "dispatcher.shutdown signalled 0 job(s)" in caplog.text
+
+
+def test_dispatcher_shutdown_log_skips_closed_stream(capsys):
+    srv_mod = _import_server()
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    srv_mod.logger.addHandler(handler)
+    try:
+        stream.close()
+
+        srv_mod._log_dispatcher_shutdown("maya", None)
+
+        assert capsys.readouterr().err == ""
+    finally:
+        srv_mod.logger.removeHandler(handler)
 
 
 def _core_supports_nested_dcc_mcp_metadata():

--- a/tools/lint_skills.py
+++ b/tools/lint_skills.py
@@ -48,6 +48,23 @@ VALID_DCC_VALUES: Set[str] = {
 # For this project all skills must target maya
 PROJECT_DCC = "maya"
 
+# Keep this list in sync with the gateway/core parser version used by CI.
+VALID_DCC_MCP_KEYS: Set[str] = {
+    "dcc",
+    "depends",
+    "external-deps",
+    "groups",
+    "introspection",
+    "layer",
+    "recipes",
+    "search-hint",
+    "stage",
+    "tags",
+    "tools",
+    "version",
+    "workflows",
+}
+
 CONFLICT_MARKER_RE = re.compile(r"^(<{7}|={7}|>{7})", re.MULTILINE)
 CONFLICT_FULL_RE = re.compile(
     r"<<<<<<< HEAD\n(.*?)=======\n(.*?)>>>>>>> origin/main\n",
@@ -281,6 +298,34 @@ def _extract_dcc_mcp_field(fm: dict, key: str, default=None):
     return default
 
 
+def check_dcc_mcp_metadata_keys(skill_dir: Path, skill_name: str, fm: dict) -> List[LintIssue]:
+    issues: List[LintIssue] = []
+    file_path = str(skill_dir / "SKILL.md")
+    metadata = fm.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        return issues
+
+    keys: Set[str] = set()
+    for key in metadata:
+        if isinstance(key, str) and key.startswith("dcc-mcp."):
+            keys.add(key[len("dcc-mcp.") :])
+    nested = metadata.get("dcc-mcp")
+    if isinstance(nested, dict):
+        keys.update(str(key) for key in nested)
+
+    for key in sorted(keys - VALID_DCC_MCP_KEYS):
+        issues.append(
+            LintIssue(
+                skill=skill_name,
+                file=file_path,
+                severity="WARNING",
+                rule="UNKNOWN_DCC_MCP_METADATA",
+                message=f"metadata.dcc-mcp.{key} is not accepted by the CI gateway/core parser",
+            )
+        )
+    return issues
+
+
 def check_dcc_field(skill_dir: Path, skill_name: str, fm: dict) -> List[LintIssue]:
     issues: List[LintIssue] = []
     file_path = str(skill_dir / "SKILL.md")
@@ -507,10 +552,7 @@ def check_depends_exist(
 
 
 def _references_metadata_ok(fm: dict) -> bool:
-    """True when references/ content is wired for agent read tools (recipes, introspection, or skill-reference-docs)."""
-    srd = _extract_dcc_mcp_field(fm, "skill-reference-docs")
-    if srd:
-        return True
+    """True when references/ content is wired for agent read tools."""
     recipes = _extract_dcc_mcp_field(fm, "recipes")
     if isinstance(recipes, str) and recipes.strip().startswith("references"):
         return True
@@ -536,8 +578,8 @@ def check_references_dir_wiring(skill_dir: Path, skill_name: str, fm: dict) -> L
             severity="WARNING",
             rule="REF_DIR_UNWIRED",
             message=(
-                "references/ exists — add metadata.dcc-mcp.skill-reference-docs (glob list), "
-                "or point recipes/introspection under references/ "
+                "references/ exists — point metadata.dcc-mcp.recipes or "
+                "metadata.dcc-mcp.introspection under references/ "
                 "(see docs/guide/skill-maintenance.md in dcc-mcp-core)"
             ),
         )
@@ -711,6 +753,7 @@ def lint_skill(
         return issues, info
 
     issues += check_name_field(skill_dir, skill_name, fm)
+    issues += check_dcc_mcp_metadata_keys(skill_dir, skill_name, fm)
     issues += check_dcc_field(skill_dir, skill_name, fm)
     issues += check_version_field(skill_dir, skill_name, fm)
     issues += check_description_field(skill_dir, skill_name, fm)


### PR DESCRIPTION
## Summary

- return structured `EMPTY_PLAYBLAST` errors when capture/playblast writes a 0-byte PNG
- force offscreen capture when `view_fit` was requested but could not be applied
- make `new_scene` and `open_scene` refuse dirty scenes by default instead of allowing Maya save prompts
- enable opt-out faulthandler crash logs from the Maya plugin
- quiet CI metadata/debug noise by removing gateway-unknown SKILL.md metadata keys and guarding late shutdown logging

## Validation

- `python -m pytest tests/test_render_safety.py tests/test_plugin_faulthandler.py tests/test_plugin_env_vars.py::TestExportWorkerEnv -q`
- `python -m pytest tests/test_python_3_7_compat.py -q`
- `python -m pytest tests/test_lint_skills.py::TestCheckDccMcpMetadataKeys tests/test_server.py::test_dispatcher_shutdown_log_normalizes_missing_count tests/test_server.py::test_dispatcher_shutdown_log_skips_closed_stream tests/test_dispatcher_cancellation.py::test_server_stop_drains_attached_dispatcher -q`
- `python -m pytest tests/test_skill_taxonomy.py -q`
- `python -m ruff check ...`
- `python -m ruff format --check ...`
- `python tools/lint_skills.py --error-only`
- real Maya 2025 `mayapy`: dirty `new_scene` / `open_scene` return structured errors without replacing the scene
- real Maya 2025 `mayapy`: `capture_viewport(off_screen=True)` returns `EMPTY_PLAYBLAST` instead of `success=True` with an empty image

Closes #237.
Closes #243.
Refs #240.
Refs #235.