### PR TITLE
docs: document rez skill paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,7 +371,7 @@ All other skills appear as `__skill__<name>` stubs (default behavior). Call `loa
 |----------|---------|---------|
 | `DCC_MCP_MAYA_PORT` | `8765` | TCP port for MCP HTTP server. |
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | Name in MCP `initialize` response. |
-| `DCC_MCP_MAYA_SKILL_PATHS` | — | Extra skill directories (`;` on Windows, `:` on Unix). |
+| `DCC_MCP_MAYA_SKILL_PATHS` | — | Maya skill search roots (`;` on Windows, `:` on Unix); Rez packages usually append `{root}/skills` whose children are skill packages. |
 | `DCC_MCP_MINIMAL` | `1` | `0` = full mode; `1` = minimal mode. |
 | `DCC_MCP_DEFAULT_TOOLS` | — | Comma-separated skill names to load at startup (overrides minimal). |
 | `DCC_MCP_MAYA_METRICS` | `0` | `1` = enable Prometheus `/metrics` endpoint. |

--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ Useful plugin defaults:
 |---|---|---|
 | `DCC_MCP_MAYA_PORT` | `8765` direct, `0` plugin | TCP port for the in-process Maya server. Plugin mode uses an OS-assigned instance port by default. |
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | Name shown in MCP `initialize`. |
-| `DCC_MCP_MAYA_SKILL_PATHS` | none | Extra Maya skill directories (`;` on Windows, `:` on Unix). |
-| `DCC_MCP_SKILL_PATHS` | none | Global fallback skill directories for all DCC adapters. |
+| `DCC_MCP_MAYA_SKILL_PATHS` | none | Maya-specific skill search roots (`;` on Windows, `:` on Unix); each root can be a single skill package or contain child skill packages. |
+| `DCC_MCP_SKILL_PATHS` | none | Global fallback skill search roots for all DCC adapters. |
 | `DCC_MCP_MINIMAL` | `1` | `0` loads the full tool surface at startup. |
 | `DCC_MCP_DEFAULT_TOOLS` | none | Comma-separated skill names to load at startup. |
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Hide `__skill__*` / `__group__*` stubs from large `tools/list` syncs. |
@@ -229,6 +229,39 @@ Useful plugin defaults:
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | Refuse `execute_python`. |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_MEL` | `0` | Refuse `execute_mel`. |
 | `DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT` | `0` | Refuse both arbitrary Python and MEL execution. |
