### PR TITLE
feat: add maya dev assistant skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ## 30-Second Summary
 
-`dcc-mcp-maya` embeds a standards-compliant MCP Streamable HTTP server directly inside Autodesk Maya. It exposes 164 Maya operations as MCP tools that any AI agent (Claude, Cursor, Gemini, etc.) can call over HTTP — no external gateway, no subprocess bridge.
+`dcc-mcp-maya` embeds a standards-compliant MCP Streamable HTTP server directly inside Autodesk Maya. It exposes 172 Maya operations as MCP tools that any AI agent (Claude, Cursor, Gemini, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
 **Current version:** 0.3.6 <!-- x-release-please-version -->
 **Core dependency:** `dcc-mcp-core>=0.15.9,<1.0.0`
@@ -108,7 +108,7 @@ is checked against disk by tests so the human-readable inventory cannot drift.
 | `scene`       | Scene file lifecycle, DAG, attributes, node graph, viewport display. | partial (`maya-scene` only) | `maya-scene`, `maya-scene-assembly`, `maya-display`, `maya-attributes`, `maya-node-graph` |
 | `authoring`   | Create / edit content (mesh, UV, mat, rig, anim, light).             | no                        | `maya-primitives`, `maya-mesh-ops`, `maya-uv-ops`, `maya-materials`, `maya-material-library`, `maya-texture-bake`, `maya-rigging`, `maya-animation`, `maya-pose-library`, `maya-expressions`, `maya-light-rig` |
 | `interchange` | Geometry / scene I/O across DCCs (FBX, OBJ, presets, save).          | no                        | `maya-geometry`, `maya-export-preset` |
-| `pipeline`    | Production: project, publish, shot export, render, render farm.       | no                        | `maya-pipeline`, `maya-shot-export`, `maya-render`, `maya-render-farm` |
+| `pipeline`    | Production: project, publish, shot export, render, render farm, development diagnostics. | no                        | `maya-dev`, `maya-pipeline`, `maya-shot-export`, `maya-render`, `maya-render-farm` |
 
 Helpers in `_skill_loader.py`:
 
@@ -408,7 +408,7 @@ A: Poll `check_maya_cancelled()` inside the loop. It raises `CancelledError` whe
 A: Same API — `dcc_mcp_maya.start_server(port=0)`. In batch mode the `MayaStandaloneDispatcher` runs jobs on the calling thread directly.
 
 **Q: Where are the built-in skills?**  
-A: `src/dcc_mcp_maya/skills/` (23 packages, 161 scripts, 164 tool declarations). Each package contains `SKILL.md`, `tools.yaml`, optional `groups.yaml`, and `scripts/*.py`.
+A: `src/dcc_mcp_maya/skills/` (24 packages, 169 scripts, 172 tool declarations). Each package contains `SKILL.md`, `tools.yaml`, optional `groups.yaml`, and `scripts/*.py`.
 
 **Q: How do I force agents to stop using ``execute_python``?**  
 A: Set ``DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON=1`` (Python only) or ``DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT=1`` (Python + MEL). Callers get a structured error that points to ``load_skill`` + typed tools.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Maya plugin starts a Rust `dcc-mcp-server` sidecar by default, so HTTP and g
 
 | What you get | Why it matters |
 |---|---|
-| **164 typed Maya tools** across 23 bundled skill packages | Agents can call validated tools for scene, mesh, material, animation, render, export, and pipeline work. |
+| **172 typed Maya tools** across 24 bundled skill packages | Agents can call validated tools for scene, mesh, material, animation, render, export, pipeline work, and live tool-development diagnostics. |
 | **Progressive loading** | Maya boots with a compact tool surface; agents discover unloaded capabilities and load only what they need. |
 | **Sidecar isolation by default** | HTTP/gateway runtime is out of Maya's UI thread, with a Qt dispatcher bridge back into Maya. |
 | **Multi-instance gateway** | Run several Maya sessions behind one local MCP URL, with optional LAN gateway exposure. |
@@ -122,7 +122,7 @@ Default startup is intentionally small: `maya-scripting` and the core `maya-scen
 | `scene` | Scene lifecycle, DAG, attributes, node graph, viewport display | `maya-scene`, `maya-scene-assembly`, `maya-display`, `maya-attributes`, `maya-node-graph` |
 | `authoring` | Meshes, UVs, materials, rigs, animation, expressions, lighting | `maya-primitives`, `maya-mesh-ops`, `maya-uv-ops`, `maya-materials`, `maya-material-library`, `maya-texture-bake`, `maya-rigging`, `maya-animation`, `maya-pose-library`, `maya-expressions`, `maya-light-rig` |
 | `interchange` | Geometry and scene I/O | `maya-geometry`, `maya-export-preset` |
-| `pipeline` | Project, publish, shot export, render, render farm | `maya-pipeline`, `maya-shot-export`, `maya-render`, `maya-render-farm` |
+| `pipeline` | Project, publish, shot export, render, render farm, development diagnostics | `maya-dev`, `maya-pipeline`, `maya-shot-export`, `maya-render`, `maya-render-farm` |
 
 Typical agent flow:
 
@@ -149,6 +149,7 @@ See [`src/dcc_mcp_maya/skills/SKILLS_INDEX.md`](src/dcc_mcp_maya/skills/SKILLS_I
 | Shutdown hardening | Maya exiting hook, `atexit`, process sentinel, and optional defensive finalizer reduce stale registry rows. |
 | Safe sessions | MCP-dispatched Maya jobs suppress blocking modal dialogs and snooze AutoSave unless opted out. |
 | Metrics | Optional Prometheus `/metrics` endpoint via `DCC_MCP_MAYA_METRICS=1`. |
+| Dev workflow | `maya-dev` can attach a local Python tool project, hot-reload modules, run entrypoints/scripts, start debugpy, and capture Maya UI evidence. |
 
 ## Installation
 
@@ -219,6 +220,7 @@ Useful plugin defaults:
 | `DCC_MCP_MAYA_JOB_STORAGE` | `<data_dir>/jobs.db` | SQLite job persistence path; set `""` to disable. |
 | `DCC_MCP_MAYA_JOB_RECOVERY` | `drop` | `requeue` resumes idempotent interrupted jobs. |
 | `DCC_MCP_MAYA_HOT_RELOAD` | `0` | `1` watches skills for disk changes. |
+| `DCC_MCP_MAYA_DEV_ROOTS` | none | Optional path-list of trusted roots that `maya-dev` projects must live under. |
 | `DCC_MCP_MAYA_FAULTHANDLER` | `1` | `0` disables fatal-signal traceback logging from the Maya plugin. |
 | `DCC_MCP_MAYA_SUPPRESS_CRASH_REPORTER` | `0` | `1` suppresses Maya crash reporter dialogs during unattended startup. |
 | `DCC_MCP_MAYA_DISABLE_AUTOSAVE` | `1` | `0` opts out of the plugin's AutoSave suppression during MCP jobs. |

--- a/docs/assets/readme-architecture.svg
+++ b/docs/assets/readme-architecture.svg
@@ -68,7 +68,7 @@
 
   <rect x="412" y="434" width="256" height="98" class="soft"/>
   <text x="436" y="464" class="label">Progressive skills</text>
-  <text x="436" y="490" class="small">23 skill packages, 164 tools</text>
+  <text x="436" y="490" class="small">24 skill packages, 172 tools</text>
   <text x="436" y="512" class="small">minimal boot, load on demand</text>
 
   <rect x="716" y="434" width="230" height="98" class="soft"/>

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -65,7 +65,7 @@ Actions follow the convention:
 
 ### Progressive Loading
 
-The package ships 23 Maya skill packages. Minimal mode loads only the core
+The package ships 24 Maya skill packages. Minimal mode loads only the core
 bootstrap and scene tools, while unloaded skills remain discoverable through
 `dcc_capability_manifest`, `search_skills`, or `search_tools`.
 

--- a/docs/guide/mcp-tools.md
+++ b/docs/guide/mcp-tools.md
@@ -4,7 +4,7 @@ This guide is for users who want to control Maya using natural language through 
 
 ## How It Works
 
-Once the `dcc-mcp-maya` server is running inside Maya, your AI assistant can discover **23 Maya skill packages** and load **160+ typed Maya tools** on demand. Just describe what you want in plain English; the assistant should search capabilities, load the matching skill, then call the typed tool.
+Once the `dcc-mcp-maya` server is running inside Maya, your AI assistant can discover **24 Maya skill packages** and load **170+ typed Maya tools** on demand. Just describe what you want in plain English; the assistant should search capabilities, load the matching skill, then call the typed tool.
 
 Default startup is intentionally small. If a tool appears missing, ask the assistant to call `dcc_capability_manifest` or `search_skills`, then `load_skill("<skill-name>")`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,8 @@ features:
     title: MCP Protocol Native
     details: Implements the 2025-03-26 MCP Streamable HTTP spec — compatible with Claude Desktop, Cursor, OpenClaw and any MCP host.
   - icon: 🎬
-    title: 160+ Typed Maya Tools
-    details: 23 Maya skill packages covering scene management, geometry, materials, animation, light rigs, rendering, rigging, UV operations, interchange and pipeline workflows.
+    title: 170+ Typed Maya Tools
+    details: 24 Maya skill packages covering scene management, geometry, materials, animation, light rigs, rendering, rigging, UV operations, interchange, pipeline workflows, and live development diagnostics.
   - icon: 📸
     title: Viewport Capture
     details: Capture any Maya viewport as a base64-encoded PNG with a single MCP call. Perfect for AI visual feedback loops.

--- a/docs/zh/guide/index.md
+++ b/docs/zh/guide/index.md
@@ -63,7 +63,7 @@ maya-scene/
 
 ### 渐进式加载
 
-本包内置 23 个 Maya Skill 包。Minimal mode 启动时只加载核心 bootstrap 与 scene 工具；未加载的 Skill 仍可通过 `dcc_capability_manifest`、`search_skills` 或 `search_tools` 发现。
+本包内置 24 个 Maya Skill 包。Minimal mode 启动时只加载核心 bootstrap 与 scene 工具；未加载的 Skill 仍可通过 `dcc_capability_manifest`、`search_skills` 或 `search_tools` 发现。
 
 只有任务需要某个领域能力时再加载对应 Skill：
 

--- a/docs/zh/guide/mcp-tools.md
+++ b/docs/zh/guide/mcp-tools.md
@@ -4,7 +4,7 @@
 
 ## 工作原理
 
-`dcc-mcp-maya` 服务器在 Maya 内运行后，你的 AI 助手可以发现 **23 个 Maya Skill 包**，并按需加载 **160+ 个 typed Maya 工具**。只需用普通话描述你的需求即可；助手应先搜索能力、加载匹配 Skill，再调用带 schema 的 typed tool。
+`dcc-mcp-maya` 服务器在 Maya 内运行后，你的 AI 助手可以发现 **24 个 Maya Skill 包**，并按需加载 **170+ 个 typed Maya 工具**。只需用普通话描述你的需求即可；助手应先搜索能力、加载匹配 Skill，再调用带 schema 的 typed tool。
 
 默认启动工具面很小。如果某个工具看起来不存在，请让助手先调用 `dcc_capability_manifest` 或 `search_skills`，再调用 `load_skill("<skill-name>")`。
 

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -21,8 +21,8 @@ features:
     title: 原生 MCP 协议
     details: 实现 2025-03-26 版 MCP Streamable HTTP 规范，兼容 Claude Desktop、Cursor、OpenClaw 及任意 MCP 宿主。
   - icon: 🎬
-    title: 160+ Typed Maya 工具
-    details: 内置 23 个 Maya Skill 包，覆盖场景管理、几何体、材质、动画、灯光绑定、渲染、绑定、UV、交换与管线工作流。
+    title: 170+ Typed Maya 工具
+    details: 内置 24 个 Maya Skill 包，覆盖场景管理、几何体、材质、动画、灯光绑定、渲染、绑定、UV、交换、管线工作流与实时开发诊断。
   - icon: 📸
     title: 视口截图
     details: 一次 MCP 调用即可将任意 Maya 视口捕获为 base64 编码的 PNG 图像，完美支持 AI 视觉反馈循环。

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -419,12 +419,13 @@ tools:
 
 ---
 
-## Built-in Skills (12 Packages)
+## Built-in Skills (24 Packages)
 
 **Core pipeline skills:**
 - `maya-scene` — scene info, new scene, open/save scene, selection, session info
 - `maya-scripting` — execute_python, execute_mel
 - `maya-export-preset` — export preset management
+- `maya-dev` — live project attach, hot reload, debugpy, and UI capture for tool development
 - `maya-light-rig` — lighting rig creation and management
 - `maya-material-library` — material library and assignment
 - `maya-pipeline` — pipeline integration utilities
@@ -445,6 +446,7 @@ tools:
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | per-process | Name in MCP `initialize`. |
 | `DCC_MCP_MAYA_SKILL_PATHS` | — | per-process | Extra skill dirs (`;` Win, `:` Unix). |
 | `DCC_MCP_SKILL_PATHS` | — | global fallback | Global skill dirs for all DCC adapters. |
+| `DCC_MCP_MAYA_DEV_ROOTS` | — | per-process | Optional path-list of trusted roots for `maya-dev` project attachment. |
 | `DCC_MCP_MINIMAL` | `1` | per-process | `0`=full mode; `1`=minimal mode. |
 | `DCC_MCP_DEFAULT_TOOLS` | — | per-process | Comma-separated skill names overriding minimal mode. |
 | `DCC_MCP_MAYA_METRICS` | `0` | per-process | `1`=enable Prometheus `/metrics`. |
@@ -537,7 +539,7 @@ legacy `list_dcc_instances` / `connect_to_dcc` meta-tools.
 | `src/dcc_mcp_maya/dispatcher/` | Thread-affinity dispatchers + cancellation (directory module) |
 | `src/dcc_mcp_maya/api.py` | 18 skill-authoring helpers |
 | `src/dcc_mcp_maya/capabilities.py` | DCC capability declarations |
-| `src/dcc_mcp_maya/skills/` | 23 built-in skill packages, 160+ typed tool declarations |
+| `src/dcc_mcp_maya/skills/` | 24 built-in skill packages, 172 typed tool declarations |
 | `docs/` | VitePress site (EN + ZH) |
 | `tests/` | pytest suite |
 | `maya/plugin/dcc_mcp_maya_plugin.py` | Maya plugin file for `MAYA_PLUG_IN_PATH` |

--- a/llms.txt
+++ b/llms.txt
@@ -192,6 +192,7 @@ Tool naming: `{skill_name.replace("-","_")}__{script_stem}` (e.g. `maya_scene__n
 | `DCC_MCP_GATEWAY_NAME` | `dcc-mcp-gateway@<hostname>` | Human-readable standalone gateway label |
 | `DCC_MCP_REGISTRY_DIR` | OS temp | Shared discovery registry |
 | `DCC_MCP_MAYA_HOT_RELOAD` | `0` | `1`=watch skills for disk changes |
+| `DCC_MCP_MAYA_DEV_ROOTS` | — | Optional path-list of trusted roots for `maya-dev` project attachment |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | `1`/`true`/`yes`/`on` — refuse `execute_python` (skills-first enforcement) |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_MEL` | `0` | Same tokens — refuse `execute_mel` only |
 | `DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT` | `0` | Same tokens — refuse **both** `execute_python` and `execute_mel` |
@@ -206,7 +207,7 @@ Tool naming: `{skill_name.replace("-","_")}__{script_stem}` (e.g. `maya_scene__n
 | `src/dcc_mcp_maya/dispatcher/` | Thread-affinity dispatchers + cancellation (directory module) |
 | `src/dcc_mcp_maya/api.py` | Skill authoring helpers (18 symbols) |
 | `src/dcc_mcp_maya/plugin.py` | Maya plugin entry point |
-| `src/dcc_mcp_maya/skills/` | 23 built-in skill packages (160+ typed tool declarations) |
+| `src/dcc_mcp_maya/skills/` | 24 built-in skill packages (172 typed tool declarations) |
 | `docs/` | VitePress docs (EN + ZH) |
 | `README.md` | Human overview |
 | `AGENTS.md` | Progressive disclosure map |

--- a/src/dcc_mcp_maya/_dev_session.py
+++ b/src/dcc_mcp_maya/_dev_session.py
@@ -1,0 +1,796 @@
+"""Development-session helpers for MCP-assisted Maya tool authoring.
+
+The ``maya-dev`` skill exposes these helpers as typed tools.  Keeping the
+state in a package module (rather than in individual skill scripts) makes the
+session survive core's per-call script loading model.
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import importlib
+import io
+import json
+import os
+import runpy
+import sys
+import tempfile
+import threading
+import time
+import traceback
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+ENV_DEV_ROOTS = "DCC_MCP_MAYA_DEV_ROOTS"
+
+_LOCK = threading.RLock()
+_DEBUGPY_STATE: Dict[str, Any] = {
+    "listening": False,
+    "host": None,
+    "port": None,
+}
+
+
+@dataclass
+class DevProject:
+    """A project root attached to the live Maya Python session."""
+
+    name: str
+    root: str
+    package_prefixes: Tuple[str, ...] = ()
+    sys_path_entries: Tuple[str, ...] = ()
+    attached_at: float = field(default_factory=time.time)
+
+    def to_context(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "root": self.root,
+            "package_prefixes": list(self.package_prefixes),
+            "sys_path_entries": list(self.sys_path_entries),
+            "attached_at": self.attached_at,
+        }
+
+
+_STATE: Dict[str, Any] = {
+    "active": None,
+    "projects": {},
+}
+
+
+def _as_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw = value.replace("\n", ",")
+        return [part.strip() for part in raw.split(",") if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return [str(part).strip() for part in value if str(part).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _norm(path: str) -> str:
+    return os.path.normcase(os.path.realpath(os.path.abspath(os.path.expanduser(path))))
+
+
+def _display_path(path: str) -> str:
+    return os.path.abspath(os.path.expanduser(path))
+
+
+def _split_env_paths(raw: str) -> List[str]:
+    if not raw:
+        return []
+    paths: List[str] = []
+    for part in raw.split(os.pathsep):
+        part = part.strip().strip('"')
+        if part:
+            paths.append(part)
+    return paths
+
+
+def _is_under(child: str, parent: str) -> bool:
+    try:
+        return os.path.commonpath([_norm(child), _norm(parent)]) == _norm(parent)
+    except (OSError, ValueError):
+        return False
+
+
+def _allowed_roots() -> List[str]:
+    return [_display_path(path) for path in _split_env_paths(os.environ.get(ENV_DEV_ROOTS, ""))]
+
+
+def _validate_allowed_root(root: str) -> Optional[Dict[str, Any]]:
+    roots = _allowed_roots()
+    if not roots:
+        return None
+    if any(_is_under(root, allowed) for allowed in roots):
+        return None
+    return skill_error(
+        "Project root is outside allowed development roots",
+        "{} is set; attach a project below one of those roots.".format(ENV_DEV_ROOTS),
+        possible_solutions=[
+            "Choose a project under an allowed development root.",
+            "Update {} before starting Maya if this root should be trusted.".format(ENV_DEV_ROOTS),
+        ],
+        env_var=ENV_DEV_ROOTS,
+        allowed_root_count=len(roots),
+    )
+
+
+def _normalize_prefixes(prefixes: Any) -> Tuple[str, ...]:
+    cleaned: List[str] = []
+    for raw in _as_list(prefixes):
+        value = raw.strip()
+        if not value:
+            continue
+        # Dotted package prefixes only.  A bad prefix is more likely to purge
+        # too much than to help, so silently ignore obviously invalid values.
+        parts = value.split(".")
+        if all(part.isidentifier() for part in parts):
+            cleaned.append(value)
+    return tuple(dict.fromkeys(cleaned))
+
+
+def _project_name_from_root(root: str) -> str:
+    name = os.path.basename(os.path.normpath(root)) or "maya-dev-project"
+    return "".join(ch if ch.isalnum() or ch in ("-", "_") else "-" for ch in name)
+
+
+def _get_project(project_name: Optional[str] = None) -> Tuple[Optional[DevProject], Optional[Dict[str, Any]]]:
+    with _LOCK:
+        name = project_name or _STATE.get("active")
+        projects = _STATE.get("projects") or {}
+        if not name:
+            return None, skill_error(
+                "No development project is attached",
+                "Call maya_dev__attach_project before running project code.",
+                possible_solutions=["Attach a project root first."],
+            )
+        project = projects.get(name)
+        if project is None:
+            return None, skill_error(
+                "Development project not found",
+                "No attached project named {!r}.".format(name),
+                attached_projects=sorted(projects.keys()),
+            )
+        return project, None
+
+
+def _prepend_sys_path(entries: Iterable[str]) -> List[str]:
+    added: List[str] = []
+    for entry in reversed([_display_path(e) for e in entries if e]):
+        if entry not in sys.path:
+            sys.path.insert(0, entry)
+            added.append(entry)
+    added.reverse()
+    return added
+
+
+def attach_project(
+    project_root: str,
+    name: Optional[str] = None,
+    package_prefixes: Any = None,
+    include_src: bool = True,
+    make_active: bool = True,
+) -> Dict[str, Any]:
+    """Attach a Python tool project to the live Maya session."""
+
+    if not project_root:
+        return skill_error("No project root provided", "Pass project_root as an absolute path.")
+
+    root = _display_path(project_root)
+    if not os.path.isdir(root):
+        return skill_error(
+            "Project root not found",
+            "The supplied project_root does not exist or is not a directory.",
+            project_root=root,
+        )
+
+    denied = _validate_allowed_root(root)
+    if denied is not None:
+        return denied
+
+    sys_path_entries = [root]
+    src_root = os.path.join(root, "src")
+    if include_src and os.path.isdir(src_root):
+        sys_path_entries.append(src_root)
+
+    added = _prepend_sys_path(sys_path_entries)
+    project_name = str(name or _project_name_from_root(root)).strip() or _project_name_from_root(root)
+    prefixes = _normalize_prefixes(package_prefixes)
+    project = DevProject(
+        name=project_name,
+        root=root,
+        package_prefixes=prefixes,
+        sys_path_entries=tuple(sys_path_entries),
+    )
+
+    with _LOCK:
+        _STATE["projects"][project_name] = project
+        if make_active:
+            _STATE["active"] = project_name
+
+    return skill_success(
+        "Development project attached: {}".format(project_name),
+        prompt="Use reload_modules then run_entrypoint or run_check to execute project code inside Maya.",
+        project=project.to_context(),
+        active_project=_STATE.get("active"),
+        added_sys_path=added,
+        reused_sys_path=[entry for entry in sys_path_entries if entry not in added],
+    )
+
+
+def _module_file(module: Any) -> Optional[str]:
+    path = getattr(module, "__file__", None)
+    if not path:
+        return None
+    try:
+        return _display_path(path)
+    except Exception:
+        return None
+
+
+def _matches_module(name: str, module: Any, project: DevProject, prefixes: Tuple[str, ...]) -> bool:
+    if name == "__main__" or name.startswith("_maya_skill_script"):
+        return False
+
+    module_path = _module_file(module)
+    under_root = bool(module_path and _is_under(module_path, project.root))
+    if prefixes:
+        prefix_match = any(name == prefix or name.startswith(prefix + ".") for prefix in prefixes)
+        return bool(prefix_match and (under_root or module_path is None))
+    return under_root
+
+
+def _bounded(items: Sequence[str], limit: int = 200) -> Tuple[List[str], int]:
+    shown = list(items[:limit])
+    return shown, max(0, len(items) - len(shown))
+
+
+def reload_modules(
+    project_name: Optional[str] = None,
+    package_prefixes: Any = None,
+    mode: str = "purge",
+) -> Dict[str, Any]:
+    """Reload or purge modules that belong to an attached project."""
+
+    project, error = _get_project(project_name)
+    if error is not None:
+        return error
+    assert project is not None
+
+    mode = (mode or "purge").strip().lower()
+    if mode not in {"purge", "reload"}:
+        return skill_error("Invalid reload mode", "mode must be 'purge' or 'reload'.", mode=mode)
+
+    prefixes = _normalize_prefixes(package_prefixes) or project.package_prefixes
+    matches = [
+        name
+        for name, module in list(sys.modules.items())
+        if _matches_module(name, module, project, prefixes)
+    ]
+    matches = sorted(set(matches), key=lambda item: (item.count("."), item))
+    errors: List[Dict[str, str]] = []
+    changed: List[str] = []
+
+    if mode == "purge":
+        for name in sorted(matches, key=lambda item: (item.count("."), item), reverse=True):
+            sys.modules.pop(name, None)
+            changed.append(name)
+    else:
+        for name in matches:
+            module = sys.modules.get(name)
+            if module is None:
+                continue
+            try:
+                importlib.reload(module)
+                changed.append(name)
+            except Exception as exc:  # noqa: BLE001
+                errors.append({"module": name, "error": repr(exc)})
+
+    shown, omitted = _bounded(changed)
+    return skill_success(
+        "Project modules {}ed: {}".format(mode, len(changed)),
+        project=project.to_context(),
+        mode=mode,
+        package_prefixes=list(prefixes),
+        module_count=len(changed),
+        modules=shown,
+        omitted_module_count=omitted,
+        errors=errors,
+    )
+
+
+def _parse_target(target: Optional[str], module: Optional[str], callable_name: Optional[str]) -> Tuple[str, str]:
+    if target:
+        raw = str(target).strip()
+        if ":" in raw:
+            mod_name, attr = raw.split(":", 1)
+            return mod_name.strip(), attr.strip() or "main"
+        return raw, str(callable_name or "main").strip()
+    return str(module or "").strip(), str(callable_name or "main").strip()
+
+
+def _resolve_callable(module_name: str, callable_name: str) -> Tuple[Optional[Any], Optional[Dict[str, Any]]]:
+    if not module_name:
+        return None, skill_error("No module provided", "Pass target='package.module:function' or module='package.module'.")
+    if not callable_name:
+        callable_name = "main"
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:  # noqa: BLE001
+        return None, skill_exception(exc, message="Failed to import module {}".format(module_name))
+
+    obj: Any = module
+    for part in callable_name.split("."):
+        if not part:
+            continue
+        try:
+            obj = getattr(obj, part)
+        except AttributeError:
+            return None, skill_error(
+                "Callable not found",
+                "{} has no attribute path {!r}.".format(module_name, callable_name),
+                module=module_name,
+                callable=callable_name,
+            )
+    if not callable(obj):
+        return None, skill_error(
+            "Resolved object is not callable",
+            "{}:{} is not callable.".format(module_name, callable_name),
+            module=module_name,
+            callable=callable_name,
+        )
+    return obj, None
+
+
+def _jsonable(value: Any) -> bool:
+    try:
+        json.dumps(value)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def _result_context(value: Any) -> Dict[str, Any]:
+    ctx = {
+        "return_type": type(value).__name__,
+        "return_repr": repr(value),
+    }
+    if _jsonable(value):
+        ctx["return_value"] = value
+    return ctx
+
+
+@contextlib.contextmanager
+def _maybe_chdir(path: Optional[str]):
+    if not path:
+        yield
+        return
+    old = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
+
+def _run_callable(
+    fn: Any,
+    args: Any = None,
+    kwargs: Any = None,
+    capture_output: bool = True,
+    cwd: Optional[str] = None,
+) -> Dict[str, Any]:
+    call_args = args if isinstance(args, (list, tuple)) else []
+    call_kwargs = kwargs if isinstance(kwargs, dict) else {}
+    stdout_buf = io.StringIO()
+    stderr_buf = io.StringIO()
+
+    started = time.time()
+    try:
+        with _maybe_chdir(cwd):
+            if capture_output:
+                with contextlib.redirect_stdout(stdout_buf), contextlib.redirect_stderr(stderr_buf):
+                    value = fn(*call_args, **call_kwargs)
+            else:
+                value = fn(*call_args, **call_kwargs)
+        elapsed = time.time() - started
+        ctx = _result_context(value)
+        ctx.update(
+            {
+                "stdout": stdout_buf.getvalue() if capture_output else "",
+                "stderr": stderr_buf.getvalue() if capture_output else "",
+                "elapsed_secs": elapsed,
+            }
+        )
+        return skill_success("Entrypoint executed", **ctx)
+    except Exception as exc:  # noqa: BLE001
+        elapsed = time.time() - started
+        return skill_error(
+            "Entrypoint execution failed",
+            repr(exc),
+            traceback=traceback.format_exc(),
+            stdout=stdout_buf.getvalue() if capture_output else "",
+            stderr=stderr_buf.getvalue() if capture_output else "",
+            elapsed_secs=elapsed,
+        )
+
+
+def run_entrypoint(
+    target: Optional[str] = None,
+    module: Optional[str] = None,
+    callable: Optional[str] = None,  # noqa: A002 - public tool parameter
+    args: Any = None,
+    kwargs: Any = None,
+    project_name: Optional[str] = None,
+    reload_before: bool = True,
+    reload_mode: str = "purge",
+    capture_output: bool = True,
+    chdir_project: bool = True,
+) -> Dict[str, Any]:
+    """Run a Python callable from an attached project inside Maya."""
+
+    project, error = _get_project(project_name)
+    if error is not None:
+        return error
+    assert project is not None
+
+    reload_context: Optional[Dict[str, Any]] = None
+    if reload_before:
+        reload_result = reload_modules(project.name, mode=reload_mode)
+        reload_context = reload_result.get("context", reload_result)
+
+    module_name, callable_name = _parse_target(target, module, callable)
+    fn, resolve_error = _resolve_callable(module_name, callable_name)
+    if resolve_error is not None:
+        if reload_context is not None:
+            resolve_error.setdefault("context", {})["reload"] = reload_context
+        return resolve_error
+    assert fn is not None
+
+    result = _run_callable(
+        fn,
+        args=args,
+        kwargs=kwargs,
+        capture_output=bool(capture_output),
+        cwd=project.root if chdir_project else None,
+    )
+    ctx = result.setdefault("context", {})
+    ctx.update(
+        {
+            "project": project.to_context(),
+            "target": "{}:{}".format(module_name, callable_name),
+        }
+    )
+    if reload_context is not None:
+        ctx["reload"] = reload_context
+    return result
+
+
+def _resolve_script_path(script_path: str, project: DevProject) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    if not script_path:
+        return None, skill_error("No script path provided", "Pass script_path as a project-relative or absolute .py path.")
+    path = script_path
+    if not os.path.isabs(path):
+        path = os.path.join(project.root, path)
+    path = _display_path(path)
+    if not os.path.isfile(path):
+        return None, skill_error("Script not found", "The supplied script_path does not exist.", script_path=path)
+    if not path.lower().endswith(".py"):
+        return None, skill_error("Unsupported script type", "Only .py scripts are supported.", script_path=path)
+    if not _is_under(path, project.root):
+        return None, skill_error(
+            "Script is outside the attached project",
+            "run_script only executes files below the attached development root.",
+            script_path=path,
+            project_root=project.root,
+        )
+    return path, None
+
+
+def run_script(
+    script_path: str,
+    argv: Any = None,
+    project_name: Optional[str] = None,
+    reload_before: bool = True,
+    reload_mode: str = "purge",
+    capture_output: bool = True,
+    chdir_project: bool = True,
+) -> Dict[str, Any]:
+    """Run a Python script file below the attached project root."""
+
+    project, error = _get_project(project_name)
+    if error is not None:
+        return error
+    assert project is not None
+
+    resolved, path_error = _resolve_script_path(script_path, project)
+    if path_error is not None:
+        return path_error
+    assert resolved is not None
+
+    reload_context: Optional[Dict[str, Any]] = None
+    if reload_before:
+        reload_result = reload_modules(project.name, mode=reload_mode)
+        reload_context = reload_result.get("context", reload_result)
+
+    script_argv = _as_list(argv)
+    old_argv = sys.argv[:]
+    stdout_buf = io.StringIO()
+    stderr_buf = io.StringIO()
+    started = time.time()
+    try:
+        sys.argv = [resolved] + script_argv
+        with _maybe_chdir(project.root if chdir_project else None):
+            if capture_output:
+                with contextlib.redirect_stdout(stdout_buf), contextlib.redirect_stderr(stderr_buf):
+                    globals_after = runpy.run_path(resolved, run_name="__main__")
+            else:
+                globals_after = runpy.run_path(resolved, run_name="__main__")
+        elapsed = time.time() - started
+        ctx = {
+            "project": project.to_context(),
+            "script_path": resolved,
+            "argv": script_argv,
+            "stdout": stdout_buf.getvalue() if capture_output else "",
+            "stderr": stderr_buf.getvalue() if capture_output else "",
+            "elapsed_secs": elapsed,
+            "global_names": sorted(k for k in globals_after if not k.startswith("__"))[:200],
+        }
+        if reload_context is not None:
+            ctx["reload"] = reload_context
+        return skill_success("Script executed", **ctx)
+    except Exception as exc:  # noqa: BLE001
+        elapsed = time.time() - started
+        return skill_error(
+            "Script execution failed",
+            repr(exc),
+            traceback=traceback.format_exc(),
+            stdout=stdout_buf.getvalue() if capture_output else "",
+            stderr=stderr_buf.getvalue() if capture_output else "",
+            elapsed_secs=elapsed,
+            script_path=resolved,
+            project=project.to_context(),
+            reload=reload_context,
+        )
+    finally:
+        sys.argv = old_argv
+
+
+def start_debugpy(host: str = "127.0.0.1", port: int = 5678, wait_for_client: bool = False) -> Dict[str, Any]:
+    """Start debugpy in the Maya process so an IDE can attach."""
+
+    host = str(host or "127.0.0.1")
+    port = int(port or 5678)
+    with _LOCK:
+        if _DEBUGPY_STATE.get("listening"):
+            return _debugpy_status("debugpy is already listening", reused=True)
+
+    try:
+        import debugpy  # noqa: PLC0415
+    except ImportError:
+        return skill_error(
+            "debugpy is not installed in this Maya Python environment",
+            "Install debugpy into the Python interpreter used by Maya.",
+            possible_solutions=[
+                "Run mayapy -m pip install debugpy for the Maya version you are debugging.",
+                "Restart Maya after installing debugpy, then call start_debugpy again.",
+            ],
+        )
+
+    try:
+        debugpy.listen((host, port))
+        if wait_for_client:
+            debugpy.wait_for_client()
+        connected = bool(getattr(debugpy, "is_client_connected", lambda: False)())
+    except RuntimeError as exc:
+        message = str(exc).lower()
+        if "already" not in message:
+            return skill_exception(exc, message="Failed to start debugpy")
+        connected = bool(getattr(debugpy, "is_client_connected", lambda: False)())
+
+    with _LOCK:
+        _DEBUGPY_STATE.update({"listening": True, "host": host, "port": port})
+
+    return skill_success(
+        "debugpy listening on {}:{}".format(host, port),
+        host=host,
+        port=port,
+        client_connected=connected,
+        wait_for_client=bool(wait_for_client),
+    )
+
+
+def _debugpy_status(message: str = "debugpy status", reused: bool = False) -> Dict[str, Any]:
+    try:
+        import debugpy  # noqa: PLC0415
+
+        connected = bool(getattr(debugpy, "is_client_connected", lambda: False)())
+    except ImportError:
+        connected = False
+    return skill_success(
+        message,
+        listening=bool(_DEBUGPY_STATE.get("listening")),
+        host=_DEBUGPY_STATE.get("host"),
+        port=_DEBUGPY_STATE.get("port"),
+        client_connected=connected,
+        reused=bool(reused),
+    )
+
+
+def _qt_modules() -> Tuple[Optional[Any], Optional[Any], Optional[Any], Optional[str]]:
+    candidates = (
+        ("PySide6", "shiboken6"),
+        ("PySide2", "shiboken2"),
+        ("PySide", "shiboken"),
+    )
+    for qt_name, shiboken_name in candidates:
+        try:
+            qt_widgets = importlib.import_module(qt_name + ".QtWidgets")
+            qt_core = importlib.import_module(qt_name + ".QtCore")
+            shiboken = importlib.import_module(shiboken_name)
+            return qt_widgets, qt_core, shiboken, qt_name
+        except ImportError:
+            continue
+    return None, None, None, None
+
+
+def _maya_main_window() -> Tuple[Optional[Any], Optional[Any], Optional[Dict[str, Any]]]:
+    qt_widgets, _qt_core, shiboken, qt_name = _qt_modules()
+    if qt_widgets is None or shiboken is None:
+        return None, None, skill_error(
+            "Qt bindings are not available",
+            "Maya UI capture requires PySide/PySide2/PySide6 and shiboken.",
+        )
+    try:
+        import maya.OpenMayaUI as omui  # noqa: PLC0415
+
+        ptr = omui.MQtUtil.mainWindow()
+    except Exception as exc:  # noqa: BLE001
+        return None, None, skill_exception(exc, message="Failed to resolve Maya main window")
+    if not ptr:
+        return None, None, skill_error("Maya main window is unavailable", "UI capture only works in Maya GUI mode.")
+    try:
+        widget = shiboken.wrapInstance(int(ptr), qt_widgets.QWidget)
+    except Exception as exc:  # noqa: BLE001
+        return None, None, skill_exception(exc, message="Failed to wrap Maya main window ({})".format(qt_name))
+    return widget, qt_widgets.QWidget, None
+
+
+def _find_widget(root: Any, widget_type: Any, object_name: Optional[str]) -> Any:
+    if not object_name:
+        return root
+    if str(root.objectName()) == object_name:
+        return root
+    found = root.findChild(widget_type, object_name)
+    if found is not None:
+        return found
+    for child in root.findChildren(widget_type):
+        try:
+            if str(child.objectName()) == object_name or str(child.windowTitle()) == object_name:
+                return child
+        except Exception:
+            continue
+    return None
+
+
+def capture_ui(object_name: Optional[str] = None) -> Dict[str, Any]:
+    """Capture the Maya main window or a named Qt widget as base64 PNG."""
+
+    root, widget_type, error = _maya_main_window()
+    if error is not None:
+        return error
+    assert root is not None
+    assert widget_type is not None
+
+    widget = _find_widget(root, widget_type, object_name)
+    if widget is None:
+        return skill_error(
+            "Qt widget not found",
+            "No Maya widget matched object_name={!r}.".format(object_name),
+            object_name=object_name,
+        )
+
+    tmp_path: Optional[str] = None
+    try:
+        pixmap = widget.grab()
+        if pixmap.isNull():
+            return skill_error(
+                "UI capture produced an empty image",
+                "Qt returned a null pixmap for the requested widget.",
+                object_name=object_name,
+            )
+        fd, tmp_path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        if not pixmap.save(tmp_path, "PNG"):
+            return skill_error("UI capture failed", "Qt could not save the grabbed pixmap as PNG.")
+        with open(tmp_path, "rb") as fh:
+            image_bytes = fh.read()
+        encoded = base64.b64encode(image_bytes).decode("ascii")
+        size = pixmap.size()
+        return skill_success(
+            "Maya UI captured",
+            image=encoded,
+            width=int(size.width()),
+            height=int(size.height()),
+            format="png",
+            encoding="base64",
+            object_name=object_name,
+            widget_class=type(widget).__name__,
+            widget_object_name=str(widget.objectName()),
+            window_title=str(widget.windowTitle()),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return skill_exception(exc, message="Failed to capture Maya UI")
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def run_check(
+    target: Optional[str] = None,
+    module: Optional[str] = None,
+    callable: Optional[str] = None,  # noqa: A002 - public tool parameter
+    args: Any = None,
+    kwargs: Any = None,
+    project_name: Optional[str] = None,
+    reload_before: bool = True,
+    reload_mode: str = "purge",
+    capture_ui_image: bool = False,
+    ui_object_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Reload project code, run an entrypoint, and optionally capture Maya UI."""
+
+    run_result = run_entrypoint(
+        target=target,
+        module=module,
+        callable=callable,
+        args=args,
+        kwargs=kwargs,
+        project_name=project_name,
+        reload_before=reload_before,
+        reload_mode=reload_mode,
+        capture_output=True,
+    )
+    run_context = run_result.get("context", {})
+    ui_context: Optional[Dict[str, Any]] = None
+    ui_success: Optional[bool] = None
+    if capture_ui_image:
+        ui_result = capture_ui(ui_object_name)
+        ui_success = bool(ui_result.get("success"))
+        ui_context = ui_result.get("context", ui_result)
+
+    ctx = {
+        "run": run_context,
+        "run_success": bool(run_result.get("success")),
+    }
+    if ui_context is not None:
+        ctx["ui_capture"] = ui_context
+        ctx["ui_capture_success"] = ui_success
+    if run_result.get("success"):
+        return skill_success(
+            "Development check completed",
+            prompt="For viewport evidence, load maya-render and call capture_viewport after this check.",
+            **ctx,
+        )
+    return skill_error(
+        "Development check failed",
+        run_result.get("message") or "Entrypoint failed",
+        prompt="Inspect context.run.stdout, context.run.stderr, and context.run.traceback.",
+        **ctx,
+    )
+
+
+def reset_for_tests() -> None:
+    """Reset module state for unit tests."""
+
+    with _LOCK:
+        _STATE["active"] = None
+        _STATE["projects"] = {}
+        _DEBUGPY_STATE.update({"listening": False, "host": None, "port": None})

--- a/src/dcc_mcp_maya/_dev_session.py
+++ b/src/dcc_mcp_maya/_dev_session.py
@@ -266,11 +266,7 @@ def reload_modules(
         return skill_error("Invalid reload mode", "mode must be 'purge' or 'reload'.", mode=mode)
 
     prefixes = _normalize_prefixes(package_prefixes) or project.package_prefixes
-    matches = [
-        name
-        for name, module in list(sys.modules.items())
-        if _matches_module(name, module, project, prefixes)
-    ]
+    matches = [name for name, module in list(sys.modules.items()) if _matches_module(name, module, project, prefixes)]
     matches = sorted(set(matches), key=lambda item: (item.count("."), item))
     errors: List[Dict[str, str]] = []
     changed: List[str] = []
@@ -315,7 +311,9 @@ def _parse_target(target: Optional[str], module: Optional[str], callable_name: O
 
 def _resolve_callable(module_name: str, callable_name: str) -> Tuple[Optional[Any], Optional[Dict[str, Any]]]:
     if not module_name:
-        return None, skill_error("No module provided", "Pass target='package.module:function' or module='package.module'.")
+        return None, skill_error(
+            "No module provided", "Pass target='package.module:function' or module='package.module'."
+        )
     if not callable_name:
         callable_name = "main"
     try:
@@ -472,7 +470,9 @@ def run_entrypoint(
 
 def _resolve_script_path(script_path: str, project: DevProject) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
     if not script_path:
-        return None, skill_error("No script path provided", "Pass script_path as a project-relative or absolute .py path.")
+        return None, skill_error(
+            "No script path provided", "Pass script_path as a project-relative or absolute .py path."
+        )
     path = script_path
     if not os.path.isabs(path):
         path = os.path.join(project.root, path)
@@ -641,9 +641,13 @@ def _qt_modules() -> Tuple[Optional[Any], Optional[Any], Optional[Any], Optional
 def _maya_main_window() -> Tuple[Optional[Any], Optional[Any], Optional[Dict[str, Any]]]:
     qt_widgets, _qt_core, shiboken, qt_name = _qt_modules()
     if qt_widgets is None or shiboken is None:
-        return None, None, skill_error(
-            "Qt bindings are not available",
-            "Maya UI capture requires PySide/PySide2/PySide6 and shiboken.",
+        return (
+            None,
+            None,
+            skill_error(
+                "Qt bindings are not available",
+                "Maya UI capture requires PySide/PySide2/PySide6 and shiboken.",
+            ),
         )
     try:
         import maya.OpenMayaUI as omui  # noqa: PLC0415

--- a/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
@@ -2,7 +2,7 @@
 
 > Cross-skill navigation map. Read this before deciding which skill to load.
 
-The 23 bundled skills are organised into **five stages** that match the
+The 24 bundled skills are organised into **five stages** that match the
 mental model of a Maya pipeline. Each skill carries the stage in its
 SKILL.md frontmatter under `metadata.dcc-mcp.stage`.
 
@@ -14,7 +14,7 @@ SKILL.md frontmatter under `metadata.dcc-mcp.stage`.
 | `scene` | Scene file lifecycle, DAG navigation, attributes, node graph, viewport visibility. | partial (`maya-scene` only) | `maya-scene`, `maya-scene-assembly`, `maya-display`, `maya-attributes`, `maya-node-graph` |
 | `authoring` | Create / edit content: meshes, UVs, materials, rigs, animation, light rigs. | no | `maya-primitives`, `maya-mesh-ops`, `maya-uv-ops`, `maya-materials`, `maya-material-library`, `maya-texture-bake`, `maya-rigging`, `maya-animation`, `maya-pose-library`, `maya-expressions`, `maya-light-rig` |
 | `interchange` | Move geometry / scenes across DCCs (FBX, OBJ, presets, save). | no | `maya-geometry`, `maya-export-preset` |
-| `pipeline` | Production pipeline: project, publish, shot export, render, render farm. | no | `maya-pipeline`, `maya-shot-export`, `maya-render`, `maya-render-farm` |
+| `pipeline` | Production pipeline: project, publish, shot export, render, render farm, development diagnostics. | no | `maya-dev`, `maya-pipeline`, `maya-shot-export`, `maya-render`, `maya-render-farm` |
 
 ## Deciding which skill to load
 
@@ -49,6 +49,7 @@ Full rationale: repo root `AGENTS.md` § *Bulk import, export, and naming*; exam
 | Bake AO maps from high-res to low-res | `maya-uv-ops` → `maya-texture-bake` |
 | Create a three-point light rig and tweak intensity | `maya-light-rig` |
 | Snapshot the viewport | `maya-render` (`playblast`) |
+| Develop and debug a Maya Python tool inside the live session | `maya-dev` (`attach_project` → `run_check`; optional `start_debugpy`) |
 
 ## Side-Effect Taxonomy
 

--- a/src/dcc_mcp_maya/skills/maya-dev/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-dev/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: maya-dev
+description: |-
+  Pipeline stage — development workflow helpers for authoring Maya tools inside
+  a live Maya session. Use to attach a local Python project, hot-reload its
+  modules, run entrypoints or scripts, start debugpy, and capture Maya UI
+  evidence while iterating with an agent. Not for general scene editing: use
+  domain skills first.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    stage: pipeline
+    version: 0.1.0
+    tags:
+    - maya
+    - development
+    - debug
+    - hot-reload
+    - ui-capture
+    search-hint: |-
+      develop maya tools, attach python project, hot reload modules, run
+      project entrypoint, debugpy attach, capture maya ui screenshot, script
+      stdout stderr traceback diagnostics
+    depends: []
+    tools: tools.yaml
+    groups: groups.yaml
+---
+# maya-dev (Pipeline stage)
+
+Development workflow helpers for agents working on Maya Python tools in a
+live Maya session. The intended loop is:
+
+1. `attach_project` once for the project root.
+2. Edit files in the normal workspace.
+3. `run_check` or `reload_modules` + `run_entrypoint`.
+4. Inspect stdout, stderr, traceback, and optional UI screenshot.
+
+Set `DCC_MCP_MAYA_DEV_ROOTS` to a path-list of trusted roots when a studio
+wants to restrict which local projects can be attached.
+
+## Scripts
+
+- `attach_project` — Add a development project root to Maya's `sys.path`
+- `reload_modules` — Purge or reload modules belonging to the attached project
+- `run_entrypoint` — Import and call a Python entrypoint from the project
+- `run_script` — Run a project-local `.py` script with captured output
+- `start_debugpy` — Start a debugpy listener in the Maya process
+- `capture_ui` — Capture the Maya main window or a named Qt widget as PNG
+- `run_check` — Reload, run an entrypoint, capture diagnostics, optionally grab UI

--- a/src/dcc_mcp_maya/skills/maya-dev/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-dev/groups.yaml
@@ -1,0 +1,12 @@
+groups:
+- name: development
+  description: Live Maya development helpers for project reload, execution, debugging, and UI evidence
+  default_active: false
+  tools:
+  - attach_project
+  - reload_modules
+  - run_entrypoint
+  - run_script
+  - start_debugpy
+  - capture_ui
+  - run_check

--- a/src/dcc_mcp_maya/skills/maya-dev/scripts/attach_project.py
+++ b/src/dcc_mcp_maya/skills/maya-dev/scripts/attach_project.py
@@ -1,0 +1,18 @@
+"""Attach a local Maya tool development project to the live session."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya import _dev_session
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return _dev_session.attach_project(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-dev/scripts/capture_ui.py
+++ b/src/dcc_mcp_maya/skills/maya-dev/scripts/capture_ui.py
@@ -1,0 +1,18 @@
+"""Capture Maya's main window or a named Qt widget as PNG."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya import _dev_session
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return _dev_session.capture_ui(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-dev/scripts/reload_modules.py
+++ b/src/dcc_mcp_maya/skills/maya-dev/scripts/reload_modules.py
@@ -1,0 +1,18 @@
+"""Hot-reload modules from an attached Maya tool development project."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya import _dev_session
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return _dev_session.reload_modules(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-dev/scripts/run_check.py
+++ b/src/dcc_mcp_maya/skills/maya-dev/scripts/run_check.py
@@ -1,0 +1,18 @@
+"""Run a development verification pass inside Maya."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya import _dev_session
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return _dev_session.run_check(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-dev/scripts/run_entrypoint.py
+++ b/src/dcc_mcp_maya/skills/maya-dev/scripts/run_entrypoint.py
@@ -1,0 +1,18 @@
+"""Run a Python entrypoint from an attached Maya tool project."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya import _dev_session
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return _dev_session.run_entrypoint(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-dev/scripts/run_script.py
+++ b/src/dcc_mcp_maya/skills/maya-dev/scripts/run_script.py
@@ -1,0 +1,18 @@
+"""Run a Python script below an attached Maya tool project root."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya import _dev_session
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return _dev_session.run_script(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-dev/scripts/start_debugpy.py
+++ b/src/dcc_mcp_maya/skills/maya-dev/scripts/start_debugpy.py
@@ -1,0 +1,18 @@
+"""Start debugpy in the Maya process for IDE attach debugging."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya import _dev_session
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return _dev_session.start_debugpy(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-dev/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-dev/tools.yaml
@@ -1,0 +1,235 @@
+tools:
+- name: attach_project
+  description: Attach a local Maya tool project to the live Maya Python session by adding
+    its root (and optional src/ directory) to sys.path. Use this once before run_entrypoint/run_script.
+    Set DCC_MCP_MAYA_DEV_ROOTS to restrict trusted roots in studio deployments.
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: false
+    idempotent_hint: true
+  group: development
+  inputSchema:
+    type: object
+    required:
+    - project_root
+    properties:
+      project_root:
+        type: string
+        description: Absolute path to the Python/Maya tool project root.
+      name:
+        type: string
+        description: Optional session label; defaults to the directory name.
+      package_prefixes:
+        description: Package/module prefixes to hot-reload, e.g. ["my_tool"].
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+      include_src:
+        type: boolean
+        default: true
+        description: Also add project_root/src to sys.path when it exists.
+      make_active:
+        type: boolean
+        default: true
+        description: Make this project the default target for later dev tools.
+- name: reload_modules
+  description: Purge or reload modules that belong to the attached development project.
+    Default mode=purge removes matching modules from sys.modules so the next import
+    sees edited files, which is usually safer than importlib.reload in long-lived Maya
+    sessions.
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: false
+    idempotent_hint: true
+  group: development
+  inputSchema:
+    type: object
+    properties:
+      project_name:
+        type: string
+        description: Attached project label; defaults to the active project.
+      package_prefixes:
+        description: Override package/module prefixes for this reload.
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+      mode:
+        type: string
+        enum:
+        - purge
+        - reload
+        default: purge
+        description: purge removes modules from sys.modules; reload calls importlib.reload.
+- name: run_entrypoint
+  description: Run a callable from the attached development project inside Maya, with
+    stdout/stderr/traceback captured into the result envelope. Use target="package.module:function"
+    or module + callable.
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: false
+  group: development
+  inputSchema:
+    type: object
+    properties:
+      target:
+        type: string
+        description: Shorthand "package.module:function". Overrides module/callable
+          when supplied.
+      module:
+        type: string
+        description: Python module to import when target is not supplied.
+      callable:
+        type: string
+        default: main
+        description: Callable attribute path inside module.
+      args:
+        type: array
+        description: Positional JSON arguments.
+      kwargs:
+        type: object
+        description: Keyword JSON arguments.
+      project_name:
+        type: string
+        description: Attached project label; defaults to the active project.
+      reload_before:
+        type: boolean
+        default: true
+      reload_mode:
+        type: string
+        enum:
+        - purge
+        - reload
+        default: purge
+      capture_output:
+        type: boolean
+        default: true
+      chdir_project:
+        type: boolean
+        default: true
+- name: run_script
+  description: Run a project-local .py script with sys.argv, cwd, stdout/stderr, traceback,
+    and elapsed time captured. The script must live under the attached project root.
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: false
+  group: development
+  inputSchema:
+    type: object
+    required:
+    - script_path
+    properties:
+      script_path:
+        type: string
+        description: Project-relative or absolute path to a .py file under the attached
+          root.
+      argv:
+        description: Arguments exposed through sys.argv[1:].
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+      project_name:
+        type: string
+      reload_before:
+        type: boolean
+        default: true
+      reload_mode:
+        type: string
+        enum:
+        - purge
+        - reload
+        default: purge
+      capture_output:
+        type: boolean
+        default: true
+      chdir_project:
+        type: boolean
+        default: true
+- name: start_debugpy
+  description: Start a debugpy listener inside the Maya process so Cursor or VS Code
+    can attach breakpoints before MCP-triggered project code runs.
+  execution: sync
+  affinity: main
+  annotations:
+    read_only_hint: false
+    idempotent_hint: true
+  group: development
+  inputSchema:
+    type: object
+    properties:
+      host:
+        type: string
+        default: 127.0.0.1
+      port:
+        type: integer
+        minimum: 1
+        maximum: 65535
+        default: 5678
+      wait_for_client:
+        type: boolean
+        default: false
+        description: Block until an IDE attaches. Usually keep false for agent workflows.
+- name: capture_ui
+  description: Capture the Maya main window or a named Qt widget as a base64 PNG. Use
+    this for debugging custom tool windows and dock controls; use maya-render capture_viewport
+    for viewport imagery.
+  execution: async
+  affinity: main
+  timeout_hint_secs: 60
+  group: development
+  inputSchema:
+    type: object
+    properties:
+      object_name:
+        type: string
+        description: Optional Qt objectName or windowTitle to capture instead of the
+          whole main window.
+- name: run_check
+  description: 'Development convenience wrapper: reload project modules, run an entrypoint,
+    capture stdout/stderr/traceback, and optionally capture a Maya UI screenshot. Use
+    after editing project code to verify behavior inside the live Maya session.'
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
+  group: development
+  inputSchema:
+    type: object
+    properties:
+      target:
+        type: string
+        description: Shorthand "package.module:function".
+      module:
+        type: string
+      callable:
+        type: string
+        default: main
+      args:
+        type: array
+      kwargs:
+        type: object
+      project_name:
+        type: string
+      reload_before:
+        type: boolean
+        default: true
+      reload_mode:
+        type: string
+        enum:
+        - purge
+        - reload
+        default: purge
+      capture_ui_image:
+        type: boolean
+        default: false
+      ui_object_name:
+        type: string
+        description: Optional Qt objectName/windowTitle when capture_ui_image=true.

--- a/tests/test_maya_dev_skill.py
+++ b/tests/test_maya_dev_skill.py
@@ -1,0 +1,252 @@
+"""Unit tests for the maya-dev skill.
+
+These tests run without a live Maya session.  They pin the development
+workflow pieces that are pure Python: project attachment, module purge,
+entrypoint/script execution, debugpy bootstrap, and graceful UI-capture
+degradation when Qt/Maya is absent.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from tests.conftest import load_skill_script
+
+
+def _write_demo_package(root: Path) -> None:
+    pkg = root / "demo_tool"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "runner.py").write_text(
+        "VALUE = 1\n"
+        "\n"
+        "def main(x=0):\n"
+        "    print('runner-main', x)\n"
+        "    return {'value': VALUE, 'x': x}\n"
+        "\n"
+        "def boom():\n"
+        "    print('before-boom')\n"
+        "    raise RuntimeError('dev-boom')\n",
+        encoding="utf-8",
+    )
+
+
+def _cleanup_demo_modules() -> None:
+    for name in list(sys.modules):
+        if name == "demo_tool" or name.startswith("demo_tool."):
+            sys.modules.pop(name, None)
+
+
+def test_attach_project_adds_root_and_src_to_sys_path(tmp_path: Path, monkeypatch) -> None:
+    from dcc_mcp_maya import _dev_session
+
+    _dev_session.reset_for_tests()
+    old_sys_path = sys.path[:]
+    root = tmp_path / "project"
+    src = root / "src"
+    src.mkdir(parents=True)
+
+    try:
+        out = _dev_session.attach_project(str(root), package_prefixes=["demo_tool"])
+        assert out["success"] is True
+        ctx = out["context"]
+        assert ctx["project"]["root"] == str(root)
+        assert ctx["project"]["package_prefixes"] == ["demo_tool"]
+        assert str(root) in sys.path
+        assert str(src) in sys.path
+    finally:
+        sys.path[:] = old_sys_path
+        _dev_session.reset_for_tests()
+
+
+def test_attach_project_respects_allowed_roots(tmp_path: Path, monkeypatch) -> None:
+    from dcc_mcp_maya import _dev_session
+
+    _dev_session.reset_for_tests()
+    allowed = tmp_path / "allowed"
+    denied = tmp_path / "denied"
+    allowed.mkdir()
+    denied.mkdir()
+
+    with patch.dict("os.environ", {"DCC_MCP_MAYA_DEV_ROOTS": str(allowed)}):
+        out = _dev_session.attach_project(str(denied))
+
+    assert out["success"] is False
+    assert "outside allowed" in out["message"].lower()
+    assert out["context"]["allowed_root_count"] == 1
+
+
+def test_reload_modules_purges_attached_project_modules(tmp_path: Path) -> None:
+    from dcc_mcp_maya import _dev_session
+
+    _dev_session.reset_for_tests()
+    old_sys_path = sys.path[:]
+    _cleanup_demo_modules()
+    _write_demo_package(tmp_path)
+
+    try:
+        assert _dev_session.attach_project(str(tmp_path), package_prefixes=["demo_tool"])["success"] is True
+        importlib.import_module("demo_tool.runner")
+
+        assert "demo_tool.runner" in sys.modules
+        out = _dev_session.reload_modules()
+        assert out["success"] is True
+        assert "demo_tool.runner" in out["context"]["modules"]
+        assert "demo_tool.runner" not in sys.modules
+    finally:
+        sys.path[:] = old_sys_path
+        _cleanup_demo_modules()
+        _dev_session.reset_for_tests()
+
+
+def test_run_entrypoint_captures_stdout_and_json_return(tmp_path: Path) -> None:
+    from dcc_mcp_maya import _dev_session
+
+    _dev_session.reset_for_tests()
+    old_sys_path = sys.path[:]
+    _cleanup_demo_modules()
+    _write_demo_package(tmp_path)
+
+    try:
+        _dev_session.attach_project(str(tmp_path), package_prefixes=["demo_tool"])
+        out = _dev_session.run_entrypoint(target="demo_tool.runner:main", kwargs={"x": 7})
+        assert out["success"] is True
+        ctx = out["context"]
+        assert "runner-main 7" in ctx["stdout"]
+        assert ctx["return_value"] == {"value": 1, "x": 7}
+        assert ctx["target"] == "demo_tool.runner:main"
+        assert ctx["reload"]["mode"] == "purge"
+    finally:
+        sys.path[:] = old_sys_path
+        _cleanup_demo_modules()
+        _dev_session.reset_for_tests()
+
+
+def test_run_entrypoint_returns_traceback_on_failure(tmp_path: Path) -> None:
+    from dcc_mcp_maya import _dev_session
+
+    _dev_session.reset_for_tests()
+    old_sys_path = sys.path[:]
+    _cleanup_demo_modules()
+    _write_demo_package(tmp_path)
+
+    try:
+        _dev_session.attach_project(str(tmp_path), package_prefixes=["demo_tool"])
+        out = _dev_session.run_entrypoint(target="demo_tool.runner:boom")
+        assert out["success"] is False
+        ctx = out["context"]
+        assert "before-boom" in ctx["stdout"]
+        assert "RuntimeError" in ctx["traceback"]
+        assert "dev-boom" in ctx["traceback"]
+    finally:
+        sys.path[:] = old_sys_path
+        _cleanup_demo_modules()
+        _dev_session.reset_for_tests()
+
+
+def test_run_script_executes_project_local_file_and_blocks_escape(tmp_path: Path) -> None:
+    from dcc_mcp_maya import _dev_session
+
+    _dev_session.reset_for_tests()
+    old_sys_path = sys.path[:]
+    script = tmp_path / "scripts" / "check.py"
+    script.parent.mkdir()
+    script.write_text("import sys\nprint('argv', sys.argv[1:])\nRESULT = 42\n", encoding="utf-8")
+    outside = tmp_path.parent / "outside_dev_script.py"
+    outside.write_text("print('nope')\n", encoding="utf-8")
+
+    try:
+        _dev_session.attach_project(str(tmp_path))
+        out = _dev_session.run_script("scripts/check.py", argv=["a", "b"])
+        assert out["success"] is True
+        assert "argv ['a', 'b']" in out["context"]["stdout"]
+        assert "RESULT" in out["context"]["global_names"]
+
+        blocked = _dev_session.run_script(str(outside))
+        assert blocked["success"] is False
+        assert "outside" in blocked["message"].lower()
+    finally:
+        try:
+            outside.unlink()
+        except OSError:
+            pass
+        sys.path[:] = old_sys_path
+        _dev_session.reset_for_tests()
+
+
+def test_start_debugpy_uses_existing_listener_state(monkeypatch) -> None:
+    from dcc_mcp_maya import _dev_session
+
+    _dev_session.reset_for_tests()
+    fake = types.ModuleType("debugpy")
+    calls = []
+    fake.listen = lambda address: calls.append(address)
+    fake.wait_for_client = lambda: None
+    fake.is_client_connected = lambda: True
+
+    with patch.dict(sys.modules, {"debugpy": fake}):
+        first = _dev_session.start_debugpy(port=5679)
+        second = _dev_session.start_debugpy(port=9999)
+
+    assert first["success"] is True
+    assert first["context"]["port"] == 5679
+    assert first["context"]["client_connected"] is True
+    assert second["context"]["reused"] is True
+    assert calls == [("127.0.0.1", 5679)]
+
+
+def test_capture_ui_degrades_without_qt() -> None:
+    from dcc_mcp_maya import _dev_session
+
+    with patch.object(_dev_session, "_qt_modules", return_value=(None, None, None, None)):
+        out = _dev_session.capture_ui()
+    assert out["success"] is False
+    assert "qt" in out["message"].lower()
+
+
+def test_maya_dev_scripts_delegate_to_shared_session(tmp_path: Path) -> None:
+    from dcc_mcp_maya import _dev_session
+
+    _dev_session.reset_for_tests()
+    old_sys_path = sys.path[:]
+    _write_demo_package(tmp_path)
+
+    try:
+        attach = load_skill_script("maya-dev", "attach_project")
+        run = load_skill_script("maya-dev", "run_entrypoint")
+
+        attached = attach.main(project_root=str(tmp_path), package_prefixes=["demo_tool"])
+        assert attached["success"] is True
+        out = run.main(target="demo_tool.runner:main", kwargs={"x": 3})
+        assert out["success"] is True
+        assert out["context"]["return_value"]["x"] == 3
+    finally:
+        sys.path[:] = old_sys_path
+        _cleanup_demo_modules()
+        _dev_session.reset_for_tests()
+
+
+def test_maya_dev_tools_yaml_contract() -> None:
+    path = Path(__file__).parents[1] / "src" / "dcc_mcp_maya" / "skills" / "maya-dev" / "tools.yaml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    tools = {tool["name"]: tool for tool in data["tools"]}
+
+    expected = {
+        "attach_project",
+        "reload_modules",
+        "run_entrypoint",
+        "run_script",
+        "start_debugpy",
+        "capture_ui",
+        "run_check",
+    }
+    assert set(tools) == expected
+    assert tools["capture_ui"]["execution"] == "async"
+    assert tools["run_check"]["timeout_hint_secs"] == 300
+    assert tools["run_entrypoint"]["affinity"] == "main"

--- a/tools/annotate_skill_affinity.py
+++ b/tools/annotate_skill_affinity.py
@@ -69,6 +69,7 @@ SKILL_DEFAULTS: Dict[str, ExecAffinity] = {
     # async if they know the script is long-running.
     "maya-scripting": ("sync", "main", None),
     # Pure filesystem readers: worker-thread safe
+    "maya-dev": ("sync", "main", None),
     "maya-pipeline": ("sync", "main", None),
     "maya-material-library": ("sync", "main", None),
     # Everything else: sync + main (touches maya.cmds)
@@ -195,6 +196,9 @@ TOOL_OVERRIDES: Dict[Tuple[str, str], ExecAffinity] = {
     ("maya-texture-bake", "set_color_management"): ("sync", "main", None),
     # maya-shot-export meta
     ("maya-shot-export", "get_shot_info"): ("sync", "main", None),
+    # maya-dev diagnostics
+    ("maya-dev", "capture_ui"): ("async", "main", 60),
+    ("maya-dev", "run_check"): ("async", "main", 300),
     # maya-scripting introspect tools: list/signature/search are worker-safe (no DAG access)
     ("maya-scripting", "introspect_list_module"): ("sync", "any", None),
     ("maya-scripting", "introspect_signature"): ("sync", "any", None),


### PR DESCRIPTION
## Summary
- Add a `maya-dev` skill for agent-assisted Maya tool development: attach project roots, reload modules, run scripts/entrypoints/checks, start optional `debugpy`, and capture lightweight UI state.
- Add shared dev-session helpers with explicit project allowlisting through `DCC_MCP_MAYA_DEV_ROOTS`.
- Update skill docs, tool counts, and affinity annotation so the new skill is discoverable and validated like the existing bundled skills.

## Validation
- `python -m ruff check src\dcc_mcp_maya\_dev_session.py src\dcc_mcp_maya\skills\maya-dev tests\test_maya_dev_skill.py tools\annotate_skill_affinity.py`
- `python tools\lint_skills.py --skills-root src\dcc_mcp_maya\skills --error-only`
- `python -m pytest -q`

## Follow-ups
- Maya follow-up issues: #277, #278, #279, #280
- Core follow-up issues: loonghao/dcc-mcp-core#1078, loonghao/dcc-mcp-core#1079, loonghao/dcc-mcp-core#1080, loonghao/dcc-mcp-core#1081