### PR TITLE
feat: wire maya sidecar remote gateway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,11 +141,100 @@ jobs:
       - name: Install PyYAML
         run: pip install pyyaml
 
+      - name: Install dcc-mcp-cli
+        run: |
+          export DCC_MCP_INSTALL_DIR="$RUNNER_TEMP/dcc-mcp-bin"
+          curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
+          echo "$DCC_MCP_INSTALL_DIR" >> "$GITHUB_PATH"
+
       - name: Lint SKILL.md files
         run: python tools/lint_skills.py --error-only
 
       - name: Lint tools.yaml affinity (issue #84)
         run: python tools/lint_skill_affinity.py
 
+      - name: Lint skills with dcc-mcp-cli
+        run: dcc-mcp-cli lint src/dcc_mcp_maya/skills
+
       - name: Check EN/ZH documentation parity (issue #88)
         run: python tools/check_doc_parity.py
+
+  cli-smoke:
+    name: dcc-mcp-cli Service Smoke
+    runs-on: ubuntu-latest
+    env:
+      DCC_MCP_ALLOW_AMBIENT_PYTHON: "1"
+      DCC_MCP_DISABLE_FILE_LOGGING: "1"
+      DCC_MCP_GATEWAY_PORT: "0"
+      DCC_MCP_MAYA_SIDECAR: "0"
+      DCC_MCP_BASE_URL: "http://127.0.0.1:18765"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Install dcc-mcp-cli
+        run: |
+          export DCC_MCP_INSTALL_DIR="$RUNNER_TEMP/dcc-mcp-bin"
+          curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
+          echo "$DCC_MCP_INSTALL_DIR" >> "$GITHUB_PATH"
+
+      - name: Start Maya adapter service
+        run: |
+          python - <<'PY' > "$RUNNER_TEMP/maya-cli-smoke.log" 2>&1 &
+          import time
+          from dcc_mcp_maya import start_server
+
+          handle = start_server(port=18765, gateway_port=0, enable_gateway_failover=False)
+          print(handle.mcp_url(), flush=True)
+          try:
+              while True:
+                  time.sleep(1)
+          finally:
+              handle.shutdown()
+          PY
+          echo "$!" > "$RUNNER_TEMP/maya-cli-smoke.pid"
+
+      - name: Probe service with dcc-mcp-cli
+        run: |
+          cleanup() {
+            if [ -f "$RUNNER_TEMP/maya-cli-smoke.pid" ]; then
+              kill "$(cat "$RUNNER_TEMP/maya-cli-smoke.pid")" 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
+
+          for _ in $(seq 1 30); do
+            if dcc-mcp-cli health; then
+              break
+            fi
+            sleep 1
+          done
+
+          dcc-mcp-cli health
+          dcc-mcp-cli search --query get_session --limit 3 | tee "$RUNNER_TEMP/dcc-mcp-cli-search.json"
+          dcc-mcp-cli describe maya.maya-scene.maya_scene__get_session_info
+
+          python - <<'PY'
+          import json
+          import os
+
+          path = os.path.join(os.environ["RUNNER_TEMP"], "dcc-mcp-cli-search.json")
+          payload = json.load(open(path, encoding="utf-8"))
+          slugs = {hit.get("slug") for hit in payload.get("hits", [])}
+          expected = "maya.maya-scene.maya_scene__get_session_info"
+          if expected not in slugs:
+              raise SystemExit(f"{expected} not found in dcc-mcp-cli search results: {sorted(slugs)}")
+          PY
+
+      - name: Dump service log on failure
+        if: failure()
+        run: cat "$RUNNER_TEMP/maya-cli-smoke.log" || true

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Embeds a standards-compliant **MCP Streamable HTTP server** (2025-03-26 spec) di
 
 Sidecar mode keeps the same public MCP surface but runs the `dcc-mcp-server sidecar` process beside Maya by default. It connects back through the Qt event-loop dispatcher; set `DCC_MCP_MAYA_SIDECAR=0` to return to the legacy in-process gateway path.
 
+By default, local MCP clients connect to `http://127.0.0.1:9765/mcp`. Newer sidecar binaries also expose a LAN listener from the elected gateway at `http://<this-machine-lan-ip>:59765/mcp`; gateway election still happens only on the local `127.0.0.1:9765` port, so multiple Maya sessions do not race to publish separate remote entrypoints. If the LAN port is occupied, the sidecar degrades to the local gateway without blocking Maya startup.
+
 ## Installation
 
 ### Into Maya's Python
@@ -101,6 +103,8 @@ The server starts automatically when the plugin loads.
 | `DCC_MCP_DEFAULT_TOOLS` | _(none)_ | Comma-separated skill names to load at startup (overrides minimal default) |
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | `1` hides `__skill__*` / `__group__*` stubs from large `tools/list` syncs; use `dcc_capability_manifest` for discovery |
 | `DCC_MCP_MAYA_SIDECAR` | `1` | `0` disables the default `dcc-mcp-server sidecar` process from the Maya plugin |
+| `DCC_MCP_GATEWAY_REMOTE_PORT` | `59765` | LAN gateway listener port exposed by the elected sidecar gateway; `0` disables the remote listener |
+| `DCC_MCP_GATEWAY_REMOTE_HOST` | `0.0.0.0` | Bind address for the LAN gateway listener |
 | `DCC_MCP_MAYA_FAULTHANDLER` | `1` | `0` disables Python fatal-signal traceback logging from the Maya plugin |
 | `DCC_MCP_MAYA_SUPPRESS_CRASH_REPORTER` | `0` | `1` suppresses Maya crash-reporter/CER dialogs during plugin startup for unattended automation |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | `1` / `true` / `yes` / `on` — refuse `execute_python` (skills-first enforcement) |

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -206,4 +206,6 @@ Returned by `server.start()` and `start_server()`.
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Hide unloaded skill/group stubs from `tools/list` |
 | `DCC_MCP_MAYA_SIDECAR` | `1` | Set `0` to disable the default `dcc-mcp-server sidecar` from the Maya plugin |
 | `DCC_MCP_GATEWAY_PORT` | `9765` in plugin mode | Gateway competition port; `0` disables gateway mode |
+| `DCC_MCP_GATEWAY_REMOTE_PORT` | `59765` in sidecar mode | LAN gateway listener port opened by the elected sidecar gateway; `0` disables remote access |
+| `DCC_MCP_GATEWAY_REMOTE_HOST` | `0.0.0.0` | Bind address for the LAN gateway listener |
 | `DCC_MCP_REGISTRY_DIR` | OS temp dir | Shared registry directory for service discovery |

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -41,13 +41,15 @@ Copy the plugin file to a directory on `MAYA_PLUG_IN_PATH`, then load it through
 
 The plugin starts the server automatically on load. By default it uses an OS-assigned instance port and participates in the gateway on port `9765`.
 
+With sidecar mode enabled, local MCP clients use `http://127.0.0.1:9765/mcp`. Newer sidecar binaries also expose the elected gateway on the LAN at `http://<this-machine-lan-ip>:59765/mcp`. Set `DCC_MCP_GATEWAY_REMOTE_PORT=0` to disable the LAN listener, or override `DCC_MCP_GATEWAY_REMOTE_HOST` / `DCC_MCP_GATEWAY_REMOTE_PORT` before loading the plugin.
+
 During plugin initialization, `dcc-mcp-maya` also closes Maya's legacy MEL commandPort on `127.0.0.1:50007`. The MCP server never uses that port, and closing it prevents accidental HTTP probes from opening Maya's security warning dialog. Studios that still depend on the legacy commandPort can opt out with `DCC_MCP_MAYA_CLOSE_DEFAULT_COMMANDPORT=0` before loading the plugin.
 
-The default plugin runtime is still the embedded in-process MCP server. To run
-the Rust sidecar beside Maya by default. Set `DCC_MCP_MAYA_SIDECAR=0` before
-loading the plugin to return to the legacy in-process gateway path. Sidecar
-mode uses the in-Maya Qt event-loop dispatcher and does not require opening
-Maya's legacy commandPort.
+The plugin starts the Rust sidecar beside Maya by default while keeping the
+embedded in-process MCP server as the host bridge. Set `DCC_MCP_MAYA_SIDECAR=0`
+before loading the plugin to return to the legacy in-process gateway path.
+Sidecar mode uses the in-Maya Qt event-loop dispatcher and does not require
+opening Maya's legacy commandPort.
 
 ## Method 3 — mayapy bootstrap
 

--- a/docs/zh/api/server.md
+++ b/docs/zh/api/server.md
@@ -193,4 +193,6 @@ server.stop()
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | 从 `tools/list` 隐藏未加载 skill/group stub |
 | `DCC_MCP_MAYA_SIDECAR` | `1` | 设为 `0` 可禁用 Maya 插件默认启动的 `dcc-mcp-server sidecar` |
 | `DCC_MCP_GATEWAY_PORT` | 插件模式下为 `9765` | 网关竞争端口；设为 `0` 可禁用 |
+| `DCC_MCP_GATEWAY_REMOTE_PORT` | sidecar 模式下为 `59765` | 由选举胜出的 sidecar gateway 打开的局域网入口；设为 `0` 可关闭远程访问 |
+| `DCC_MCP_GATEWAY_REMOTE_HOST` | `0.0.0.0` | 局域网 gateway listener 的绑定地址 |
 | `DCC_MCP_REGISTRY_DIR` | 操作系统临时目录 | 用于服务发现的共享注册目录 |

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -41,6 +41,8 @@ mayapy -c "import dcc_mcp_maya; print(dcc_mcp_maya.__version__)"
 
 插件加载后会自动启动服务器。默认情况下实例端口由操作系统分配，并接入 `9765` 端口上的网关。
 
+启用 sidecar 模式时，本机 MCP 客户端使用 `http://127.0.0.1:9765/mcp`。新版 sidecar binary 还会由选举胜出的 gateway 在局域网暴露 `http://<这台机器的局域网IP>:59765/mcp`。如需关闭局域网入口，可在加载插件前设置 `DCC_MCP_GATEWAY_REMOTE_PORT=0`；如需改绑定地址或端口，设置 `DCC_MCP_GATEWAY_REMOTE_HOST` / `DCC_MCP_GATEWAY_REMOTE_PORT`。
+
 插件初始化期间，`dcc-mcp-maya` 还会关闭 Maya 旧式 MEL commandPort（`127.0.0.1:50007`）。MCP 服务器不会使用该端口，关闭它可以避免误发的 HTTP 探测触发 Maya 安全警告弹窗。如果工作室仍依赖旧式 commandPort，可在加载插件前设置 `DCC_MCP_MAYA_CLOSE_DEFAULT_COMMANDPORT=0` 选择保留。
 
 插件默认会在 Maya 旁边启动 Rust sidecar，同时保留进程内 MCP server 作为 host bridge。如需回到旧的进程内 gateway 路径，请在加载插件前设置 `DCC_MCP_MAYA_SIDECAR=0`。Sidecar 模式使用 Maya 内部 Qt event-loop dispatcher，不需要打开旧式 commandPort。

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -464,6 +464,8 @@ tools:
 | `DCC_MCP_MAYA_RESOURCES` | `1` | per-process | `0`=disable Maya MCP resource publishing (`scene://current` snapshot + `maya-cmds://` / `maya-api://` / `maya-project://` producers).  Issue #187 / core 0.15.0. |
 | `DCC_MCP_MAYA_FAULTHANDLER` | `1` | per-process | `0`=disable plugin-installed Python fatal-signal traceback logging. Logs are written under `DCC_MCP_LOG_DIR` or the OS temp directory. |
 | `DCC_MCP_GATEWAY_PORT` | `9765` | per-host | Gateway election port. `0`=disable gateway mode. |
+| `DCC_MCP_GATEWAY_REMOTE_PORT` | `59765` | per-host | LAN gateway listener port opened only by the elected sidecar gateway. `0`=disable remote listener; local gateway remains on `127.0.0.1:9765`. |
+| `DCC_MCP_GATEWAY_REMOTE_HOST` | `0.0.0.0` | per-host | LAN gateway listener bind address. Use a specific interface IP to narrow exposure. |
 | `DCC_MCP_REGISTRY_DIR` | OS temp dir | per-user | Shared FileRegistry directory. |
 | `DCC_MCP_PYTHON_EXECUTABLE` | `sys.executable` | per-process | Python interpreter for skill worker subprocesses. |
 | `DCC_MCP_PYTHON_INIT_SNIPPET` | `import maya.standalone; maya.standalone.initialize(name='python')` | per-process | One-liner run by workers before tool scripts. |

--- a/llms.txt
+++ b/llms.txt
@@ -25,7 +25,7 @@ handle = dcc_mcp_maya.start_server(port=8765)
 handle.shutdown()
 ```
 
-Plugin mode: copy `maya/plugin/dcc_mcp_maya_plugin.py` to `MAYA_PLUG_IN_PATH` and load it. Server auto-starts.
+Plugin mode: copy `maya/plugin/dcc_mcp_maya_plugin.py` to `MAYA_PLUG_IN_PATH` and load it. Server auto-starts. Sidecar mode exposes the elected gateway locally at `http://127.0.0.1:9765/mcp`; newer core sidecars also bind a LAN listener at `http://<this-machine-lan-ip>:59765/mcp` unless `DCC_MCP_GATEWAY_REMOTE_PORT=0`.
 
 ---
 

--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -34,6 +34,16 @@ Connect your MCP client (Claude Desktop, etc.) to the **single gateway endpoint*
 
     http://127.0.0.1:9765/mcp
 
+Newer sidecar binaries also expose the elected gateway on the local network by
+default::
+
+    http://<this-machine-lan-ip>:59765/mcp
+
+Remote listener election still follows the local gateway winner on
+``127.0.0.1:9765``. Set ``DCC_MCP_GATEWAY_REMOTE_PORT=0`` to disable the LAN
+listener, or ``DCC_MCP_GATEWAY_REMOTE_HOST`` / ``DCC_MCP_GATEWAY_REMOTE_PORT``
+to choose a different bind address.
+
 The gateway exposes a bounded dynamic surface (``search_tools`` / ``describe_tool`` /
 ``call_tool``) and MCP ``resources/read`` on ``gateway://instances`` for instance
 discovery (see ``gateway://docs/agent-workflows``). Legacy ``list_dcc_instances`` /
@@ -52,6 +62,12 @@ Configuration
 
 ``DCC_MCP_GATEWAY_PORT``
     Gateway competition port.  Default ``9765``.  Set to ``0`` to disable.
+
+``DCC_MCP_GATEWAY_REMOTE_PORT``
+    LAN gateway listener port. Default ``59765``. Set to ``0`` to disable.
+
+``DCC_MCP_GATEWAY_REMOTE_HOST``
+    LAN gateway listener bind address. Default ``0.0.0.0``.
 
 ``DCC_MCP_REGISTRY_DIR``
     Directory for the shared ``FileRegistry`` JSON.  Defaults to OS temp dir.
@@ -87,6 +103,7 @@ import faulthandler
 import logging
 import os
 import signal
+import socket
 import sys
 import tempfile
 import threading
@@ -838,6 +855,20 @@ def _maybe_spawn_sidecar() -> None:
 
 def _print_sidecar_info(handle) -> None:  # noqa: ANN001
     """Append a sidecar banner to the script editor / viewport HUD."""
+    gateway_port = _resolve_gateway_port_for_display()
+    gateway_lines = []
+    if gateway_port > 0:
+        gateway_lines.append(f"  Gateway local: http://127.0.0.1:{gateway_port}/mcp  (if elected)")
+        try:
+            from dcc_mcp_maya.sidecar import resolve_gateway_remote_options  # noqa: PLC0415
+
+            remote_host, remote_port = resolve_gateway_remote_options()
+        except Exception:  # noqa: BLE001
+            remote_host, remote_port = "0.0.0.0", 59765
+        if remote_port > 0:
+            display_host = _gateway_remote_display_host(remote_host)
+            gateway_lines.append(f"  Gateway LAN  : http://{display_host}:{remote_port}/mcp  (if elected)")
+
     border = "=" * 60
     lines = [
         border,
@@ -848,6 +879,7 @@ def _print_sidecar_info(handle) -> None:  # noqa: ANN001
         f"  Qt server    : 127.0.0.1:{handle.qt_port}  ({handle.qt_binding})",
         f"  host-rpc URI : {handle.host_rpc_uri}",
         f"  watch-pid    : {handle.maya_pid} (Maya)",
+        *gateway_lines,
         border,
     ]
     print("\n".join(lines))  # noqa: T201 — intentional console output
@@ -862,6 +894,35 @@ def _print_sidecar_info(handle) -> None:  # noqa: ANN001
             )
         except Exception:  # noqa: BLE001 — viewport HUD is cosmetic
             pass
+
+
+def _resolve_gateway_port_for_display() -> int:
+    raw = os.environ.get("DCC_MCP_GATEWAY_PORT", str(_DEFAULT_GATEWAY_PORT))
+    try:
+        port = int(raw)
+    except ValueError:
+        port = _DEFAULT_GATEWAY_PORT
+    return port if port > 0 else 0
+
+
+def _gateway_remote_display_host(bind_host: str) -> str:
+    if bind_host not in {"", "0.0.0.0", "::"}:
+        return bind_host
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            host = sock.getsockname()[0]
+            if host and not host.startswith("127."):
+                return host
+    except OSError:
+        pass
+    try:
+        host = socket.gethostbyname(socket.gethostname())
+        if host and not host.startswith("127."):
+            return host
+    except OSError:
+        pass
+    return "<LAN-IP>"
 
 
 def _print_startup_info(cfg: dict) -> None:

--- a/src/dcc_mcp_maya/sidecar/__init__.py
+++ b/src/dcc_mcp_maya/sidecar/__init__.py
@@ -71,16 +71,25 @@ from dcc_mcp_maya.sidecar._resolver import (
     resolve_sidecar_binary,
 )
 from dcc_mcp_maya.sidecar._supervisor import (
+    DEFAULT_GATEWAY_REMOTE_HOST,
+    DEFAULT_GATEWAY_REMOTE_PORT,
+    ENV_GATEWAY_REMOTE_HOST,
+    ENV_GATEWAY_REMOTE_PORT,
     ENV_SIDECAR_MODE,
     SidecarHandle,
     SidecarSpawnError,
     build_qtserver_uri,
     is_sidecar_mode_enabled,
+    resolve_gateway_remote_options,
     start_sidecar,
     stop_sidecar,
 )
 
 __all__ = [
+    "DEFAULT_GATEWAY_REMOTE_HOST",
+    "DEFAULT_GATEWAY_REMOTE_PORT",
+    "ENV_GATEWAY_REMOTE_HOST",
+    "ENV_GATEWAY_REMOTE_PORT",
     "ENV_SIDECAR_BINARY",
     "ENV_SIDECAR_MODE",
     "SidecarBinaryError",
@@ -91,6 +100,7 @@ __all__ = [
     "dispatch_payload",
     "is_sidecar_mode_enabled",
     "resolve_sidecar_binary",
+    "resolve_gateway_remote_options",
     "start_sidecar",
     "stop_sidecar",
 ]

--- a/src/dcc_mcp_maya/sidecar/_supervisor.py
+++ b/src/dcc_mcp_maya/sidecar/_supervisor.py
@@ -63,11 +63,16 @@ from dcc_mcp_maya.sidecar._resolver import (
 )
 
 __all__ = [
+    "DEFAULT_GATEWAY_REMOTE_HOST",
+    "DEFAULT_GATEWAY_REMOTE_PORT",
+    "ENV_GATEWAY_REMOTE_HOST",
+    "ENV_GATEWAY_REMOTE_PORT",
     "ENV_SIDECAR_MODE",
     "SidecarHandle",
     "SidecarSpawnError",
     "build_qtserver_uri",
     "is_sidecar_mode_enabled",
+    "resolve_gateway_remote_options",
     "start_sidecar",
     "stop_sidecar",
 ]
@@ -75,6 +80,10 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 ENV_SIDECAR_MODE = "DCC_MCP_MAYA_SIDECAR"
+ENV_GATEWAY_REMOTE_HOST = "DCC_MCP_GATEWAY_REMOTE_HOST"
+ENV_GATEWAY_REMOTE_PORT = "DCC_MCP_GATEWAY_REMOTE_PORT"
+DEFAULT_GATEWAY_REMOTE_HOST = "0.0.0.0"
+DEFAULT_GATEWAY_REMOTE_PORT = 59765
 _TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
 _FALSEY_VALUES = frozenset({"0", "false", "no", "off"})
 
@@ -158,6 +167,30 @@ def is_sidecar_mode_enabled(env: Optional[dict] = None) -> bool:
     # Unknown values preserve the default-on behaviour; only explicit
     # falsey tokens opt out.
     return True
+
+
+def resolve_gateway_remote_options(env: Optional[dict] = None) -> tuple[str, int]:
+    """Resolve LAN gateway listener options for the sidecar process.
+
+    The elected gateway still competes on the local loopback port
+    (``DCC_MCP_GATEWAY_PORT``, default 9765).  Newer ``dcc-mcp-server``
+    sidecars can additionally bind a LAN-facing listener for company
+    network clients; older binaries simply ignore these env vars.
+    """
+
+    source = os.environ if env is None else env
+    host = str(source.get(ENV_GATEWAY_REMOTE_HOST, DEFAULT_GATEWAY_REMOTE_HOST)).strip()
+    if not host:
+        host = DEFAULT_GATEWAY_REMOTE_HOST
+
+    raw_port = str(source.get(ENV_GATEWAY_REMOTE_PORT, str(DEFAULT_GATEWAY_REMOTE_PORT))).strip()
+    try:
+        port = int(raw_port)
+    except ValueError:
+        port = DEFAULT_GATEWAY_REMOTE_PORT
+    if port < 0:
+        port = DEFAULT_GATEWAY_REMOTE_PORT
+    return host, port
 
 
 def start_sidecar(
@@ -271,6 +304,9 @@ def start_sidecar(
     spawn_env = os.environ.copy()
     if extra_env:
         spawn_env.update(extra_env)
+    gateway_remote_host, gateway_remote_port = resolve_gateway_remote_options(spawn_env)
+    spawn_env[ENV_GATEWAY_REMOTE_HOST] = gateway_remote_host
+    spawn_env[ENV_GATEWAY_REMOTE_PORT] = str(gateway_remote_port)
 
     logger.info(
         "dcc-mcp-maya: spawning sidecar %s (qt_port=%d, watch_pid=%d, qt_binding=%s)",

--- a/tests/test_plugin_env_vars.py
+++ b/tests/test_plugin_env_vars.py
@@ -370,6 +370,9 @@ class TestSidecarSharesRegistryWithInProcessServer:
 
     def test_sidecar_banner_omits_internal_rfc_marker(self, plugin_module, monkeypatch, capsys):
         monkeypatch.setattr(plugin_module, "_is_interactive", lambda: False)
+        monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "9765")
+        monkeypatch.setenv("DCC_MCP_GATEWAY_REMOTE_PORT", "59765")
+        monkeypatch.setattr(plugin_module, "_gateway_remote_display_host", lambda _host: "192.168.1.20")
         handle = MagicMock(
             binary_path="C:/tools/dcc-mcp-server.exe",
             qt_port=53123,
@@ -386,6 +389,19 @@ class TestSidecarSharesRegistryWithInProcessServer:
         assert "RFC #998" not in output
         assert f"dcc-mcp-maya v{plugin_module.VERSION}" in output
         assert "PID          : 5678" in output
+        assert "Gateway local: http://127.0.0.1:9765/mcp  (if elected)" in output
+        assert "Gateway LAN  : http://192.168.1.20:59765/mcp  (if elected)" in output
+
+    def test_sidecar_remote_gateway_options_default_and_disable(self, monkeypatch):
+        from dcc_mcp_maya.sidecar import resolve_gateway_remote_options
+
+        monkeypatch.delenv("DCC_MCP_GATEWAY_REMOTE_HOST", raising=False)
+        monkeypatch.delenv("DCC_MCP_GATEWAY_REMOTE_PORT", raising=False)
+        assert resolve_gateway_remote_options() == ("0.0.0.0", 59765)
+
+        monkeypatch.setenv("DCC_MCP_GATEWAY_REMOTE_HOST", "192.168.2.10")
+        monkeypatch.setenv("DCC_MCP_GATEWAY_REMOTE_PORT", "0")
+        assert resolve_gateway_remote_options() == ("192.168.2.10", 0)
 
 
 class TestRestartStopsSidecar:


### PR DESCRIPTION
## Summary
- default Maya sidecar remote gateway env to 0.0.0.0:19765 while local election remains on 127.0.0.1:9765
- show local and LAN gateway URLs in the sidecar banner without exposing internal RFC labels
- document remote gateway host/port env vars across README, API, install, and llms references

## Tests
- pytest tests\\test_plugin_env_vars.py tests\\test_maya_http_transport.py::TestSidecarHttpApi::test_sidecar_mcp_initialize -q
- ruff check src\\dcc_mcp_maya\\sidecar\\_supervisor.py src\\dcc_mcp_maya\\sidecar\\__init__.py maya\\plugin\\dcc_mcp_maya_plugin.py tests\\test_plugin_env_vars.py
- ruff format --check src\\dcc_mcp_maya\\sidecar\\_supervisor.py src\\dcc_mcp_maya\\sidecar\\__init__.py maya\\plugin\\dcc_mcp_maya_plugin.py tests\\test_plugin_env_vars.py