+
+### Studio Skill Paths and Rez
+
+`DCC_MCP_MAYA_SKILL_PATHS` is read during server registration/startup and is
+split with the platform path separator (`;` on Windows, `:` on Linux/macOS).
+Each entry is a skill search root. The scanner accepts either a single skill
+package directly or a directory whose immediate children are skill packages:
+
+```text
+studio_maya_skills/
+└── skills/
+    ├── lightbox-maya-dev/
+    │   ├── SKILL.md
+    │   ├── tools.yaml
+    │   └── scripts/
+    └── shot-publish/
+        ├── SKILL.md
+        └── scripts/
+```
+
+Rez packages should append the `skills` root in `package.py`:
+
+```python
+def commands():
+    env.DCC_MCP_MAYA_SKILL_PATHS.append("{root}/skills")
+```
+
+`load_skill("lightbox-maya-dev")`, `search_skills`, the gateway `/v1/search`,
+and `dcc_capability_manifest` operate on the skills discovered at registration
+time. If a Rez context or environment variable changes after Maya has started,
+restart/reload the plugin or start the server again so the adapter rescans the
+new roots; `load_skill` activates an already discovered skill, but it does not
+rescan newly added environment paths.
 
 ## Authoring Skills
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -85,13 +85,43 @@ print(handle.mcp_url())   # http://127.0.0.1:8765/mcp
 |---|---|---|
 | `DCC_MCP_MAYA_PORT` | `8765` | MCP 服务器的 TCP 端口 |
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | MCP initialize 中显示的名称 |
-| `DCC_MCP_MAYA_SKILL_PATHS` | _(无)_ | 额外的技能目录（Windows 用分号分隔，Unix 用冒号） |
-| `DCC_MCP_SKILL_PATHS` | _(无)_ | 所有 DCC 适配器的全局回退技能目录 |
+| `DCC_MCP_MAYA_SKILL_PATHS` | _(无)_ | Maya 专用 skill 搜索根目录（Windows 用分号分隔，Unix 用冒号）；每个根目录可以是单个 skill 包，也可以包含多个子 skill 包 |
+| `DCC_MCP_SKILL_PATHS` | _(无)_ | 所有 DCC 适配器的全局回退 skill 搜索根目录 |
 | `DCC_MCP_MINIMAL` | `1` | `0` = full mode；`1` = minimal mode |
 | `DCC_MCP_DEFAULT_TOOLS` | _(无)_ | 启动时加载的逗号分隔技能名称（覆盖最小默认） |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | `1`/`true`/`yes`/`on` — 拒绝 `execute_python`（强制技能优先） |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_MEL` | `0` | 同上真值 — 仅拒绝 `execute_mel` |
 | `DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT` | `0` | 同上真值 — 同时拒绝 `execute_python` 与 `execute_mel` |
+
+### Studio Skill 路径与 Rez
+
+`DCC_MCP_MAYA_SKILL_PATHS` 会在服务器注册/启动时读取，并按平台路径分隔符切分
+（Windows 为 `;`，Linux/macOS 为 `:`）。每一项都是一个 skill 搜索根目录：
+它可以直接是单个 skill 包，也可以是多个子 skill 包的父目录：
+
+```text
+studio_maya_skills/
+└── skills/
+    ├── lightbox-maya-dev/
+    │   ├── SKILL.md
+    │   ├── tools.yaml
+    │   └── scripts/
+    └── shot-publish/
+        ├── SKILL.md
+        └── scripts/
+```
+
+Rez 包可以在 `package.py` 的 `commands()` 中追加 `skills` 根目录：
+
+```python
+def commands():
+    env.DCC_MCP_MAYA_SKILL_PATHS.append("{root}/skills")
+```
+
+`load_skill("lightbox-maya-dev")`、`search_skills`、gateway `/v1/search` 与
+`dcc_capability_manifest` 都基于注册时发现的 skill 集合工作。Maya 启动后如果
+Rez context 或环境变量发生变化，需要重启/重载插件或重新启动 server 让适配器重新扫描；
+`load_skill` 只会激活已发现的 skill，不会重新扫描新加入的环境路径。
 
 ### 渐进式加载（最小模式）
 

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -194,8 +194,8 @@ Returned by `server.start()` and `start_server()`.
 |----------|---------|-------------|
 | `DCC_MCP_MAYA_PORT` | `8765` | Default TCP port when you start the singleton server directly |
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | Default server name |
-| `DCC_MCP_MAYA_SKILL_PATHS` | — | Maya-specific skill directories (`;`-separated) |
-| `DCC_MCP_SKILL_PATHS` | — | Global fallback skill directories |
+| `DCC_MCP_MAYA_SKILL_PATHS` | — | Maya-specific skill search roots (`;` on Windows, `:` on Unix); each root may be one skill package or a parent of skill packages |
+| `DCC_MCP_SKILL_PATHS` | — | Global fallback skill search roots |
 | `DCC_MCP_MAYA_HOT_RELOAD` | `0` | Enable skill hot-reload when set to `1` |
 | `DCC_MCP_MAYA_METRICS` | `0` | Enable Prometheus `/metrics` endpoint when set to `1` |
 | `DCC_MCP_MAYA_JOB_STORAGE` | `<data_dir>/jobs.db` | SQLite job persistence database path |

--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -95,6 +95,35 @@ set DCC_MCP_MAYA_SKILL_PATHS=C:\studio\maya-skills;C:\personal\skills
 export DCC_MCP_MAYA_SKILL_PATHS=/studio/maya-skills:/personal/skills
 ```
 
