### PR TITLE
fix: allow py37 dev installs without sidecar wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ For plugin-side sidecar mode, install the sidecar extra when your environment do
 mayapy -m pip install "dcc-mcp-maya[sidecar]"
 ```
 
+The sidecar extra installs `dcc-mcp-server` on Python 3.8+. Maya 2022 uses Python 3.7; in that environment either run without sidecar (`DCC_MCP_MAYA_SIDECAR=0`) or provide the binary explicitly with `DCC_MCP_SERVER_BIN`.
+
 ### Maya Plugin
 
 1. Put `maya/plugin/dcc_mcp_maya_plugin.py` on `MAYA_PLUG_IN_PATH`.
@@ -276,7 +278,7 @@ Windows symlinks require Developer Mode or an elevated shell. If symlinks are un
 - Autodesk Maya 2020+
 - Python 3.7+
 - `dcc-mcp-core>=0.17.9,<1.0.0`
-- Optional sidecar binary: `dcc-mcp-server>=0.17.9`
+- Optional sidecar binary: `dcc-mcp-server>=0.17.9` on Python 3.8+, or `DCC_MCP_SERVER_BIN` pointing to a compatible binary
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
 
 dependencies = [
     # 0.17.9+: hardened gateway initialization, remote gateway listener,
-    # instance-scoped unloaded capabilities, and Python 3.7-compatible
-    # dcc-mcp-server binary wheels for Maya 2022 sidecar installs.
-    # abi3 (cp38+) on 3.8+; separate cp37 wheels on Python 3.7 (Maya 2022).
+    # and instance-scoped unloaded capabilities. The Rust sidecar binary is
+    # optional below because Python 3.7 / Maya 2022 test environments must be
+    # able to install the adapter even when no dcc-mcp-server wheel is present.
     "dcc-mcp-core>=0.17.9,<1.0.0",
 ]
 
@@ -42,7 +42,7 @@ dev = [
     "pytest-timeout>=2.1.0",
     "pytest-xdist>=3.0",
     "requests>=2.28.0",
-    "dcc-mcp-server>=0.17.9",
+    "dcc-mcp-server>=0.17.9; python_version >= '3.8'",
     "ruff>=0.8.0",
     "hatchling",
     "build",
@@ -50,7 +50,7 @@ dev = [
     "pyyaml>=5.0",  # YAML parsing for SKILL.md test validation
 ]
 sidecar = [
-    "dcc-mcp-server>=0.17.9",
+    "dcc-mcp-server>=0.17.9; python_version >= '3.8'",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- Keep `dcc-mcp-server>=0.17.9` in the dev/sidecar extras only for Python 3.8+.
- Allow Maya 2022 / Python 3.7 CI to install `.[dev]` without requiring an unavailable `dcc-mcp-server` wheel.
- Document the Python 3.7 sidecar path: disable sidecar or provide a binary with `DCC_MCP_SERVER_BIN`.

## Why

The merged core 0.17.9 alignment made the mayapy 2022 job install `.[dev]`, but PyPI currently has no Python 3.7-compatible `dcc-mcp-server>=0.17.9` distribution for that environment. The job fails during dependency resolution before tests or the plugin load smoke can run.

The Maya 2022 CI path does not need the sidecar binary: regular sidecar tests already skip when the binary is unavailable, and the plugin load smoke explicitly uses `DCC_MCP_MAYA_SIDECAR=0` to validate plugin loading independently from sidecar startup.

## Validation

- `git diff --check HEAD~1..HEAD`
- `python -m pip install -e ".[dev]"`
- `python -m pytest tests/test_maya_http_transport.py::test_sidecar_registry_wait_filters_by_host_rpc_uri -q`