### PR TITLE
fix: surface maya recovery dialogs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,6 +384,7 @@ All other skills appear as `__skill__<name>` stubs (default behavior). Call `loa
 | `DCC_MCP_MAYA_DEFENSIVE_DEL` | `0` | `1` = enable the defensive `__del__` guard. Recommended only for `mayapy` / test fixtures — interactive Maya disables by default to avoid Tokio deadlocks (issue #186). |
 | `DCC_MCP_MAYA_RESOURCES` | `1` | `0` = disable Maya MCP resource publishing entirely (issue #187 / core 0.15.0). |
 | `DCC_MCP_MAYA_FAULTHANDLER` | `1` | `0` = disable plugin-installed Python fatal-signal traceback logging. Logs go under `DCC_MCP_LOG_DIR` or the OS temp directory. |
+| `DCC_MCP_MAYA_AUTO_DISMISS_CRASH_DIALOG` | `0` | `1` = auto-dismiss detected Maya Qt recovery dialogs after main-thread tool calls and surface `maya_recovered` in results / `scene://current`. |
 | `DCC_MCP_GATEWAY_PORT` | `9765` | Multi-instance gateway election port. `0` = disable. |
 | `DCC_MCP_REGISTRY_DIR` | OS temp dir | Shared service-discovery registry directory. |
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | `1` = exclude ``__skill__*`` / ``__group__*`` stubs from ``tools/list`` (issue #174). Discovery still possible via capability manifest / ``/v1/search``. |
@@ -446,6 +447,7 @@ Bugs that only reproduce through the **gateway REST** surface (`/v1/search`, `/v
 | `src/dcc_mcp_maya/_stale_cleanup.py` | Stale FileRegistry detection + warning (issue #126) |
 | `src/dcc_mcp_maya/_project_tools.py` | `register_project_tools` integration — `project.save/load/resume/status` MCP tools (issue #576 / core 0.14.21) |
 | `src/dcc_mcp_maya/_readiness.py` | Three-state readiness probe (`process` / `dispatcher` / `dcc`) — honest `/v1/readyz` signal during Maya boot (issue #184) |
+| `src/dcc_mcp_maya/_recovery_dialog.py` | Qt-level Maya recovery dialog detector — optional auto-dismiss + `maya_recovered` status in results/context (issue #241) |
 | `src/dcc_mcp_maya/_resources.py` | `MayaResourceBinder` — `scene://current` snapshot + `maya-cmds://` / `maya-api://` / `maya-project://` producers (issue #187 / core 0.15.0) |
 | `src/dcc_mcp_maya/_shutdown_safety.py` | Non-cooperative shutdown safety nets — `kMayaExiting` hook, `atexit` fallback, crash-resilient process sentinel, defensive `__del__` (issue #186) |
 | `src/dcc_mcp_maya/dispatcher/` | Thread-affinity dispatchers + cancellation (directory module) |

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Useful plugin defaults:
 | `DCC_MCP_MAYA_DEV_ROOTS` | none | Optional path-list of trusted roots that `maya-dev` projects must live under. |
 | `DCC_MCP_MAYA_FAULTHANDLER` | `1` | `0` disables fatal-signal traceback logging from the Maya plugin. |
 | `DCC_MCP_MAYA_SUPPRESS_CRASH_REPORTER` | `0` | `1` suppresses Maya crash reporter dialogs during unattended startup. |
+| `DCC_MCP_MAYA_AUTO_DISMISS_CRASH_DIALOG` | `0` | `1` auto-dismisses detected Maya Qt recovery dialogs after main-thread tool calls and surfaces `maya_recovered` in results/context. |
 | `DCC_MCP_MAYA_DISABLE_AUTOSAVE` | `1` | `0` opts out of the plugin's AutoSave suppression during MCP jobs. |
 | `DCC_MCP_MAYA_SAFE_SESSION` | `1` | `0` disables the modal-dialog firewall around MCP-dispatched jobs. |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | Refuse `execute_python`. |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,7 +14,7 @@ Embeds a standards-compliant MCP Streamable HTTP server (2025-03-26 spec) direct
 - **Repository:** https://github.com/loonghao/dcc-mcp-maya
 - **Python:** >=3.7
 - **Maya:** 2020+
-- **Core dependency:** `dcc-mcp-core>=0.17.19,<1.0.0`
+- **Core dependency:** `dcc-mcp-core>=0.17.20,<1.0.0`
 - **Entry point:** `dcc_mcp.adapters` → `maya = "dcc_mcp_maya:MayaMcpServer"`
 
 ---
@@ -465,6 +465,7 @@ tools:
 | `DCC_MCP_MAYA_DEFENSIVE_DEL` | `0` | per-process | `1`=enable defensive `__del__` guard. Off in interactive Maya (Tokio deadlock risk); recommended for `mayapy` / test fixtures (issue #186). |
 | `DCC_MCP_MAYA_RESOURCES` | `1` | per-process | `0`=disable Maya MCP resource publishing (`scene://current` snapshot + `maya-cmds://` / `maya-api://` / `maya-project://` producers).  Issue #187 / core 0.15.0. |
 | `DCC_MCP_MAYA_FAULTHANDLER` | `1` | per-process | `0`=disable plugin-installed Python fatal-signal traceback logging. Logs are written under `DCC_MCP_LOG_DIR` or the OS temp directory. |
+| `DCC_MCP_MAYA_AUTO_DISMISS_CRASH_DIALOG` | `0` | per-process | `1`=best-effort dismiss detected Maya Qt recovery dialogs after `affinity: main` tool calls and surface `maya_recovered` in result contexts / `scene://current`. |
 | `DCC_MCP_GATEWAY_PORT` | `9765` | per-host | Gateway election port. `0`=disable gateway mode. |
 | `DCC_MCP_GATEWAY_NAME` | `dcc-mcp-gateway@<hostname>` | per-host | Human-readable standalone gateway label surfaced in admin, health, and CLI diagnostics. |
 | `DCC_MCP_GATEWAY_REMOTE_PORT` | `59765` | per-host | LAN gateway listener port opened by the standalone gateway. `0`=disable remote listener; local gateway remains on `127.0.0.1:9765`. |
@@ -538,6 +539,7 @@ legacy `list_dcc_instances` / `connect_to_dcc` meta-tools.
 | `src/dcc_mcp_maya/server.py` | `MayaMcpServer`, discovery, metrics, jobs |
 | `src/dcc_mcp_maya/dispatcher/` | Thread-affinity dispatchers + cancellation (directory module) |
 | `src/dcc_mcp_maya/api.py` | 18 skill-authoring helpers |
+| `src/dcc_mcp_maya/_recovery_dialog.py` | Qt-level Maya recovery dialog detector + `maya_recovered` status surfacing |
 | `src/dcc_mcp_maya/capabilities.py` | DCC capability declarations |
 | `src/dcc_mcp_maya/skills/` | 24 built-in skill packages, 177 typed tool declarations |
 | `docs/` | VitePress site (EN + ZH) |

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 **Repo:** https://github.com/loonghao/dcc-mcp-maya
 **Python:** >=3.7
 **Maya:** 2020+
-**Core dep:** `dcc-mcp-core>=0.17.19,<1.0.0`
+**Core dep:** `dcc-mcp-core>=0.17.20,<1.0.0`
 
 ---
 
@@ -127,6 +127,12 @@ Runtime readiness wiring (issue #184, requires `dcc-mcp-core>=0.15.0`; API lande
 * Opt-in advisory timeout: `DCC_MCP_MAYA_READINESS_TIMEOUT_SECS=<positive int>` — consumed by orchestrators, never auto-fails the probe.
 * Maya public symbols: `ReadinessBinder`, `install_readiness`, `resolve_readiness_timeout_secs`, `ENV_READINESS_TIMEOUT_SECS`.  Core public symbols used here: `dcc_mcp_core.ReadinessProbe` (with `set_dispatcher_ready` / `set_dcc_ready` / `report` / `is_ready` / `fully_ready`).
 
+Qt recovery dialog detection (issue #241):
+
+* `dcc_mcp_maya._recovery_dialog.scan_recovery_dialog()` polls Maya Qt top-level windows for C++ crash-recovery dialogs (`"Maya has stopped working"`, `"已停止工作"`, recovery-file titles). It is called automatically after `affinity: main` skill actions return, on the main-thread callable path.
+* If `DCC_MCP_MAYA_AUTO_DISMISS_CRASH_DIALOG=1`, matching dialogs are dismissed best-effort via OK / Close / Reopen buttons or dialog `accept()` / `close()`.
+* Tool result contexts and `scene://current` snapshots include `maya_recovered`, `maya_status`, and `maya_recovery_dialog` once a dialog is detected. Public symbols: `ENV_AUTO_DISMISS_CRASH_DIALOG`, `scan_recovery_dialog`, `current_recovery_status`, `clear_recovery_status`.
+
 Shutdown safety nets (issue #186):
 
 * `dcc_mcp_maya._shutdown_safety.ShutdownCoordinator` — composes four independent safety nets so non-cooperative Maya exits stop leaking `FileRegistry` rows: `MSceneMessage.kMayaExiting` hook, `atexit` fallback, crash-resilient process sentinel (OS drops on `kill -9`), opt-in defensive `__del__` guard.  Auto-installed from the Maya plugin's `initializePlugin` after `_start()`; torn down in `uninitializePlugin`.
@@ -193,6 +199,7 @@ Tool naming: `{skill_name.replace("-","_")}__{script_stem}` (e.g. `maya_scene__n
 | `DCC_MCP_REGISTRY_DIR` | OS temp | Shared discovery registry |
 | `DCC_MCP_MAYA_HOT_RELOAD` | `0` | `1`=watch skills for disk changes |
 | `DCC_MCP_MAYA_DEV_ROOTS` | — | Optional path-list of trusted roots for `maya-dev` project attachment |
+| `DCC_MCP_MAYA_AUTO_DISMISS_CRASH_DIALOG` | `0` | `1`=best-effort dismiss detected Maya Qt recovery dialogs after `affinity: main` tool calls |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | `1`/`true`/`yes`/`on` — refuse `execute_python` (skills-first enforcement) |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_MEL` | `0` | Same tokens — refuse `execute_mel` only |
 | `DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT` | `0` | Same tokens — refuse **both** `execute_python` and `execute_mel` |
@@ -206,6 +213,7 @@ Tool naming: `{skill_name.replace("-","_")}__{script_stem}` (e.g. `maya_scene__n
 | `src/dcc_mcp_maya/server.py` | `MayaMcpServer`, builtin skill discovery, metrics, jobs |
 | `src/dcc_mcp_maya/dispatcher/` | Thread-affinity dispatchers + cancellation (directory module) |
 | `src/dcc_mcp_maya/api.py` | Skill authoring helpers (18 symbols) |
+| `src/dcc_mcp_maya/_recovery_dialog.py` | Qt-level crash/recovery dialog detector + status surfacing |
 | `src/dcc_mcp_maya/plugin.py` | Maya plugin entry point |
 | `src/dcc_mcp_maya/skills/` | 24 built-in skill packages (177 typed tool declarations) |
 | `docs/` | VitePress docs (EN + ZH) |

--- a/src/dcc_mcp_maya/__init__.py
+++ b/src/dcc_mcp_maya/__init__.py
@@ -56,6 +56,12 @@ from dcc_mcp_maya._readiness import (
     install_readiness,
     resolve_readiness_timeout_secs,
 )
+from dcc_mcp_maya._recovery_dialog import (
+    ENV_AUTO_DISMISS_CRASH_DIALOG,
+    clear_recovery_status,
+    current_recovery_status,
+    scan_recovery_dialog,
+)
 from dcc_mcp_maya._resources import (
     DEFAULT_SCENE_EVENTS,
     DEFAULT_SCENE_THROTTLE_SECS,
@@ -268,6 +274,11 @@ __all__ = [
     "ReadinessBinder",
     "install_readiness",
     "resolve_readiness_timeout_secs",
+    # Qt-level recovery dialog detector (issue #241)
+    "ENV_AUTO_DISMISS_CRASH_DIALOG",
+    "scan_recovery_dialog",
+    "current_recovery_status",
+    "clear_recovery_status",
     # Shutdown safety nets (issue #186)
     "ENV_KMAYA_EXITING_HOOK",
     "ENV_ATEXIT_HOOK",

--- a/src/dcc_mcp_maya/_executor.py
+++ b/src/dcc_mcp_maya/_executor.py
@@ -54,7 +54,7 @@ from typing import Any, Dict, Iterator
 from dcc_mcp_core.skill import skill_error, skill_exception
 
 # Import local modules
-from dcc_mcp_maya import _affinity
+from dcc_mcp_maya import _affinity, _recovery_dialog
 from dcc_mcp_maya._cmds_file_guard import guard_cmds_file
 
 logger = logging.getLogger(__name__)
@@ -105,6 +105,11 @@ def run_skill_script(script_path: str, params: Dict[str, Any]) -> Dict[str, Any]
     with _busy_scope():
         with guard_cmds_file():
             return _run_skill_script_untracked(script_path, params)
+
+
+def _run_main_affinity_skill_script(script_path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Run a main-thread skill and poll Qt recovery dialogs before returning."""
+    return _recovery_dialog.poll_and_annotate_result(run_skill_script(script_path, params))
 
 
 def _run_skill_script_untracked(script_path: str, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -207,7 +212,7 @@ def _run_via_main_thread_queue(script_path: str, params: Dict[str, Any], action_
     # pump thread on first ``submit``).
     from dcc_mcp_maya import _main_thread_queue  # noqa: PLC0415
 
-    fut = _main_thread_queue.get_queue().submit(lambda: run_skill_script(script_path, params))
+    fut = _main_thread_queue.get_queue().submit(lambda: _run_main_affinity_skill_script(script_path, params))
     try:
         return fut.result()
     except _main_thread_queue.QueueFullError as exc:
@@ -268,7 +273,7 @@ def execute_in_process(
     #    queue would deadlock waiting for ourselves. This is the common
     #    case in mayapy / pytest where the HTTP worker IS the main thread.
     if _on_main_thread():
-        return run_skill_script(script_path, params)
+        return _run_main_affinity_skill_script(script_path, params)
 
     # 3. Preferred path: dispatcher (cancellation token, job context).
     dispatcher = getattr(server_obj, "_maya_dispatcher", None)
@@ -279,7 +284,7 @@ def execute_in_process(
         try:
             result = dispatcher.submit_callable(
                 action_name,
-                lambda: run_skill_script(script_path, params),
+                lambda: _run_main_affinity_skill_script(script_path, params),
                 affinity="main",
             )
         except BaseException as exc:  # noqa: BLE001 — relay everything

--- a/src/dcc_mcp_maya/_recovery_dialog.py
+++ b/src/dcc_mcp_maya/_recovery_dialog.py
@@ -1,0 +1,331 @@
+"""Qt-level Maya recovery dialog detection (issue #241).
+
+Maya can raise its own C++/Qt crash-recovery reporter without going through
+``maya.cmds``. The MCP server may keep answering while the artist's UI is
+blocked behind that modal dialog. This module is intentionally tiny and
+best-effort: poll top-level Qt widgets, optionally dismiss a matching reporter,
+and surface a durable status flag to agents.
+"""
+
+from __future__ import annotations
+
+# Import built-in modules
+import copy
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+ENV_AUTO_DISMISS_CRASH_DIALOG = "DCC_MCP_MAYA_AUTO_DISMISS_CRASH_DIALOG"
+
+_STATUS_DETECTED = "recovery_dialog_detected"
+_STATUS_RECOVERED = "recovered"
+
+_BUTTON_MARKERS = (
+    "ok",
+    "close",
+    "dismiss",
+    "reopen",
+    "continue",
+    "确定",
+    "关闭",
+    "重新打开",
+    "继续",
+)
+
+_state_lock = threading.RLock()
+_last_event: Optional[Dict[str, Any]] = None
+
+
+def resolve_auto_dismiss(flag: Optional[bool] = None) -> bool:
+    """Resolve the opt-in automatic dialog dismissal flag."""
+    if flag is not None:
+        return bool(flag)
+    return os.environ.get(ENV_AUTO_DISMISS_CRASH_DIALOG, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def scan_recovery_dialog(
+    qt_widgets: Optional[Any] = None,
+    auto_dismiss: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Scan Qt top-level windows for Maya's recovery/crash reporter dialog.
+
+    The optional ``qt_widgets`` parameter exists for tests; production calls
+    lazily import PySide/PyQt from Maya.
+    """
+    event = _scan_recovery_dialog(qt_widgets=qt_widgets, auto_dismiss=auto_dismiss)
+    if event.get("detected") or event.get("status") == _STATUS_RECOVERED:
+        _record_event(event)
+    return event
+
+
+def current_recovery_status() -> Dict[str, Any]:
+    """Return the latest Maya recovery status fields for result contexts."""
+    with _state_lock:
+        if not _last_event:
+            return {}
+        event = copy.deepcopy(_last_event)
+
+    return {
+        "maya_recovered": True,
+        "maya_status": event.get("status") or _STATUS_DETECTED,
+        "maya_recovery_dialog": event,
+    }
+
+
+def clear_recovery_status() -> None:
+    """Clear the remembered recovery status."""
+    global _last_event
+    with _state_lock:
+        _last_event = None
+
+
+def poll_and_annotate_result(
+    result: Dict[str, Any],
+    qt_widgets: Optional[Any] = None,
+    auto_dismiss: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Poll for a recovery dialog and annotate a skill result envelope."""
+    try:
+        scan_recovery_dialog(qt_widgets=qt_widgets, auto_dismiss=auto_dismiss)
+        fields = current_recovery_status()
+    except Exception as exc:  # noqa: BLE001 — detector must never break tools
+        logger.debug("Maya recovery-dialog poll skipped: %s", exc)
+        return result
+
+    if not fields or not isinstance(result, dict):
+        return result
+
+    out = dict(result)
+    context = out.get("context")
+    if not isinstance(context, dict):
+        context = {}
+    else:
+        context = dict(context)
+    context.update(fields)
+    out["context"] = context
+    return out
+
+
+def current_context_fields() -> Dict[str, Any]:
+    """Return fields safe to merge into a Maya context snapshot."""
+    return current_recovery_status()
+
+
+def reset_for_tests() -> None:
+    """Reset module state for unit tests."""
+    clear_recovery_status()
+
+
+def _scan_recovery_dialog(
+    qt_widgets: Optional[Any] = None,
+    auto_dismiss: Optional[bool] = None,
+) -> Dict[str, Any]:
+    widgets_api = qt_widgets if qt_widgets is not None else _import_qt_widgets()
+    if widgets_api is None:
+        return _no_dialog_event()
+
+    should_dismiss = resolve_auto_dismiss(auto_dismiss)
+    for widget in _iter_top_level_widgets(widgets_api):
+        if not _is_visible(widget):
+            continue
+        title = _call_text(widget, "windowTitle")
+        if not _matches_recovery_title(title):
+            continue
+
+        dismissed = False
+        dismissal_attempted = should_dismiss
+        if should_dismiss:
+            dismissed = _dismiss_widget(widget, widgets_api)
+
+        status = _STATUS_RECOVERED if dismissed else _STATUS_DETECTED
+        event = {
+            "detected": True,
+            "active": not dismissed,
+            "dismissed": dismissed,
+            "dismissal_attempted": dismissal_attempted,
+            "status": status,
+            "title": title,
+            "source": "qt_top_level_window",
+            "timestamp": time.time(),
+        }
+        logger.warning(
+            "Detected Maya recovery dialog%s: %s",
+            " and dismissed it" if dismissed else "",
+            title,
+        )
+        return event
+
+    return _mark_recovered_if_previous_dialog_cleared()
+
+
+def _record_event(event: Dict[str, Any]) -> None:
+    global _last_event
+    with _state_lock:
+        _last_event = copy.deepcopy(event)
+
+
+def _no_dialog_event() -> Dict[str, Any]:
+    return {
+        "detected": False,
+        "active": False,
+        "dismissed": False,
+        "dismissal_attempted": False,
+        "status": "ok",
+        "source": "qt_top_level_window",
+        "timestamp": time.time(),
+    }
+
+
+def _mark_recovered_if_previous_dialog_cleared() -> Dict[str, Any]:
+    with _state_lock:
+        previous = copy.deepcopy(_last_event)
+    if previous and previous.get("active"):
+        previous["detected"] = False
+        previous["active"] = False
+        previous["dismissed"] = bool(previous.get("dismissed"))
+        previous["status"] = _STATUS_RECOVERED
+        previous["timestamp"] = time.time()
+        return previous
+    return _no_dialog_event()
+
+
+def _import_qt_widgets() -> Optional[Any]:
+    for module_name in ("PySide6.QtWidgets", "PySide2.QtWidgets", "PySide.QtGui"):
+        try:
+            module = __import__(module_name, fromlist=["dummy"])
+            return module
+        except Exception:  # noqa: BLE001
+            continue
+    return None
+
+
+def _iter_top_level_widgets(qt_widgets: Any) -> Iterable[Any]:
+    if isinstance(qt_widgets, (list, tuple)):
+        return list(qt_widgets)
+
+    app_cls = getattr(qt_widgets, "QApplication", None)
+    if app_cls is None:
+        return []
+
+    widgets = _call(app_cls, "topLevelWidgets")
+    if widgets is None:
+        instance = _call(app_cls, "instance")
+        widgets = _call(instance, "topLevelWidgets") if instance is not None else None
+    if widgets is None:
+        return []
+    try:
+        return list(widgets)
+    except TypeError:
+        return []
+
+
+def _matches_recovery_title(title: str) -> bool:
+    if not title:
+        return False
+
+    lower = title.strip().lower()
+    if "stopped working" in lower or "has stopped working" in lower:
+        return True
+    if "recover" in lower and any(marker in lower for marker in ("maya", "file", "crash", "report")):
+        return True
+    if "crash" in lower and any(marker in lower for marker in ("maya", "report", "recovery")):
+        return True
+
+    return any(marker in title for marker in ("已停止工作", "正在恢复", "恢复文件"))
+
+
+def _dismiss_widget(widget: Any, qt_widgets: Any) -> bool:
+    for button in _iter_buttons(widget, qt_widgets):
+        label = _call_text(button, "text").strip().lower()
+        if not label or not any(marker in label for marker in _BUTTON_MARKERS):
+            continue
+        if _invoke(button, "click"):
+            return True
+
+    if _invoke(widget, "accept"):
+        return True
+    return _invoke(widget, "close")
+
+
+def _iter_buttons(widget: Any, qt_widgets: Any) -> List[Any]:
+    find_children = getattr(widget, "findChildren", None)
+    if find_children is None:
+        return []
+
+    classes = []
+    button_cls = getattr(qt_widgets, "QAbstractButton", None)
+    if button_cls is not None:
+        classes.append(button_cls)
+    classes.append(object)
+
+    seen = set()
+    buttons: List[Any] = []
+    for cls in classes:
+        try:
+            children = find_children(cls)
+        except TypeError:
+            try:
+                children = find_children()
+            except Exception:  # noqa: BLE001
+                continue
+        except Exception:  # noqa: BLE001
+            continue
+        for child in children or []:
+            ident = id(child)
+            if ident in seen:
+                continue
+            seen.add(ident)
+            if hasattr(child, "text") and hasattr(child, "click"):
+                buttons.append(child)
+    return buttons
+
+
+def _is_visible(widget: Any) -> bool:
+    value = _call(widget, "isVisible")
+    return True if value is None else bool(value)
+
+
+def _call_text(obj: Any, method_name: str) -> str:
+    value = _call(obj, method_name)
+    return "" if value is None else str(value)
+
+
+def _call(obj: Any, method_name: str, *args: Any) -> Any:
+    if obj is None:
+        return None
+    method = getattr(obj, method_name, None)
+    if method is None:
+        return None
+    try:
+        return method(*args)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _invoke(obj: Any, method_name: str, *args: Any) -> bool:
+    if obj is None:
+        return False
+    method = getattr(obj, method_name, None)
+    if method is None:
+        return False
+    try:
+        method(*args)
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+__all__ = [
+    "ENV_AUTO_DISMISS_CRASH_DIALOG",
+    "clear_recovery_status",
+    "current_context_fields",
+    "current_recovery_status",
+    "poll_and_annotate_result",
+    "reset_for_tests",
+    "resolve_auto_dismiss",
+    "scan_recovery_dialog",
+]

--- a/src/dcc_mcp_maya/context_snapshot.py
+++ b/src/dcc_mcp_maya/context_snapshot.py
@@ -119,6 +119,7 @@ class MayaContextSnapshotProvider:
 
         cmds = self._safe_cmds()
         if cmds is None:
+            _attach_recovery_status(snapshot)
             return snapshot
 
         snapshot["available"] = True
@@ -171,6 +172,7 @@ class MayaContextSnapshotProvider:
         if display:
             snapshot["display_name"] = display
 
+        _attach_recovery_status(snapshot)
         return snapshot
 
     # ------------------------------------------------------------ internals
@@ -262,6 +264,16 @@ def _safe_call(cmds: Any, name: str, *args: Any, **kwargs: Any) -> Any:
     except Exception as exc:  # noqa: BLE001 — Maya raises RuntimeError often
         logger.debug("MayaContextSnapshot: cmds.%s raised %s", name, exc)
         return None
+
+
+def _attach_recovery_status(snapshot: Dict[str, Any]) -> None:
+    """Merge the latest Qt recovery-dialog status into a snapshot if present."""
+    try:
+        from dcc_mcp_maya import _recovery_dialog  # noqa: PLC0415
+
+        snapshot.update(_recovery_dialog.current_context_fields())
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("MayaContextSnapshotProvider: recovery status unavailable: %s", exc)
 
 
 def _derive_display_name(scene: Optional[str], version: Optional[str]) -> Optional[str]:

--- a/tests/test_context_snapshot.py
+++ b/tests/test_context_snapshot.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from dcc_mcp_maya import _recovery_dialog
 from dcc_mcp_maya.context_snapshot import (
     MayaContextSnapshotProvider,
     collect_gateway_metadata,
@@ -21,6 +22,13 @@ from dcc_mcp_maya.context_snapshot import (
 # ---------------------------------------------------------------------------
 # Fake ``cmds`` factory
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_recovery_dialog_state():
+    _recovery_dialog.reset_for_tests()
+    yield
+    _recovery_dialog.reset_for_tests()
 
 
 def _fake_cmds(**overrides):
@@ -120,6 +128,25 @@ def test_provider_returns_fresh_dict_each_call():
     # Mutating one must not affect the other.
     snap1["selection"].append("extra")
     assert snap2["selection"] == ["a"]
+
+
+def test_provider_includes_recovery_dialog_status_when_present():
+    widget = type(
+        "Widget",
+        (),
+        {
+            "windowTitle": lambda self: "Maya has stopped working",
+            "isVisible": lambda self: True,
+        },
+    )()
+    _recovery_dialog.scan_recovery_dialog(qt_widgets=[widget], auto_dismiss=False)
+
+    provider = MayaContextSnapshotProvider(cmds_provider=lambda: _fake_cmds())
+    snap = provider()
+
+    assert snap["maya_recovered"] is True
+    assert snap["maya_status"] == "recovery_dialog_detected"
+    assert snap["maya_recovery_dialog"]["title"] == "Maya has stopped working"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_executor_affinity_safety_net.py
+++ b/tests/test_executor_affinity_safety_net.py
@@ -43,7 +43,9 @@ from dcc_mcp_maya import _affinity, _executor, _main_thread_queue
 @pytest.fixture(autouse=True)
 def _reset_queue_singleton():
     _main_thread_queue.reset_for_tests()
+    _executor._recovery_dialog.reset_for_tests()
     yield
+    _executor._recovery_dialog.reset_for_tests()
     _main_thread_queue.reset_for_tests()
 
 
@@ -80,6 +82,19 @@ class TestAffinityAnyAlwaysInline:
         dispatcher.submit_callable.assert_not_called()
         # And must NOT touch the queue either.
         assert _main_thread_queue.get_queue().status()["submitted"] == 0
+
+    def test_skips_recovery_dialog_poll(self, fake_script, monkeypatch):
+        monkeypatch.setattr(_affinity, "resolve_affinity", lambda _p: "any")
+        monkeypatch.setattr(_executor, "_on_main_thread", lambda: False)
+
+        def fail_poll(_result):
+            raise AssertionError("affinity:any must not poll Qt dialogs")
+
+        monkeypatch.setattr(_executor._recovery_dialog, "poll_and_annotate_result", fail_poll)
+
+        out = _executor.execute_in_process(MagicMock(spec=[]), fake_script, {}, "fake__main")
+
+        assert out["success"] is True
 
 
 class TestAffinityMainOnMainThreadInline:
@@ -125,6 +140,35 @@ class TestAffinityMainOffMainWithDispatcher:
         assert captured["request_id"] == "fake__main"
         # Safety-net queue must NOT have been touched when dispatcher is healthy.
         assert _main_thread_queue.get_queue().status()["submitted"] == 0
+
+    def test_dispatcher_path_polls_recovery_dialog_inside_callable(self, fake_script, monkeypatch):
+        monkeypatch.setattr(_affinity, "resolve_affinity", lambda _p: "main")
+        monkeypatch.setattr(_executor, "_on_main_thread", lambda: False)
+
+        calls = []
+
+        def fake_poll(result):
+            calls.append(result)
+            out = dict(result)
+            context = dict(out.get("context") or {})
+            context["maya_status"] = "recovery_dialog_detected"
+            out["context"] = context
+            return out
+
+        def fake_submit_callable(_request_id: str, task, affinity: str = "main", **_kw):
+            assert affinity == "main"
+            return {"success": True, "output": task()}
+
+        monkeypatch.setattr(_executor._recovery_dialog, "poll_and_annotate_result", fake_poll)
+        dispatcher = MagicMock()
+        dispatcher.submit_callable = fake_submit_callable
+        server = MagicMock(_maya_dispatcher=dispatcher)
+
+        out = _executor.execute_in_process(server, fake_script, {}, "fake__main")
+
+        assert len(calls) == 1
+        assert out["success"] is True
+        assert out["context"]["maya_status"] == "recovery_dialog_detected"
 
     def test_dispatcher_exception_becomes_structured_envelope(self, fake_script, monkeypatch):
         monkeypatch.setattr(_affinity, "resolve_affinity", lambda _p: "main")

--- a/tests/test_recovery_dialog.py
+++ b/tests/test_recovery_dialog.py
@@ -1,0 +1,133 @@
+"""Tests for Qt-level Maya recovery dialog detection (issue #241)."""
+
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_maya import _recovery_dialog
+
+
+class _FakeButton:
+    def __init__(self, text: str) -> None:
+        self._text = text
+        self.clicked = 0
+
+    def text(self) -> str:
+        return self._text
+
+    def click(self) -> None:
+        self.clicked += 1
+
+
+class _FakeWidget:
+    def __init__(self, title: str, visible: bool = True, buttons=None) -> None:
+        self._title = title
+        self._visible = visible
+        self._buttons = list(buttons or [])
+        self.accepted = False
+        self.closed = False
+
+    def windowTitle(self) -> str:
+        return self._title
+
+    def isVisible(self) -> bool:
+        return self._visible
+
+    def findChildren(self, _cls=object):
+        return list(self._buttons)
+
+    def accept(self) -> None:
+        self.accepted = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def setup_function() -> None:
+    _recovery_dialog.reset_for_tests()
+
+
+def teardown_function() -> None:
+    _recovery_dialog.reset_for_tests()
+
+
+def test_scan_detects_visible_english_recovery_dialog() -> None:
+    widget = _FakeWidget("Maya has stopped working - recovering your file")
+
+    event = _recovery_dialog.scan_recovery_dialog(qt_widgets=[widget], auto_dismiss=False)
+
+    assert event["detected"] is True
+    assert event["active"] is True
+    assert event["status"] == "recovery_dialog_detected"
+    status = _recovery_dialog.current_recovery_status()
+    assert status["maya_recovered"] is True
+    assert status["maya_status"] == "recovery_dialog_detected"
+    assert status["maya_recovery_dialog"]["title"] == "Maya has stopped working - recovering your file"
+
+
+def test_scan_detects_visible_chinese_recovery_dialog() -> None:
+    widget = _FakeWidget("Maya 已停止工作 - 正在恢复文件")
+
+    event = _recovery_dialog.scan_recovery_dialog(qt_widgets=[widget], auto_dismiss=False)
+
+    assert event["detected"] is True
+    assert event["title"] == "Maya 已停止工作 - 正在恢复文件"
+
+
+def test_scan_ignores_hidden_or_unrelated_windows() -> None:
+    hidden = _FakeWidget("Maya has stopped working", visible=False)
+    unrelated = _FakeWidget("Maya Preferences")
+
+    event = _recovery_dialog.scan_recovery_dialog(qt_widgets=[hidden, unrelated], auto_dismiss=False)
+
+    assert event["detected"] is False
+    assert event["status"] == "ok"
+    assert _recovery_dialog.current_recovery_status() == {}
+
+
+def test_auto_dismiss_clicks_matching_dialog_button(monkeypatch) -> None:
+    monkeypatch.setenv(_recovery_dialog.ENV_AUTO_DISMISS_CRASH_DIALOG, "1")
+    button = _FakeButton("Reopen")
+    widget = _FakeWidget("Maya crash recovery", buttons=[button])
+
+    event = _recovery_dialog.scan_recovery_dialog(qt_widgets=[widget])
+
+    assert event["detected"] is True
+    assert event["dismissal_attempted"] is True
+    assert event["dismissed"] is True
+    assert event["active"] is False
+    assert event["status"] == "recovered"
+    assert button.clicked == 1
+
+
+def test_auto_dismiss_falls_back_to_accept_when_button_missing() -> None:
+    widget = _FakeWidget("Maya has stopped working")
+
+    event = _recovery_dialog.scan_recovery_dialog(qt_widgets=[widget], auto_dismiss=True)
+
+    assert event["dismissed"] is True
+    assert widget.accepted is True
+
+
+def test_next_poll_marks_previous_active_dialog_recovered_when_cleared() -> None:
+    widget = _FakeWidget("Maya has stopped working")
+    _recovery_dialog.scan_recovery_dialog(qt_widgets=[widget], auto_dismiss=False)
+
+    event = _recovery_dialog.scan_recovery_dialog(qt_widgets=[], auto_dismiss=False)
+
+    assert event["detected"] is False
+    assert event["active"] is False
+    assert event["status"] == "recovered"
+    assert _recovery_dialog.current_recovery_status()["maya_status"] == "recovered"
+
+
+def test_poll_and_annotate_result_adds_recovery_context() -> None:
+    widget = _FakeWidget("Maya has stopped working")
+    result = {"success": True, "message": "ok", "context": {"existing": "kept"}}
+
+    out = _recovery_dialog.poll_and_annotate_result(result, qt_widgets=[widget], auto_dismiss=False)
+
+    assert out is not result
+    assert out["context"]["existing"] == "kept"
+    assert out["context"]["maya_recovered"] is True
+    assert out["context"]["maya_status"] == "recovery_dialog_detected"
+    assert out["context"]["maya_recovery_dialog"]["active"] is True


### PR DESCRIPTION
## Summary
- add a Qt top-level recovery dialog detector for Maya crash/recovery reporter windows
- poll after `affinity: main` skill actions and surface `maya_recovered`, `maya_status`, and `maya_recovery_dialog` in tool contexts
- include recovery status in Maya context snapshots / `scene://current`
- document `DCC_MCP_MAYA_AUTO_DISMISS_CRASH_DIALOG` and refresh core reference docs to `0.17.20`

Fixes #241

## Tests
- `uv run pytest tests/test_recovery_dialog.py tests/test_context_snapshot.py tests/test_executor_affinity_safety_net.py -q`
- `uv run ruff check src/dcc_mcp_maya/_recovery_dialog.py src/dcc_mcp_maya/_executor.py src/dcc_mcp_maya/context_snapshot.py src/dcc_mcp_maya/__init__.py tests/test_recovery_dialog.py tests/test_context_snapshot.py tests/test_executor_affinity_safety_net.py`
- `uv run ruff format --check src/dcc_mcp_maya/_recovery_dialog.py src/dcc_mcp_maya/_executor.py src/dcc_mcp_maya/context_snapshot.py src/dcc_mcp_maya/__init__.py tests/test_recovery_dialog.py tests/test_context_snapshot.py tests/test_executor_affinity_safety_net.py`
- `uv run pytest -q`