+### Rez-Shipped Studio Skills
+
+A skill path is a search root. The root may be a single skill package with
+`SKILL.md` directly inside it, or a directory whose immediate children are skill
+packages. For Rez bundles, ship skills under a stable `skills/` directory:
+
+```text
+studio_maya_dev_skills/
+└── skills/
+    └── lightbox-maya-dev/
+        ├── SKILL.md
+        ├── tools.yaml
+        └── scripts/
+```
+
+Then append that directory in `package.py`:
+
+```python
+def commands():
+    env.DCC_MCP_MAYA_SKILL_PATHS.append("{root}/skills")
+```
+
+The adapter scans `DCC_MCP_MAYA_SKILL_PATHS` during `register_builtin_actions()`
+or `start_server()`. Gateway search, `dcc_capability_manifest`, `search_skills`,
+and `load_skill` all use that discovered catalog. After changing a Rez context
+or appending a new environment path, restart/reload the Maya plugin or start a
+new server so discovery runs again; `load_skill` only activates a skill already
+found by the startup scan.
+
 ## Main-Thread Scheduling
 
 Maya's UI and `cmds` operations must run on the **main thread**. The plugin entry points and startup helpers are written with that constraint in mind, and any custom code that touches Maya UI state should still be scheduled carefully.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -100,7 +100,7 @@ Or be more specific:
 |----------|---------|-------------|
 | `DCC_MCP_MAYA_PORT` | `8765` | TCP port for the MCP server |
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | Name shown in MCP `initialize` response |
-| `DCC_MCP_MAYA_SKILL_PATHS` | _(empty)_ | Extra skill directories (colon/semicolon separated) |
+| `DCC_MCP_MAYA_SKILL_PATHS` | _(empty)_ | Extra skill search roots (`;` on Windows, `:` on Unix); use a root like `{rez_root}/skills` whose children are skill packages |
 | `DCC_MCP_GATEWAY_PORT` | `9765` in plugin mode | Local gateway URL used by MCP hosts |
 
 ## Stop the Server

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -85,6 +85,12 @@ Paths are resolved in order (highest priority first):
 4. `DCC_MCP_SKILL_PATHS` environment variable
 5. Platform default skills directory
 
+Each environment entry is a skill search root: either the skill package itself
+or a parent directory whose immediate children are skill packages. Rez packages
+typically append `{root}/skills` from `package.py`, then Maya must restart or
+rerun registration for a changed environment to affect gateway search and
+`load_skill`.
+
 ## Next Steps
 
 - [Quick Start](./getting-started) — get Maya talking to Claude Desktop in 5 minutes

--- a/docs/zh/api/server.md
+++ b/docs/zh/api/server.md
@@ -181,8 +181,8 @@ server.stop()
 |------|--------|------|
 | `DCC_MCP_MAYA_PORT` | `8765` | 直接启动单例服务器时的默认 TCP 端口 |
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | 默认服务器名称 |
-| `DCC_MCP_MAYA_SKILL_PATHS` | — | Maya 专用技能目录（`;` 分隔）|
-| `DCC_MCP_SKILL_PATHS` | — | 全局备用技能目录 |
+| `DCC_MCP_MAYA_SKILL_PATHS` | — | Maya 专用 skill 搜索根目录（Windows 用 `;`，Unix 用 `:`）；每个根目录可以是单个 skill 包或多个子 skill 包的父目录 |
+| `DCC_MCP_SKILL_PATHS` | — | 全局回退 skill 搜索根目录 |
 | `DCC_MCP_MAYA_HOT_RELOAD` | `0` | 设为 `1` 时启用 Skill 热重载 |
 | `DCC_MCP_MAYA_METRICS` | `0` | 设为 `1` 时启用 Prometheus `/metrics` |
 | `DCC_MCP_MAYA_JOB_STORAGE` | `<data_dir>/jobs.db` | SQLite job 持久化数据库路径 |

