### PR TITLE
feat: add agent setup skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Or load the Maya plugin (`dcc_mcp_maya_plugin.py`) and the server starts automat
 - **docs/guide/getting-started.md** — Step-by-step for first-time users.
 - **docs/guide/local-mcp-debug.md** — Cursor / Claude MCP HTTP URL, **debugpy** attach, gateway vs direct port.
 - **examples/mcp/** — Copy-paste MCP JSON (`cursor-maya-streamable-http.json`).
+- **install.md** + **skills/dcc-mcp-maya-setup/** — Agent-facing setup entry: install `mayapy` pip dependencies, generate MCP config snippets, guide Maya plugin loading, and run a first smoke prompt.
 - **docs/guide/installation.md** — Plugin mode, `userSetup.py`, multi-Maya setup.
 - **docs/guide/multi-instance.md** — Run multiple Maya sessions behind one gateway.
 - **docs/guide/mcp-tools.md** — Representative tool inventory (scene, geometry, material, animation, render).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ The Maya plugin starts a Rust `dcc-mcp-server` sidecar by default, so HTTP and g
 
 ## Quick Start
 
+Agent-assisted setup is available if you want an AI agent to install the
+Maya-side dependencies, write MCP host config, and walk you through loading the
+plugin:
+
+```text
+Help me install dcc-mcp-maya using loonghao/dcc-mcp-maya/install.md.
+```
+
+The agent should follow [`install.md`](install.md), which delegates the setup
+workflow to [`skills/dcc-mcp-maya-setup`](skills/dcc-mcp-maya-setup/).
+
 Install into Maya's Python:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ Maya-side dependencies, write MCP host config, and walk you through loading the
 plugin:
 
 ```text
-Help me install dcc-mcp-maya using loonghao/dcc-mcp-maya/install.md.
+Help me install dcc-mcp-maya using https://github.com/loonghao/dcc-mcp-maya/blob/main/install.md.
 ```
 
-The agent should follow [`install.md`](install.md), which delegates the setup
-workflow to [`skills/dcc-mcp-maya-setup`](skills/dcc-mcp-maya-setup/).
+The agent should follow
+[`install.md`](https://github.com/loonghao/dcc-mcp-maya/blob/main/install.md),
+which delegates the setup workflow to
+[`skills/dcc-mcp-maya-setup`](https://github.com/loonghao/dcc-mcp-maya/tree/main/skills/dcc-mcp-maya-setup).
 
 Install into Maya's Python:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -55,12 +55,13 @@ mayapy -m pip install dcc-mcp-maya
 Maya 插件管理器里启用插件，可以直接对 agent 说：
 
 ```text
-帮我参考 loonghao/dcc-mcp-maya/install.md 去安装
+帮我参考 https://github.com/loonghao/dcc-mcp-maya/blob/main/install.md 去安装
 ```
 
-Agent 应先阅读 [`install.md`](install.md)，再按
-[`skills/dcc-mcp-maya-setup`](skills/dcc-mcp-maya-setup/) 中的 setup skill
-完成安装、MCP 配置和 smoke prompt 测试。
+Agent 应先阅读
+[`install.md`](https://github.com/loonghao/dcc-mcp-maya/blob/main/install.md)，再按
+[`skills/dcc-mcp-maya-setup`](https://github.com/loonghao/dcc-mcp-maya/tree/main/skills/dcc-mcp-maya-setup)
+中的 setup skill 完成安装、MCP 配置和 smoke prompt 测试。
 
 ### 选项 A — 从 Python 脚本面板
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -51,6 +51,17 @@ mayapy -m pip install dcc-mcp-maya
 
 ## 快速开始
 
+如果希望 AI agent 帮你安装 Maya 侧依赖、生成 MCP 配置，并引导你在
+Maya 插件管理器里启用插件，可以直接对 agent 说：
+
+```text
+帮我参考 loonghao/dcc-mcp-maya/install.md 去安装
+```
+
+Agent 应先阅读 [`install.md`](install.md)，再按
+[`skills/dcc-mcp-maya-setup`](skills/dcc-mcp-maya-setup/) 中的 setup skill
+完成安装、MCP 配置和 smoke prompt 测试。
+
 ### 选项 A — 从 Python 脚本面板
 
 ```python

--- a/install.md
+++ b/install.md
@@ -1,0 +1,76 @@
+# dcc-mcp-maya Agent Install
+
+Use this page when an agent is asked to install or configure
+`loonghao/dcc-mcp-maya` for Autodesk Maya.
+
+## Agent Instruction
+
+If the user says "帮我参考 loonghao/dcc-mcp-maya/install.md 去安装",
+do this:
+
+1. Read `skills/dcc-mcp-maya-setup/SKILL.md`.
+2. Run the setup script from the repository root.
+3. Help the user load the Maya plugin in Plug-in Manager.
+4. Configure the MCP host with the generated Streamable HTTP JSON.
+5. Run the smoke prompt to prove the connection works.
+
+## One Command
+
+From the repository root:
+
+```bash
+python skills/dcc-mcp-maya-setup/scripts/setup_dcc_mcp_maya.py
+```
+
+For an end-user install from PyPI instead of this checkout:
+
+```bash
+python skills/dcc-mcp-maya-setup/scripts/setup_dcc_mcp_maya.py --source pypi
+```
+
+If `mayapy` is not auto-detected:
+
+```bash
+python skills/dcc-mcp-maya-setup/scripts/setup_dcc_mcp_maya.py --mayapy "C:\Program Files\Autodesk\Maya2025\bin\mayapy.exe"
+```
+
+## Maya Plugin Step
+
+After the script finishes, the user must open Maya and load the plugin:
+
+1. Open `Window > Settings/Preferences > Plug-in Manager`.
+2. Find or add `maya/plugin/dcc_mcp_maya_plugin.py`.
+3. Enable `Loaded`.
+4. Enable `Auto load` if this should start with Maya.
+
+Plugin sidecar mode usually exposes MCP at:
+
+```text
+http://127.0.0.1:9765/mcp
+```
+
+Manual `start_server(port=8765)` mode uses:
+
+```text
+http://127.0.0.1:8765/mcp
+```
+
+## MCP Config
+
+Use this JSON for Cursor, Claude Desktop, or any MCP Streamable HTTP host:
+
+```json
+{
+  "mcpServers": {
+    "maya": {
+      "url": "http://127.0.0.1:9765/mcp"
+    }
+  }
+}
+```
+
+The setup script also writes config snippets and a smoke prompt under:
+
+```text
+.dcc-mcp/agent-setup/
+```

--- a/skills/dcc-mcp-maya-setup/SKILL.md
+++ b/skills/dcc-mcp-maya-setup/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: dcc-mcp-maya-setup
+description: |-
+  Set up dcc-mcp-maya for an agent or operator: install Maya Python
+  dependencies with mayapy, generate MCP host configuration, guide the user
+  through loading the Maya plugin, and run a first live-tool smoke prompt.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: operator
+    stage: bootstrap
+    version: 1.0.0
+    tags:
+    - maya
+    - mcp
+    - setup
+    - mayapy
+    - plugin
+---
+# dcc-mcp-maya setup
+
+Use this skill when a user wants an agent to prepare a machine so any MCP
+host can use `dcc-mcp-maya` with Autodesk Maya.
+
+This is an operator skill, not a Maya runtime skill. Do not load it through
+the Maya MCP server. Run it from the repository checkout or copy its steps into
+another agent's instructions.
+
+If the user says "帮我参考 `loonghao/dcc-mcp-maya/install.md` 去安装", read the
+root `install.md` first, then follow this skill.
+
+## Goal
+
+End with:
+
+- `dcc-mcp-maya` and its pip dependencies installed into the target Maya
+  `mayapy` environment.
+- An MCP host config snippet that points to the Maya plugin gateway.
+- The user guided to load `dcc_mcp_maya_plugin.py` in Maya's Plug-in Manager.
+- A live smoke prompt that proves the agent can discover and call Maya tools.
+
+## Fast Path
+
+From the repository root, run:
+
+```bash
+python skills/dcc-mcp-maya-setup/scripts/setup_dcc_mcp_maya.py
+```
+
+The script:
+
+1. Finds `mayapy` from `--mayapy`, `MAYAPY`, `DCC_MCP_MAYA_MAYAPY`, `PATH`,
+   or common Autodesk install locations.
+2. Installs this checkout into Maya with the sidecar extra:
+   `mayapy -m pip install -e ".[sidecar]"`.
+3. Verifies `import dcc_mcp_maya`.
+4. Writes reusable MCP JSON snippets under `.dcc-mcp/agent-setup/`.
+
+Use PyPI instead of the local checkout when setting up an end-user machine:
+
+```bash
+python skills/dcc-mcp-maya-setup/scripts/setup_dcc_mcp_maya.py --source pypi
+```
+
+If discovery fails, ask the user for the full `mayapy` path and re-run:
+
+```bash
+python skills/dcc-mcp-maya-setup/scripts/setup_dcc_mcp_maya.py --mayapy "C:\Program Files\Autodesk\Maya2025\bin\mayapy.exe"
+```
+
+## MCP Configuration
+
+Plugin sidecar mode is the preferred default. Configure the MCP host with:
+
+```json
+{
+  "mcpServers": {
+    "maya": {
+      "url": "http://127.0.0.1:9765/mcp"
+    }
+  }
+}
+```
+
+Use `http://127.0.0.1:8765/mcp` only when the user explicitly starts the
+server manually with `dcc_mcp_maya.start_server(port=8765)`.
+
+When editing an existing MCP config, preserve unrelated servers. Merge only the
+`maya` server entry unless the user asks for a different server name.
+
+## User Hand-Off: Load the Maya Plugin
+
+After pip setup and MCP JSON generation, tell the user:
+
+1. Open Autodesk Maya.
+2. Go to `Window > Settings/Preferences > Plug-in Manager`.
+3. Add or find `dcc_mcp_maya_plugin.py`.
+4. Check `Loaded`; optionally check `Auto load`.
+5. Watch Script Editor output for the MCP URL.
+
+Expected plugin-mode URL is usually `http://127.0.0.1:9765/mcp`.
+
+If the plugin is not visible, verify that `maya/plugin/dcc_mcp_maya_plugin.py`
+is on `MAYA_PLUG_IN_PATH` or copy it into the user's Maya plug-ins folder.
+
+## First Live Smoke Prompt
+
+Ask the MCP host to run this prompt after Maya is open and the plugin is
+loaded:
+
+```text
+Use the Maya MCP server. First call dcc_capability_manifest with loaded_only=false.
+Then load the maya-primitives skill, create a sphere named mcp_setup_smoke_sphere
+with radius 2, list scene objects, and tell me the MCP URL and created object name.
+Use typed tools where available and avoid execute_python unless no typed tool fits.
+```
+
+Expected behavior:
+
+- The agent discovers capabilities without dumping every schema.
+- The agent loads `maya-primitives`.
+- The agent calls `maya_primitives__create_sphere`.
+- The new object appears in the Maya scene.
+- `maya_scene__list_objects` or another scene query confirms it exists.
+
+## Troubleshooting
+
+- `mayapy` not found: ask for the exact Maya version and mayapy path.
+- Pip bootstrap fails: run `mayapy -m ensurepip --upgrade`, then repeat install.
+- MCP connection refused: Maya is not running, the plugin is not loaded, or the
+  host is pointing at `8765` while plugin sidecar mode is on `9765`.
+- Tool missing: call `dcc_capability_manifest` or `search_skills`, then
+  `load_skill("<skill-name>")`.
+- Plugin loaded but hangs: check Script Editor output, firewall/localhost
+  rules, and whether a blocking Maya dialog is open.

--- a/skills/dcc-mcp-maya-setup/scripts/setup_dcc_mcp_maya.py
+++ b/skills/dcc-mcp-maya-setup/scripts/setup_dcc_mcp_maya.py
@@ -1,0 +1,195 @@
+"""Prepare a Maya mayapy environment for dcc-mcp-maya MCP use."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+DEFAULT_GATEWAY_URL = "http://127.0.0.1:9765/mcp"
+DEFAULT_DIRECT_URL = "http://127.0.0.1:8765/mcp"
+
+
+def run(command: list[str], cwd: Optional[Path] = None) -> None:
+    print("+ " + " ".join(command))
+    subprocess.check_call(command, cwd=str(cwd) if cwd else None)
+
+
+def candidate_mayapy_paths() -> Iterable[Path]:
+    env_value = os.environ.get("MAYAPY") or os.environ.get("DCC_MCP_MAYA_MAYAPY")
+    if env_value:
+        yield Path(env_value)
+
+    path_match = shutil.which("mayapy")
+    if path_match:
+        yield Path(path_match)
+
+    if os.name == "nt":
+        program_files = [
+            os.environ.get("ProgramFiles"),
+            os.environ.get("ProgramFiles(x86)"),
+        ]
+        for root in program_files:
+            if not root:
+                continue
+            autodesk = Path(root) / "Autodesk"
+            for year in range(2027, 2019, -1):
+                yield autodesk / ("Maya%s" % year) / "bin" / "mayapy.exe"
+    else:
+        for year in range(2027, 2019, -1):
+            yield Path("/Applications/Autodesk/maya%s/Maya.app/Contents/bin/mayapy" % year)
+            yield Path("/usr/autodesk/maya%s/bin/mayapy" % year)
+
+
+def resolve_mayapy(explicit: Optional[str]) -> Path:
+    if explicit:
+        path = Path(explicit).expanduser()
+        if path.exists():
+            return path
+        raise SystemExit("mayapy does not exist: %s" % path)
+
+    seen = set()
+    for path in candidate_mayapy_paths():
+        expanded = path.expanduser()
+        key = str(expanded).lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        if expanded.exists():
+            return expanded
+
+    raise SystemExit(
+        "Could not find mayapy. Re-run with --mayapy, or set MAYAPY to the full path."
+    )
+
+
+def find_repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for parent in [current] + list(current.parents):
+        if (parent / "pyproject.toml").exists() and (parent / "src" / "dcc_mcp_maya").exists():
+            return parent
+    return Path.cwd()
+
+
+def install_package(mayapy: Path, source: str, repo_root: Path, skip_install: bool) -> None:
+    if skip_install:
+        print("Skipping pip install because --skip-install was passed.")
+        return
+
+    run([str(mayapy), "-m", "ensurepip", "--upgrade"])
+    run(
+        [
+            str(mayapy),
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "pip<25; python_version<'3.8'",
+            "pip; python_version>='3.8'",
+        ]
+    )
+
+    if source == "local":
+        run([str(mayapy), "-m", "pip", "install", "-e", ".[sidecar]"], cwd=repo_root)
+    elif source == "pypi":
+        run([str(mayapy), "-m", "pip", "install", "--upgrade", "dcc-mcp-maya[sidecar]"])
+    else:
+        raise SystemExit("Unknown source: %s" % source)
+
+
+def verify_import(mayapy: Path) -> None:
+    code = (
+        "import dcc_mcp_maya; "
+        "print('dcc-mcp-maya', dcc_mcp_maya.__version__); "
+        "import dcc_mcp_core; "
+        "print('dcc-mcp-core import ok')"
+    )
+    run([str(mayapy), "-c", code])
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print("Wrote %s" % path)
+
+
+def write_mcp_snippets(out_dir: Path, server_name: str, mcp_url: str) -> None:
+    payload = {"mcpServers": {server_name: {"url": mcp_url}}}
+    write_json(out_dir / "mcp-streamable-http.json", payload)
+
+    direct_payload = {"mcpServers": {server_name: {"url": DEFAULT_DIRECT_URL}}}
+    write_json(out_dir / "mcp-direct-8765.json", direct_payload)
+
+    smoke_prompt = """Use the Maya MCP server. First call dcc_capability_manifest with loaded_only=false.
+Then load the maya-primitives skill, create a sphere named mcp_setup_smoke_sphere
+with radius 2, list scene objects, and tell me the MCP URL and created object name.
+Use typed tools where available and avoid execute_python unless no typed tool fits.
+"""
+    smoke_path = out_dir / "smoke-prompt.txt"
+    smoke_path.write_text(smoke_prompt, encoding="utf-8")
+    print("Wrote %s" % smoke_path)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mayapy", help="Full path to Autodesk Maya mayapy.")
+    parser.add_argument(
+        "--source",
+        choices=["local", "pypi"],
+        default="local",
+        help="Install from this checkout or from PyPI. Default: local.",
+    )
+    parser.add_argument(
+        "--mcp-url",
+        default=DEFAULT_GATEWAY_URL,
+        help="MCP URL to write into generated host config. Default: plugin gateway URL.",
+    )
+    parser.add_argument(
+        "--server-name",
+        default="maya",
+        help="MCP server name in generated config. Default: maya.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=".dcc-mcp/agent-setup",
+        help="Directory for generated MCP snippets. Default: .dcc-mcp/agent-setup.",
+    )
+    parser.add_argument(
+        "--skip-install",
+        action="store_true",
+        help="Only verify imports and write MCP snippets.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = find_repo_root()
+    mayapy = resolve_mayapy(args.mayapy)
+    out_dir = (repo_root / args.out_dir).resolve()
+
+    print("Repository: %s" % repo_root)
+    print("mayapy: %s" % mayapy)
+    print("MCP URL: %s" % args.mcp_url)
+
+    install_package(mayapy, args.source, repo_root, args.skip_install)
+    verify_import(mayapy)
+    write_mcp_snippets(out_dir, args.server_name, args.mcp_url)
+
+    print("")
+    print("Next:")
+    print("1. Open Maya.")
+    print("2. Load dcc_mcp_maya_plugin.py in Window > Settings/Preferences > Plug-in Manager.")
+    print("3. Configure the MCP host with %s." % (out_dir / "mcp-streamable-http.json"))
+    print("4. Run the smoke prompt in %s." % (out_dir / "smoke-prompt.txt"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- Add a root `install.md` entry point for agents installing dcc-mcp-maya.
- Add a root `skills/dcc-mcp-maya-setup` operator skill with mayapy setup, MCP config, plugin-loading guidance, and a smoke prompt.
- Link the new install skill from `AGENTS.md`.

## Validation
- `python skills\dcc-mcp-maya-setup\scripts\setup_dcc_mcp_maya.py --help`
- `python -m py_compile skills\dcc-mcp-maya-setup\scripts\setup_dcc_mcp_maya.py`
- `git diff --cached --check`