### PR TITLE
feat: add maya dev artifacts and node refs

### DIFF
--- a/src/dcc_mcp_maya/__init__.py
+++ b/src/dcc_mcp_maya/__init__.py
@@ -110,7 +110,9 @@ from dcc_mcp_maya.api import (
     maya_warning,
     missing_param_error,
     node_long_name,
+    node_ref_from_name,
     node_shape_names,
+    node_uuid,
     object_transform_from_node,
     require_any_param,
     require_cmds,
@@ -210,6 +212,8 @@ __all__ = [
     "created_node_name",
     "node_long_name",
     "node_shape_names",
+    "node_uuid",
+    "node_ref_from_name",
     "summarize_node",
     "created_object_context",
     # DCC capabilities

--- a/src/dcc_mcp_maya/_dev_session.py
+++ b/src/dcc_mcp_maya/_dev_session.py
@@ -31,6 +31,7 @@ from dcc_mcp_core.adapter_contracts import (
     DebugSessionStatus,
     UiActionKind,
     UiActionResult,
+    UiArtifactRef,
     UiBounds,
     UiControlNode,
     UiErrorCode,
@@ -597,19 +598,39 @@ def _artifact_dir() -> str:
     return root
 
 
-def _write_text_artifact(kind: str, text: str) -> Dict[str, Any]:
+def _artifact_path(kind: str, suffix: str) -> Tuple[str, str]:
     safe_kind = "".join(ch if ch.isalnum() or ch in ("-", "_") else "-" for ch in kind) or "text"
-    filename = "{}-{}-{}.txt".format(int(time.time() * 1000), threading.get_ident(), safe_kind)
+    filename = "{}-{}-{}{}".format(int(time.time() * 1000), threading.get_ident(), safe_kind, suffix)
     path = os.path.join(_artifact_dir(), filename)
+    return safe_kind, path
+
+
+def _artifact_payload(kind: str, path: str, mime: str, byte_count: int) -> Dict[str, Any]:
+    ref = UiArtifactRef(uri=_path_uri(path), mime=mime).to_dict()
+    ref.update(
+        {
+            "kind": kind,
+            "path": path,
+            "bytes": int(byte_count),
+        }
+    )
+    return ref
+
+
+def _write_text_artifact(kind: str, text: str) -> Dict[str, Any]:
+    safe_kind, path = _artifact_path(kind, ".txt")
     with open(path, "w", encoding="utf-8", errors="replace") as fh:
         fh.write(text)
-    return {
-        "kind": safe_kind,
-        "uri": _path_uri(path),
-        "path": path,
-        "mime": "text/plain",
-        "bytes": len(text.encode("utf-8", errors="replace")),
-    }
+    return _artifact_payload(safe_kind, path, "text/plain", len(text.encode("utf-8", errors="replace")))
+
+
+def _ui_artifact_refs(artifacts: Sequence[Dict[str, Any]]) -> List[UiArtifactRef]:
+    refs: List[UiArtifactRef] = []
+    for artifact in artifacts:
+        uri = artifact.get("uri")
+        if uri:
+            refs.append(UiArtifactRef(uri=str(uri), mime=artifact.get("mime")))
+    return refs
 
 
 def _externalize_text_fields(ctx: Dict[str, Any], fields: Sequence[str], threshold: int) -> List[Dict[str, Any]]:
@@ -1524,6 +1545,37 @@ def _invoke_widget_action(
     raise RuntimeError("Unsupported UI action {!r}".format(action))
 
 
+def _capture_widget_png_artifact(widget: Any, kind: str) -> Optional[Dict[str, Any]]:
+    grab = getattr(widget, "grab", None)
+    if not callable(grab):
+        return None
+    pixmap = grab()
+    is_null = getattr(pixmap, "isNull", None)
+    if callable(is_null) and is_null():
+        return None
+
+    safe_kind, path = _artifact_path(kind, ".png")
+    save = getattr(pixmap, "save", None)
+    if not callable(save) or not save(path, "PNG"):
+        _remove_artifact_file(path)
+        return None
+    try:
+        byte_count = os.path.getsize(path)
+    except OSError:
+        byte_count = 0
+    if byte_count <= 0:
+        _remove_artifact_file(path)
+        return None
+    return _artifact_payload(safe_kind, path, "image/png", byte_count)
+
+
+def _remove_artifact_file(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
 def ui_action(
     action: str,
     control_id: Optional[str] = None,
@@ -1537,6 +1589,7 @@ def ui_action(
     value: Optional[str] = None,
     checked: Optional[bool] = None,
     option: Optional[str] = None,
+    capture_screenshots: bool = False,
 ) -> Dict[str, Any]:
     """Perform a bounded action on a unique Qt control."""
 
@@ -1577,15 +1630,25 @@ def ui_action(
 
     before_focus = _focus_id()
     before = _ui_ref(widget, resolved_id)
+    artifacts: List[Dict[str, Any]] = []
+    if capture_screenshots:
+        before_artifact = _capture_widget_png_artifact(widget, "ui-action-before")
+        if before_artifact is not None:
+            artifacts.append(before_artifact)
     try:
         _invoke_widget_action(widget, normalized_action, action_text_value, checked, option)
     except Exception as exc:  # noqa: BLE001
+        if capture_screenshots:
+            after_artifact = _capture_widget_png_artifact(widget, "ui-action-after-error")
+            if after_artifact is not None:
+                artifacts.append(after_artifact)
         result = UiActionResult(
             success=False,
             control_id=resolved_id,
             error_code=UiErrorCode.UNSUPPORTED_ACTION,
             message=str(exc),
             before_focus_id=before_focus,
+            artifacts=_ui_artifact_refs(artifacts),
         )
         return skill_error(
             "UI action failed",
@@ -1593,14 +1656,20 @@ def ui_action(
             error_code=result.error_code,
             action_result=result.to_dict(),
             control=before,
+            artifacts=artifacts,
         )
     after_focus = _focus_id()
     after = _ui_ref(widget, resolved_id)
+    if capture_screenshots:
+        after_artifact = _capture_widget_png_artifact(widget, "ui-action-after")
+        if after_artifact is not None:
+            artifacts.append(after_artifact)
     result = UiActionResult(
         success=True,
         control_id=resolved_id,
         before_focus_id=before_focus,
         after_focus_id=after_focus,
+        artifacts=_ui_artifact_refs(artifacts),
         metadata={"action": action},
     )
     return skill_success(
@@ -1609,6 +1678,7 @@ def ui_action(
         control=after,
         before=before,
         after=after,
+        artifacts=artifacts,
     )
 
 

--- a/src/dcc_mcp_maya/api.py
+++ b/src/dcc_mcp_maya/api.py
@@ -839,6 +839,80 @@ def node_shape_names(cmds: Any, node_name: str) -> List[str]:
         return []
 
 
+def node_uuid(cmds: Any, node_name: str) -> Optional[str]:
+    """Return Maya's UUID for *node_name* when available."""
+    try:
+        uuids = cmds.ls(node_name, uuid=True) or []
+    except Exception:  # noqa: BLE001 - old mocks / host modes may not expose uuid lookup
+        logger.debug("Could not read UUID for %s", node_name, exc_info=True)
+        return None
+    if not isinstance(uuids, (list, tuple)) or not uuids:
+        return None
+    value = str(uuids[0])
+    if value == str(node_name) or value.startswith("|"):
+        return None
+    return value
+
+
+def _node_type(cmds: Any, node_name: str) -> Optional[str]:
+    for method_name in ("nodeType", "objectType"):
+        method = getattr(cmds, method_name, None)
+        if callable(method):
+            try:
+                return str(method(node_name))
+            except Exception:  # noqa: BLE001
+                logger.debug("Could not read node type for %s via %s", node_name, method_name, exc_info=True)
+    return None
+
+
+def _node_exists(cmds: Any, node_name: str) -> bool:
+    exists = getattr(cmds, "objExists", None)
+    if callable(exists):
+        try:
+            return bool(exists(node_name))
+        except Exception:  # noqa: BLE001
+            logger.debug("Could not read existence for %s", node_name, exc_info=True)
+    return True
+
+
+def _current_scene_path(cmds: Any) -> Optional[str]:
+    file_cmd = getattr(cmds, "file", None)
+    if not callable(file_cmd):
+        return None
+    try:
+        path = file_cmd(query=True, sceneName=True)
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not read current scene path", exc_info=True)
+        return None
+    return str(path) if path else None
+
+
+def node_ref_from_name(cmds: Any, node_name: str) -> Dict[str, Any]:
+    """Build a stable JSON NodeRef for a Maya node.
+
+    The payload is intentionally plain JSON and PyMEL-free.  UUID is preferred
+    for identity when Maya exposes it; long DAG path remains the fallback so
+    agents can still resolve or display the reference in stripped-down test and
+    batch contexts.
+    """
+    long_name = node_long_name(cmds, node_name)
+    short_name = long_name.rsplit("|", 1)[-1] if "|" in long_name else str(node_name)
+    uuid_value = node_uuid(cmds, long_name)
+    exists = _node_exists(cmds, long_name)
+    node_type = _node_type(cmds, long_name)
+    return {
+        "kind": "maya_node",
+        "id": uuid_value or long_name,
+        "uuid": uuid_value,
+        "long_name": long_name,
+        "short_name": short_name,
+        "type": node_type,
+        "exists": exists,
+        "stale": not exists,
+        "metadata": build_context_dict(scene_path=_current_scene_path(cmds)),
+    }
+
+
 def summarize_node(cmds: Any, node_name: str) -> Dict[str, Any]:
     """Build a stable, JSON-safe summary for a Maya DAG node.
 
@@ -850,17 +924,20 @@ def summarize_node(cmds: Any, node_name: str) -> Dict[str, Any]:
     """
     long_name = node_long_name(cmds, node_name)
     short_name = long_name.rsplit("|", 1)[-1] if "|" in long_name else str(node_name)
+    node_ref = node_ref_from_name(cmds, long_name)
 
     summary: Dict[str, Any] = {
         "name": short_name,
         "long_name": long_name,
         "object_name": short_name,
         "shape_names": node_shape_names(cmds, long_name),
+        "uuid": node_ref.get("uuid"),
+        "exists": bool(node_ref.get("exists")),
+        "stale": bool(node_ref.get("stale")),
+        "node_ref": node_ref,
     }
-    try:
-        summary["object_type"] = cmds.objectType(long_name)
-    except Exception:  # noqa: BLE001
-        logger.debug("Could not read object type for %s", long_name, exc_info=True)
+    if node_ref.get("type"):
+        summary["object_type"] = node_ref["type"]
     try:
         summary["transform"] = object_transform_from_node(cmds, long_name)
     except Exception:  # noqa: BLE001
@@ -888,6 +965,7 @@ def created_object_context(cmds: Any, result: Any, requested_name: Optional[str]
         "object_name": summary.get("object_name", node_name),
         "long_name": summary.get("long_name", node_name),
         "node": summary,
+        "node_ref": summary.get("node_ref"),
     }
 
 
@@ -1051,6 +1129,8 @@ __all__ = [
     "created_node_name",
     "node_long_name",
     "node_shape_names",
+    "node_uuid",
+    "node_ref_from_name",
     "summarize_node",
     "created_object_context",
     # DCC capabilities

--- a/src/dcc_mcp_maya/skills/maya-dev/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-dev/SKILL.md
@@ -49,6 +49,6 @@ wants to restrict which local projects can be attached.
 - `run_script` — Run a project-local `.py` script with captured output
 - `start_debugpy` — Start a debugpy listener in the Maya process with attach metadata
 - `capture_ui` — Capture the Maya main window or a named Qt widget as PNG
-- `ui_snapshot` / `ui_find` / `ui_action` — Inspect and operate Maya Qt UI controls
+- `ui_snapshot` / `ui_find` / `ui_action` — Inspect and operate Maya Qt UI controls, with optional action evidence artifacts
 - `make_node_ref` / `resolve_node_ref` — Build and resolve stable Maya node references
 - `run_check` — Reload, run an entrypoint, capture diagnostics/artifacts, optionally grab UI

--- a/src/dcc_mcp_maya/skills/maya-dev/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-dev/tools.yaml
@@ -325,6 +325,10 @@ tools:
       option:
         type: string
         description: Option label for select_option.
+      capture_screenshots:
+        type: boolean
+        default: false
+        description: Capture before/after PNG artifact refs for action evidence.
 - name: make_node_ref
   source_file: scripts/make_node_ref.py
   description: Return a stable JSON reference for a Maya node including long name,

--- a/src/dcc_mcp_maya/skills/maya-scene/scripts/get_scene_info.py
+++ b/src/dcc_mcp_maya/skills/maya-scene/scripts/get_scene_info.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 # Import local modules
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
-from dcc_mcp_maya.api import object_transform_from_node, scene_object_from_node
+from dcc_mcp_maya.api import node_ref_from_name, object_transform_from_node, scene_object_from_node
 
 
 def get_scene_info(include_transforms: bool = True) -> dict:
@@ -37,6 +37,7 @@ def get_scene_info(include_transforms: bool = True) -> dict:
         nodes = []
         for long_name in transforms:
             node = scene_object_from_node(cmds, long_name)
+            node["node_ref"] = node_ref_from_name(cmds, long_name)
             node["children"] = cmds.listRelatives(long_name, children=True, fullPath=True) or []
             if include_transforms:
                 try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,7 +23,9 @@ from dcc_mcp_maya.api import (
     maya_success,
     missing_param_error,
     node_long_name,
+    node_ref_from_name,
     node_shape_names,
+    node_uuid,
     require_main_thread,
     require_param,
     summarize_node,
@@ -60,7 +62,10 @@ class _FakeCmdsForNodeSummary:
     def __init__(self):
         self.renamed = []
 
-    def ls(self, name, long=False):  # noqa: A002 - mirrors maya.cmds flag name
+    def ls(self, name, long=False, uuid=False):  # noqa: A002 - mirrors maya.cmds flag name
+        if uuid:
+            short = str(name).rsplit("|", 1)[-1]
+            return ["uuid-{}".format(short)]
         return ["|grp|{}".format(name)] if long and not str(name).startswith("|") else [name]
 
     def listRelatives(self, name, shapes=False, fullPath=False):  # noqa: N803
@@ -70,6 +75,17 @@ class _FakeCmdsForNodeSummary:
 
     def objectType(self, _name):
         return "transform"
+
+    def nodeType(self, _name):  # noqa: N802
+        return "transform"
+
+    def objExists(self, _name):  # noqa: N802
+        return True
+
+    def file(self, query=False, sceneName=False):  # noqa: N803
+        if query and sceneName:
+            return "C:/show/shot.ma"
+        return ""
 
     def getAttr(self, attr):
         if attr.endswith(".translate"):
@@ -104,6 +120,11 @@ def test_summarize_node_returns_stable_identity_packet():
     assert summary["object_name"] == "pCube1"
     assert summary["long_name"] == "|grp|pCube1"
     assert summary["shape_names"] == ["|grp|pCube1Shape"]
+    assert summary["uuid"] == "uuid-pCube1"
+    assert summary["exists"] is True
+    assert summary["stale"] is False
+    assert summary["node_ref"]["id"] == "uuid-pCube1"
+    assert summary["node_ref"]["metadata"]["scene_path"] == "C:/show/shot.ma"
     assert summary["transform"]["translate"] == [1.0, 2.0, 3.0]
     assert summary["bounding_box"]["center"] == [1.0, 2.0, 3.0]
 
@@ -116,6 +137,25 @@ def test_created_object_context_renames_then_summarizes():
     assert context["object_name"] == "heroCube"
     assert context["long_name"] == "|grp|heroCube"
     assert context["node"]["shape_names"] == ["|grp|heroCubeShape"]
+    assert context["node_ref"]["uuid"] == "uuid-heroCube"
+
+
+def test_node_ref_from_name_returns_plain_json_reference():
+    cmds = _FakeCmdsForNodeSummary()
+    ref = node_ref_from_name(cmds, "pCube1")
+
+    assert node_uuid(cmds, "|grp|pCube1") == "uuid-pCube1"
+    assert ref == {
+        "kind": "maya_node",
+        "id": "uuid-pCube1",
+        "uuid": "uuid-pCube1",
+        "long_name": "|grp|pCube1",
+        "short_name": "pCube1",
+        "type": "transform",
+        "exists": True,
+        "stale": False,
+        "metadata": {"scene_path": "C:/show/shot.ma"},
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -344,6 +384,8 @@ def test_public_api_reexport():
         "created_node_name",
         "node_long_name",
         "node_shape_names",
+        "node_uuid",
+        "node_ref_from_name",
         "summarize_node",
         "created_object_context",
     ]:

--- a/tests/test_maya_dev_skill.py
+++ b/tests/test_maya_dev_skill.py
@@ -64,6 +64,15 @@ class _Rect:
         return self._height
 
 
+class _FakePixmap:
+    def isNull(self) -> bool:  # noqa: N802
+        return False
+
+    def save(self, path: str, _format: str) -> bool:
+        Path(path).write_bytes(b"fake-png")
+        return True
+
+
 class _FakeWidget:
     def __init__(
         self,
@@ -105,6 +114,9 @@ class _FakeWidget:
 
     def geometry(self) -> _Rect:
         return _Rect()
+
+    def grab(self) -> _FakePixmap:
+        return _FakePixmap()
 
     def children(self) -> list["_FakeWidget"]:
         return list(self._children)
@@ -471,6 +483,30 @@ def test_ui_action_requires_unique_locator() -> None:
 
     assert out["success"] is False
     assert out["context"]["error_code"] == "ambiguous_control"
+
+
+def test_ui_action_can_capture_artifact_evidence(tmp_path: Path) -> None:
+    from dcc_mcp_maya import _dev_session
+
+    _dev_session.reset_for_tests()
+    root, _save, name = _fake_ui_tree()
+    with patch.dict("os.environ", {"DCC_MCP_MAYA_DEV_ARTIFACT_DIR": str(tmp_path / "artifacts")}):
+        with patch.object(_dev_session, "_maya_main_window", return_value=(root, _FakeWidget, None)):
+            out = _dev_session.ui_action(
+                action="set_text",
+                object_name="nameEdit",
+                text="New",
+                capture_screenshots=True,
+            )
+
+    assert out["success"] is True
+    assert name.text() == "New"
+    artifacts = out["context"]["artifacts"]
+    assert [artifact["kind"] for artifact in artifacts] == ["ui-action-before", "ui-action-after"]
+    assert all(artifact["mime"] == "image/png" for artifact in artifacts)
+    assert all(Path(artifact["path"]).exists() for artifact in artifacts)
+    action_artifacts = out["context"]["action_result"]["artifacts"]
+    assert [artifact["uri"] for artifact in action_artifacts] == [artifact["uri"] for artifact in artifacts]
 
 
 def test_run_check_writes_artifact_refs_for_large_output(tmp_path: Path) -> None:

--- a/tests/test_maya_primitives_created_context.py
+++ b/tests/test_maya_primitives_created_context.py
@@ -24,7 +24,10 @@ class _PrimitiveCmds:
     def rename(self, _old, new):
         return new
 
-    def ls(self, name, long=False):  # noqa: A002 - mirrors maya.cmds flag name
+    def ls(self, name, long=False, uuid=False):  # noqa: A002 - mirrors maya.cmds flag name
+        if uuid:
+            short = str(name).rsplit("|", 1)[-1]
+            return ["uuid-{}".format(short)]
         return ["|{}".format(name)] if long and not str(name).startswith("|") else [name]
 
     def listRelatives(self, name, shapes=False, fullPath=False):  # noqa: N803
@@ -34,6 +37,17 @@ class _PrimitiveCmds:
 
     def objectType(self, _name):  # noqa: N802
         return "transform"
+
+    def nodeType(self, _name):  # noqa: N802
+        return "transform"
+
+    def objExists(self, _name):  # noqa: N802
+        return True
+
+    def file(self, query=False, sceneName=False):  # noqa: N803
+        if query and sceneName:
+            return "C:/show/primitive.ma"
+        return ""
 
     def getAttr(self, attr):  # noqa: N802
         if attr.endswith(".translate"):
@@ -67,3 +81,6 @@ def test_primitive_create_tools_return_rich_node_context():
             assert context["long_name"] == "|{}".format(kwargs["name"])
             assert context["node"]["shape_names"] == ["|{}Shape".format(kwargs["name"])]
             assert context["node"]["transform"]["scale"] == [1.0, 1.0, 1.0]
+            assert context["node_ref"]["uuid"] == "uuid-{}".format(kwargs["name"])
+            assert context["node_ref"]["exists"] is True
+            assert context["node_ref"]["stale"] is False

--- a/tests/test_maya_scene_skill.py
+++ b/tests/test_maya_scene_skill.py
@@ -16,3 +16,43 @@ def test_save_scene_without_path_rejects_unnamed_scene_before_prompt():
     assert result["success"] is False
     assert "file_path" in result["message"]
     cmds.file.assert_called_once_with(query=True, sceneName=True)
+
+
+def test_get_scene_info_includes_node_refs():
+    cmds = MagicMock()
+
+    def _ls(*args, **kwargs):
+        if kwargs.get("type") == "transform" and kwargs.get("long"):
+            return ["|pCube1"]
+        if kwargs.get("uuid"):
+            return ["uuid-pCube1"]
+        if kwargs.get("long"):
+            return [str(args[0])]
+        return [str(args[0])] if args else []
+
+    def _get_attr(attr):
+        if attr.endswith(".translate"):
+            return [(1.0, 2.0, 3.0)]
+        if attr.endswith(".rotate"):
+            return [(0.0, 0.0, 0.0)]
+        if attr.endswith(".scale"):
+            return [(1.0, 1.0, 1.0)]
+        if attr.endswith(".visibility"):
+            return True
+        return [(0.0, 0.0, 0.0)]
+
+    cmds.ls.side_effect = _ls
+    cmds.nodeType.return_value = "transform"
+    cmds.objectType.return_value = "transform"
+    cmds.objExists.return_value = True
+    cmds.file.return_value = "C:/show/scene.ma"
+    cmds.getAttr.side_effect = _get_attr
+    cmds.listRelatives.return_value = []
+
+    result = load_and_call("maya-scene/scripts/get_scene_info.py", cmds, "main")
+
+    assert result["success"] is True
+    node = result["context"]["nodes"][0]
+    assert node["node_ref"]["uuid"] == "uuid-pCube1"
+    assert node["node_ref"]["long_name"] == "|pCube1"
+    assert node["node_ref"]["metadata"]["scene_path"] == "C:/show/scene.ma"


### PR DESCRIPTION
## Summary

Refs #278, #279, #280.

- Add optional `capture_screenshots` evidence to `maya_dev__ui_action`, writing before/after PNG artifacts and returning core `UiArtifactRef` entries in `UiActionResult.artifacts`.
- Normalize maya-dev text artifacts through the same artifact-ref payload shape while preserving existing `kind`, `path`, and `bytes` fields.
- Add reusable Maya `NodeRef` helpers (`node_uuid`, `node_ref_from_name`) and export them from the public API.
- Include `node_ref` in created-object contexts and `maya_scene__get_scene_info` nodes so agents can carry stable UUID/long-name references across later calls.

## Validation

- `uv run pytest tests/test_skills_round33.py::TestSceneObjectFromNode::test_basic_top_level_transform tests/test_skills_round39.py::TestSceneObjectFromNode::test_metadata_empty_dict tests/test_maya_scene_skill.py tests/test_api.py tests/test_maya_dev_skill.py tests/test_maya_primitives_created_context.py -q`
- `uv run ruff check src/dcc_mcp_maya/__init__.py src/dcc_mcp_maya/_dev_session.py src/dcc_mcp_maya/api.py src/dcc_mcp_maya/skills/maya-scene/scripts/get_scene_info.py tests/test_api.py tests/test_maya_dev_skill.py tests/test_maya_primitives_created_context.py tests/test_maya_scene_skill.py`
- `uv run ruff format --check src/dcc_mcp_maya/__init__.py src/dcc_mcp_maya/_dev_session.py src/dcc_mcp_maya/api.py src/dcc_mcp_maya/skills/maya-scene/scripts/get_scene_info.py tests/test_api.py tests/test_maya_dev_skill.py tests/test_maya_primitives_created_context.py tests/test_maya_scene_skill.py`
- `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/e2e_standalone -q --cov=dcc_mcp_maya --cov-report=xml --cov-report=term`