--- a/docs/zh/guide/advanced.md
+++ b/docs/zh/guide/advanced.md
@@ -87,6 +87,34 @@ set DCC_MCP_MAYA_SKILL_PATHS=C:\studio\maya-skills;C:\personal\skills
 export DCC_MCP_MAYA_SKILL_PATHS=/studio/maya-skills:/personal/skills
 ```
 
+### Rez 发布的 Studio Skills
+
+Skill 路径是一个搜索根目录。这个根目录可以直接是包含 `SKILL.md` 的单个
+skill 包，也可以是多个子 skill 包的父目录。Rez bundle 推荐把 skills 放在稳定的
+`skills/` 目录下：
+
+```text
+studio_maya_dev_skills/
+└── skills/
+    └── lightbox-maya-dev/
+        ├── SKILL.md
+        ├── tools.yaml
+        └── scripts/
+```
+
+然后在 `package.py` 中追加该目录：
+
+```python
+def commands():
+    env.DCC_MCP_MAYA_SKILL_PATHS.append("{root}/skills")
+```
+
+适配器会在 `register_builtin_actions()` 或 `start_server()` 期间扫描
+`DCC_MCP_MAYA_SKILL_PATHS`。Gateway search、`dcc_capability_manifest`、
+`search_skills` 与 `load_skill` 都使用这份已发现的 catalog。Rez context 或环境路径
+变更后，请重启/重载 Maya 插件或启动新的 server，让 discovery 重新执行；
+`load_skill` 只会激活启动扫描已发现的 skill。
+
 ## 主线程调度
 
 Maya 的 UI 和 `cmds` 操作必须在**主线程**运行。插件入口和启动辅助函数都围绕这个约束设计；你自己的自定义代码如果涉及 Maya UI 状态，仍然需要谨慎调度。

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -100,7 +100,7 @@ Agent 应先发现工具、加载需要的 skill（例如 `maya-primitives` 和
 |------|--------|------|
 | `DCC_MCP_MAYA_PORT` | `8765` | MCP 服务器 TCP 端口 |
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | MCP `initialize` 响应中显示的名称 |
-| `DCC_MCP_MAYA_SKILL_PATHS` | _(空)_ | 额外 Skill 目录（以冒号/分号分隔） |
+| `DCC_MCP_MAYA_SKILL_PATHS` | _(空)_ | 额外 skill 搜索根目录（Windows 用 `;`，Unix 用 `:`）；Rez 可指向 `{root}/skills`，其子目录是各个 skill 包 |
 | `DCC_MCP_GATEWAY_PORT` | 插件模式为 `9765` | MCP 宿主连接的本机 gateway 端口 |
 
 ## 停止服务器

--- a/docs/zh/guide/index.md
+++ b/docs/zh/guide/index.md
@@ -81,6 +81,10 @@ load_skill("maya-primitives")
 4. `DCC_MCP_SKILL_PATHS` 环境变量（全局回退）
 5. 平台默认 Skill 目录
 
+每个环境变量条目都是一个 skill 搜索根目录：它可以直接是 skill 包，也可以是多个
+子 skill 包的父目录。Rez 包通常在 `package.py` 中追加 `{root}/skills`；环境变化后，
+Maya 需要重启或重新注册，gateway search 与 `load_skill` 才会看到新的路径。
+
 ## 下一步
 
 - [快速开始](./getting-started) — 5 分钟让 Maya 与 Claude Desktop 联通

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -444,8 +444,8 @@ tools:
 |----------|---------|-------|-------------|
 | `DCC_MCP_MAYA_PORT` | `8765` | per-process | TCP port for MCP HTTP server. `0` = OS-assigned. |
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | per-process | Name in MCP `initialize`. |
-| `DCC_MCP_MAYA_SKILL_PATHS` | — | per-process | Extra skill dirs (`;` Win, `:` Unix). |
-| `DCC_MCP_SKILL_PATHS` | — | global fallback | Global skill dirs for all DCC adapters. |
+| `DCC_MCP_MAYA_SKILL_PATHS` | — | per-process | Maya skill search roots (`;` Win, `:` Unix); each root may be one skill package or a parent such as Rez `{root}/skills`. |
+| `DCC_MCP_SKILL_PATHS` | — | global fallback | Global skill search roots for all DCC adapters. |
 | `DCC_MCP_MAYA_DEV_ROOTS` | — | per-process | Optional path-list of trusted roots for `maya-dev` project attachment. |
 | `DCC_MCP_MINIMAL` | `1` | per-process | `0`=full mode; `1`=minimal mode. |
 | `DCC_MCP_DEFAULT_TOOLS` | — | per-process | Comma-separated skill names overriding minimal mode. |

--- a/llms.txt
+++ b/llms.txt
@@ -187,8 +187,8 @@ Tool naming: `{skill_name.replace("-","_")}__{script_stem}` (e.g. `maya_scene__n
 |----------|---------|-------------|
 | `DCC_MCP_MAYA_PORT` | `8765` | TCP port |
 | `DCC_MCP_MAYA_SERVER_NAME` | `maya-mcp` | MCP init name |
