### PR TITLE
fix: guard Maya playblast empty outputs

### DIFF
--- a/src/dcc_mcp_maya/skills/maya-render/scripts/capture_viewport.py
+++ b/src/dcc_mcp_maya/skills/maya-render/scripts/capture_viewport.py
@@ -27,6 +27,14 @@ def _playblast_frame_range(frame: float) -> Tuple[int, int]:
     return (fnum, fnum)
 
 
+def _unlink_if_exists(path: Optional[str]) -> None:
+    if path and os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
 def _apply_view_fit(cmds) -> bool:
     """Fit the scene in the active model panel (correct ``allObjects`` flag)."""
     try:
@@ -93,6 +101,7 @@ def capture_viewport(
     try:
         tmp_path: Optional[str] = None
         img_path: Optional[str] = None
+        f0: Optional[int] = None
         if frame is None:
             frame = cmds.currentTime(query=True)
 
@@ -109,8 +118,8 @@ def capture_viewport(
         # produce a black frame or raise (issue #152).
         if off_screen is None:
             off_screen = bool(cmds.about(batch=True)) or _no_visible_panel(cmds)
-            if view_fit and not view_fit_applied:
-                off_screen = True
+        if view_fit and not view_fit_applied:
+            off_screen = True
 
         # playblast writes  <prefix>.<frame_padded>.png
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
@@ -136,7 +145,9 @@ def capture_viewport(
         img_path = padded if os.path.exists(padded) else prefix + ".png"
 
         img_bytes = _read_nonempty_png(img_path)
-        os.unlink(img_path)
+        _unlink_if_exists(img_path)
+        if tmp_path != img_path:
+            _unlink_if_exists(tmp_path)
 
         encoded = base64.b64encode(img_bytes).decode("ascii")
         return skill_success(
@@ -148,6 +159,7 @@ def capture_viewport(
             off_screen=bool(off_screen),
             view_fit=bool(view_fit),
             view_fit_applied=view_fit_applied,
+            off_screen_forced_by_view_fit_failure=bool(view_fit and not view_fit_applied),
             prompt="Use capture_viewport with view_fit=True instead of execute_python viewFit(all=True).",
         )
     except ValueError as exc:
@@ -174,13 +186,16 @@ def capture_viewport(
             off_screen=bool(off_screen),
             view_fit=bool(view_fit),
             view_fit_applied=view_fit_applied,
+            off_screen_forced_by_view_fit_failure=bool(view_fit and not view_fit_applied),
         )
     except Exception as exc:
+        _unlink_if_exists(tmp_path)
         if tmp_path is not None:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
+            prefix = tmp_path[:-4]
+            _unlink_if_exists(prefix + ".png")
+            if f0 is not None:
+                _unlink_if_exists("{}.{}.png".format(prefix, str(f0).zfill(4)))
+                _unlink_if_exists("{}.{}.png".format(prefix, f0))
         return skill_exception(
             exc,
             message="Failed to capture viewport",

--- a/src/dcc_mcp_maya/skills/maya-render/scripts/playblast.py
+++ b/src/dcc_mcp_maya/skills/maya-render/scripts/playblast.py
@@ -34,6 +34,14 @@ def _read_nonempty_png(path: str) -> bytes:
     return img_bytes
 
 
+def _unlink_if_exists(path: Optional[str]) -> None:
+    if path and os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
 def playblast(
     width: int = 1920,
     height: int = 1080,
@@ -56,6 +64,8 @@ def playblast(
         ``context.frame``.
     """
 
+    tmp_base: Optional[str] = None
+    f0: Optional[int] = None
     try:
         import maya.cmds as cmds  # noqa: PLC0415
 
@@ -102,7 +112,10 @@ def playblast(
             )
 
         img_bytes = _read_nonempty_png(img_path)
-        os.unlink(img_path)
+        _unlink_if_exists(img_path)
+        tmp_png = "{}.png".format(tmp_base)
+        if tmp_png != img_path:
+            _unlink_if_exists(tmp_png)
 
         img_b64 = base64.b64encode(img_bytes).decode("ascii")
 
@@ -117,11 +130,12 @@ def playblast(
     except ValueError as exc:
         if str(exc) != "EMPTY_PLAYBLAST":
             raise
-        try:
-            if img_path and os.path.exists(img_path):
-                os.unlink(img_path)
-        except OSError:
-            pass
+        _unlink_if_exists(img_path)
+        if tmp_base is not None:
+            _unlink_if_exists("{}.png".format(tmp_base))
+            if f0 is not None:
+                _unlink_if_exists("{}.{:04d}.png".format(tmp_base, f0))
+                _unlink_if_exists("{}.{}.png".format(tmp_base, f0))
         return skill_error(
             "Playblast produced an empty image",
             "Maya playblast wrote a 0-byte PNG",
@@ -137,6 +151,11 @@ def playblast(
     except ImportError:
         return skill_error("Maya not available", "maya.cmds could not be imported")
     except Exception as exc:
+        if tmp_base is not None:
+            _unlink_if_exists("{}.png".format(tmp_base))
+            if f0 is not None:
+                _unlink_if_exists("{}.{:04d}.png".format(tmp_base, f0))
+                _unlink_if_exists("{}.{}.png".format(tmp_base, f0))
         return skill_exception(exc, message="Playblast failed")
 
 

--- a/tests/test_maya_render_skill.py
+++ b/tests/test_maya_render_skill.py
@@ -1,0 +1,76 @@
+"""Unit tests for Maya render skill guard rails."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from conftest import load_and_call
+
+
+def _write_playblast_bytes(data: bytes):
+    def _write(**kwargs):
+        frame = kwargs["frame"][0]
+        path = "{}.{}.png".format(kwargs["filename"], str(frame).zfill(4))
+        with open(path, "wb") as fh:
+            fh.write(data)
+        return path
+
+    return _write
+
+
+def test_capture_viewport_forces_offscreen_when_view_fit_fails():
+    cmds = MagicMock()
+    cmds.currentTime.return_value = 1.0
+    cmds.viewFit.side_effect = RuntimeError("no usable panel")
+    cmds.playblast.side_effect = _write_playblast_bytes(b"png-bytes")
+
+    result = load_and_call(
+        "maya-render/scripts/capture_viewport.py",
+        cmds,
+        "main",
+        width=320,
+        height=200,
+        view_fit=True,
+        off_screen=False,
+    )
+
+    assert result["success"] is True, result
+    assert result["context"]["off_screen"] is True
+    assert result["context"]["view_fit_applied"] is False
+    assert result["context"]["off_screen_forced_by_view_fit_failure"] is True
+    _args, kwargs = cmds.playblast.call_args
+    assert kwargs["offScreen"] is True
+
+
+def test_capture_viewport_reports_zero_byte_playblast():
+    cmds = MagicMock()
+    cmds.currentTime.return_value = 1.0
+    cmds.playblast.side_effect = _write_playblast_bytes(b"")
+
+    result = load_and_call(
+        "maya-render/scripts/capture_viewport.py",
+        cmds,
+        "main",
+        width=320,
+        height=200,
+    )
+
+    assert result["success"] is False
+    assert "0-byte" in result["message"] or "0-byte" in result["error"]
+
+
+def test_playblast_reports_zero_byte_output():
+    cmds = MagicMock()
+    cmds.currentTime.return_value = 1.0
+    cmds.playblast.side_effect = _write_playblast_bytes(b"")
+
+    result = load_and_call(
+        "maya-render/scripts/playblast.py",
+        cmds,
+        "main",
+        width=320,
+        height=200,
+    )
+
+    assert result["success"] is False
+    assert "0-byte" in result["message"] or "0-byte" in result["error"]


### PR DESCRIPTION
## Summary

- Fail `maya_render__capture_viewport` and `maya_render__playblast` when Maya writes a missing or 0-byte PNG instead of returning a successful empty image.
- Force `capture_viewport` to use offscreen playblast when `view_fit=True` but `viewFit` cannot be applied, and expose that decision in the result context.
- Clean up temporary playblast files on both success and failure paths.

## Why

This implements the tactical mitigation from #235 so agents stop retrying after a silent empty capture and can see a structured failure instead.

## Tests

- `ruff check src/dcc_mcp_maya/skills/maya-render/scripts/capture_viewport.py src/dcc_mcp_maya/skills/maya-render/scripts/playblast.py tests/test_maya_render_skill.py`
- `pytest tests/test_maya_render_skill.py tests/test_skill_taxonomy.py -q`
- `pytest -q`