-| `DCC_MCP_MAYA_SKILL_PATHS` | — | Extra skill dirs (`;` Win / `:` Unix) |
-| `DCC_MCP_SKILL_PATHS` | — | Global fallback skill dirs |
+| `DCC_MCP_MAYA_SKILL_PATHS` | — | Maya skill search roots (`;` Win / `:` Unix); Rez packages usually append `{root}/skills` |
+| `DCC_MCP_SKILL_PATHS` | — | Global fallback skill search roots |
 | `DCC_MCP_MINIMAL` | `1` | `0`=full mode, `1`=minimal mode |
 | `DCC_MCP_DEFAULT_TOOLS` | — | Comma-separated startup skill list |
 | `DCC_MCP_MAYA_METRICS` | `0` | `1`=Prometheus `/metrics` |

--- a/tests/test_skill_load_integration.py
+++ b/tests/test_skill_load_integration.py
@@ -126,6 +126,24 @@ class TestCustomSkillEndToEnd:
         finally:
             server.stop()
 
+    def test_discover_custom_skill_via_single_package_extra_skill_path(self, tmp_path):
+        """A direct skill package path is a valid ``extra_skill_paths`` entry."""
+        skill = _write_skill(
+            tmp_path,
+            "maya-itest-direct-root",
+            {"ping": "def main(**kwargs):\n    return {'success': True, 'message': 'pong'}\n"},
+        )
+        server = _make_server()
+        try:
+            server.register_builtin_actions(extra_skill_paths=[str(skill)], include_bundled=False, minimal=False)
+            assert server.load_skill(skill.name)
+
+            actions = server._server.registry.list_actions_enabled()
+            names = {a["name"] for a in actions if isinstance(a, dict) and a.get("name")}
+            assert _action_name("maya-itest-direct-root", "ping") in names
+        finally:
+            server.stop()
+
     def test_handler_registered_for_custom_skill(self, tmp_path):
         skill = _write_skill(
             tmp_path,


### PR DESCRIPTION
## Summary
- document `DCC_MCP_MAYA_SKILL_PATHS` as a skill search root list for Rez-shipped studio skills
- add Rez `package.py` examples and layout guidance in EN/ZH docs
- clarify startup scan timing and gateway/search/`load_skill` behavior after env changes
- add a Maya-side regression test for direct skill package paths in `extra_skill_paths`

## Validation
- `python tools/check_doc_parity.py`
- `python -m pytest tests\test_check_doc_parity.py -q`
- `python -m pytest tests\test_skill_load_integration.py -q`
- `python -m ruff check tests\test_skill_load_integration.py`

Closes #287