### PR TITLE
feat: publish maya-dev run check events

### DIFF
--- a/src/dcc_mcp_maya/_dev_session.py
+++ b/src/dcc_mcp_maya/_dev_session.py
@@ -759,7 +759,9 @@ def _publish_run_check_events(
     published = 0
     progress = _append_session_event(
         "progress",
-        "run_check {} for {}".format("completed" if run_success else "failed", run_summary.get("target") or "entrypoint"),
+        "run_check {} for {}".format(
+            "completed" if run_success else "failed", run_summary.get("target") or "entrypoint"
+        ),
         level="info" if run_success else "error",
         metadata=dict(base_metadata, run_summary=run_summary),
         **common,

--- a/src/dcc_mcp_maya/_dev_session.py
+++ b/src/dcc_mcp_maya/_dev_session.py
@@ -43,6 +43,7 @@ ENV_DEV_ROOTS = "DCC_MCP_MAYA_DEV_ROOTS"
 ENV_DEBUGPY_LOG_DIR = "DCC_MCP_MAYA_DEBUGPY_LOG_DIR"
 ENV_DEV_ARTIFACT_DIR = "DCC_MCP_MAYA_DEV_ARTIFACT_DIR"
 DEFAULT_ARTIFACT_THRESHOLD = 4096
+DEFAULT_SESSION_EVENT_INSTANCE_ID = "maya-dev"
 
 _LOCK = threading.RLock()
 _DEBUGPY_STATE: Dict[str, Any] = {
@@ -57,6 +58,12 @@ _UI_STATE: Dict[str, Any] = {
     "session_id": "maya-ui-1",
     "refs": {},
     "seq": 0,
+}
+_SESSION_EVENT_STATE: Dict[str, Any] = {
+    "buffer": None,
+    "instance_id": None,
+    "resource_uri": None,
+    "registered": False,
 }
 
 
@@ -622,6 +629,161 @@ def _write_text_artifact(kind: str, text: str) -> Dict[str, Any]:
     with open(path, "w", encoding="utf-8", errors="replace") as fh:
         fh.write(text)
     return _artifact_payload(safe_kind, path, "text/plain", len(text.encode("utf-8", errors="replace")))
+
+
+def _create_session_event_buffer(instance_id: str) -> Optional[Any]:
+    """Create core's bounded runtime-event buffer when the API exists."""
+    try:
+        from dcc_mcp_core import SessionEventBuffer  # noqa: PLC0415
+    except Exception:
+        return None
+    try:
+        return SessionEventBuffer(instance_id)
+    except Exception:
+        return None
+
+
+def _get_or_create_session_event_buffer(instance_id: Optional[str] = None) -> Optional[Any]:
+    with _LOCK:
+        existing = _SESSION_EVENT_STATE.get("buffer")
+        if instance_id is None and existing is not None:
+            return existing
+        resolved = str(instance_id or _SESSION_EVENT_STATE.get("instance_id") or DEFAULT_SESSION_EVENT_INSTANCE_ID)
+        if existing is not None and _SESSION_EVENT_STATE.get("instance_id") == resolved:
+            return existing
+        buffer = _create_session_event_buffer(resolved)
+        _SESSION_EVENT_STATE.update(
+            {
+                "buffer": buffer,
+                "instance_id": resolved if buffer is not None else None,
+                "resource_uri": getattr(buffer, "resource_uri", None) if buffer is not None else None,
+                "registered": False,
+            }
+        )
+        return buffer
+
+
+def get_session_event_buffer(instance_id: Optional[str] = None) -> Optional[Any]:
+    """Return the maya-dev runtime-event buffer, if supported by installed core."""
+    return _get_or_create_session_event_buffer(instance_id)
+
+
+def register_session_event_buffer(resources_handle: Any, instance_id: Optional[str] = None) -> Dict[str, Any]:
+    """Register maya-dev's session event buffer as ``events://session/*``.
+
+    This is intentionally best-effort so older core builds keep the inline
+    result behavior that ``maya-dev`` had before runtime event buffers existed.
+    """
+    buffer = _get_or_create_session_event_buffer(instance_id)
+    if buffer is None:
+        return _session_event_context(published_count=0)
+    register = getattr(resources_handle, "register_session_event_buffer", None)
+    if not callable(register):
+        return _session_event_context(published_count=0)
+    try:
+        register(buffer)
+    except Exception:
+        return _session_event_context(published_count=0)
+    with _LOCK:
+        _SESSION_EVENT_STATE["registered"] = True
+        _SESSION_EVENT_STATE["resource_uri"] = getattr(buffer, "resource_uri", None)
+    return _session_event_context(published_count=0)
+
+
+def _session_event_context(published_count: int) -> Dict[str, Any]:
+    with _LOCK:
+        buffer = _SESSION_EVENT_STATE.get("buffer")
+        return {
+            "available": buffer is not None,
+            "registered": bool(_SESSION_EVENT_STATE.get("registered")),
+            "instance_id": _SESSION_EVENT_STATE.get("instance_id"),
+            "resource_uri": _SESSION_EVENT_STATE.get("resource_uri"),
+            "published_count": int(published_count),
+        }
+
+
+def _append_session_event(
+    stream: str,
+    message: str,
+    *,
+    level: str = "info",
+    session_id: Optional[str] = None,
+    tool_call_id: Optional[str] = None,
+    job_id: Optional[str] = None,
+    correlation_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    buffer = _get_or_create_session_event_buffer()
+    if buffer is None or not message:
+        return None
+    try:
+        return buffer.append(
+            source="maya-dev",
+            stream=stream,
+            message=message,
+            level=level,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            job_id=job_id,
+            correlation_id=correlation_id,
+            metadata=metadata or {},
+        )
+    except Exception:
+        return None
+
+
+def _publish_run_check_events(
+    run_context: Dict[str, Any],
+    run_summary: Dict[str, Any],
+    artifacts: Sequence[Dict[str, Any]],
+    *,
+    run_success: bool,
+    session_id: Optional[str] = None,
+    tool_call_id: Optional[str] = None,
+    job_id: Optional[str] = None,
+    correlation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    artifacts_by_kind = {str(artifact.get("kind")): artifact for artifact in artifacts if artifact.get("kind")}
+    base_metadata = {
+        "target": run_summary.get("target"),
+        "elapsed_secs": run_summary.get("elapsed_secs"),
+        "run_success": bool(run_success),
+    }
+    common = {
+        "session_id": session_id,
+        "tool_call_id": tool_call_id,
+        "job_id": job_id,
+        "correlation_id": correlation_id,
+    }
+
+    published = 0
+    progress = _append_session_event(
+        "progress",
+        "run_check {} for {}".format("completed" if run_success else "failed", run_summary.get("target") or "entrypoint"),
+        level="info" if run_success else "error",
+        metadata=dict(base_metadata, run_summary=run_summary),
+        **common,
+    )
+    if progress is not None:
+        published += 1
+
+    for stream, level in (("stdout", "info"), ("stderr", "warning"), ("traceback", "error")):
+        text = run_context.get(stream)
+        if not isinstance(text, str) or not text:
+            continue
+        metadata = dict(base_metadata, char_count=len(text))
+        artifact = artifacts_by_kind.get(stream)
+        if artifact:
+            metadata["artifact"] = {
+                "uri": artifact.get("uri"),
+                "mime": artifact.get("mime"),
+                "bytes": artifact.get("bytes"),
+            }
+        event = _append_session_event(stream, text, level=level, metadata=metadata, **common)
+        if event is not None:
+            published += 1
+
+    return _session_event_context(published)
 
 
 def _ui_artifact_refs(artifacts: Sequence[Dict[str, Any]]) -> List[UiArtifactRef]:
@@ -1874,6 +2036,10 @@ def run_check(
     capture_ui_image: bool = False,
     ui_object_name: Optional[str] = None,
     artifact_threshold: int = DEFAULT_ARTIFACT_THRESHOLD,
+    event_session_id: Optional[str] = None,
+    event_tool_call_id: Optional[str] = None,
+    event_job_id: Optional[str] = None,
+    event_correlation_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Reload project code, run an entrypoint, and optionally capture Maya UI."""
 
@@ -1902,6 +2068,17 @@ def run_check(
         "has_traceback": bool(run_context.get("traceback")),
         "artifact_count": len(run_artifacts),
     }
+    event_context = _publish_run_check_events(
+        run_context,
+        run_summary,
+        run_artifacts,
+        run_success=bool(run_result.get("success")),
+        session_id=event_session_id,
+        tool_call_id=event_tool_call_id,
+        job_id=event_job_id,
+        correlation_id=event_correlation_id,
+    )
+    run_summary["event_count"] = event_context["published_count"]
     ui_context: Optional[Dict[str, Any]] = None
     ui_success: Optional[bool] = None
     if capture_ui_image:
@@ -1913,6 +2090,7 @@ def run_check(
         "run": run_context,
         "run_summary": run_summary,
         "artifacts": run_artifacts,
+        "observability_events": event_context,
         "run_success": bool(run_result.get("success")),
     }
     if ui_context is not None:
@@ -1950,3 +2128,11 @@ def reset_for_tests() -> None:
         )
         _UI_STATE["refs"] = {}
         _UI_STATE["seq"] = 0
+        _SESSION_EVENT_STATE.update(
+            {
+                "buffer": None,
+                "instance_id": None,
+                "resource_uri": None,
+                "registered": False,
+            }
+        )

--- a/src/dcc_mcp_maya/_resources.py
+++ b/src/dcc_mcp_maya/_resources.py
@@ -404,6 +404,7 @@ class MayaResourceBinder:
         self.bound_server: Any = None
         self.handle: Any = None
         self.registered_producers: List[str] = []
+        self.session_event_uri: Optional[str] = None
         self.scene_event_ids: List[int] = []
         self.scene_publish_count: int = 0
 
@@ -444,6 +445,7 @@ class MayaResourceBinder:
         self._register_producer(SCHEME_MAYA_CMDS, _maya_cmds_help_producer)
         self._register_producer(SCHEME_MAYA_API, _maya_api_signatures_producer)
         self._register_producer(SCHEME_MAYA_PROJECT, _maya_project_current_producer)
+        self._register_session_event_buffer(server)
 
         # Initial scene snapshot --------------------------------------
         if self.snapshot_provider is not None:
@@ -527,6 +529,22 @@ class MayaResourceBinder:
             logger.debug("resources: register_producer(%s) raised: %s", scheme, exc)
             return
         self.registered_producers.append(scheme)
+
+    def _register_session_event_buffer(self, server: Any) -> None:
+        """Register maya-dev's bounded runtime event buffer when core supports it."""
+        if self.handle is None:
+            return
+        try:
+            from dcc_mcp_maya import _dev_session  # noqa: PLC0415
+
+            instance_id = getattr(server, "instance_id", None) or "maya-dev"
+            status = _dev_session.register_session_event_buffer(self.handle, instance_id=str(instance_id))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: register_session_event_buffer raised: %s", exc)
+            return
+        uri = status.get("resource_uri") if isinstance(status, dict) else None
+        if uri:
+            self.session_event_uri = str(uri)
 
     def _is_executor_busy(self) -> bool:
         if self.busy_checker is None:

--- a/src/dcc_mcp_maya/skills/maya-dev/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-dev/SKILL.md
@@ -36,7 +36,7 @@ live Maya session. The intended loop is:
 1. `attach_project` once for the project root.
 2. Edit files in the normal workspace.
 3. `run_check` or `reload_modules` + `run_entrypoint`.
-4. Inspect stdout, stderr, traceback, and optional UI screenshot.
+4. Inspect the concise summary, artifact refs, session events, and optional UI screenshot.
 
 Set `DCC_MCP_MAYA_DEV_ROOTS` to a path-list of trusted roots when a studio
 wants to restrict which local projects can be attached.
@@ -51,4 +51,4 @@ wants to restrict which local projects can be attached.
 - `capture_ui` — Capture the Maya main window or a named Qt widget as PNG
 - `ui_snapshot` / `ui_find` / `ui_action` — Inspect and operate Maya Qt UI controls, with optional action evidence artifacts
 - `make_node_ref` / `resolve_node_ref` — Build and resolve stable Maya node references
-- `run_check` — Reload, run an entrypoint, capture diagnostics/artifacts, optionally grab UI
+- `run_check` — Reload, run an entrypoint, capture diagnostics/artifacts/session events, optionally grab UI

--- a/src/dcc_mcp_maya/skills/maya-dev/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-dev/tools.yaml
@@ -371,9 +371,10 @@ tools:
 - name: run_check
   source_file: scripts/run_check.py
   description: 'Development convenience wrapper: reload project modules, run an entrypoint,
-    capture stdout/stderr/traceback, optionally capture a Maya UI screenshot, and return
-    artifact refs for large diagnostics. Use after editing project code to verify behavior
-    inside the live Maya session.'
+    capture stdout/stderr/traceback, optionally capture a Maya UI screenshot, return
+    artifact refs for large diagnostics, and publish bounded session events when core
+    supports them. Use after editing project code to verify behavior inside the live
+    Maya session.'
   execution: async
   affinity: main
   timeout_hint_secs: 300
@@ -416,3 +417,15 @@ tools:
         minimum: 1
         default: 4096
         description: Inline text length at which run_check also writes a text artifact reference.
+      event_session_id:
+        type: string
+        description: Optional MCP/session id to stamp onto emitted observability events.
+      event_tool_call_id:
+        type: string
+        description: Optional tool-call/request id to stamp onto emitted observability events.
+      event_job_id:
+        type: string
+        description: Optional async job id to stamp onto emitted observability events.
+      event_correlation_id:
+        type: string
+        description: Optional adapter-defined correlation id for emitted observability events.

--- a/tests/test_maya_dev_skill.py
+++ b/tests/test_maya_dev_skill.py
@@ -538,6 +538,72 @@ def test_run_check_writes_artifact_refs_for_large_output(tmp_path: Path) -> None
     assert out["context"]["run_summary"]["artifact_count"] == 1
 
 
+def test_run_check_publishes_session_events_for_output(tmp_path: Path) -> None:
+    from dcc_mcp_maya import _dev_session
+
+    _dev_session.reset_for_tests()
+    old_sys_path = sys.path[:]
+    _cleanup_demo_modules()
+    _write_demo_package(tmp_path)
+    (tmp_path / "demo_tool" / "runner.py").write_text(
+        "import sys\n"
+        "def main():\n"
+        "    print('stdout-event')\n"
+        "    print('stderr-event', file=sys.stderr)\n"
+        "    return 'ok'\n",
+        encoding="utf-8",
+    )
+    buffer = _dev_session.get_session_event_buffer("maya-dev-test")
+
+    try:
+        _dev_session.attach_project(str(tmp_path), package_prefixes=["demo_tool"])
+        out = _dev_session.run_check(
+            target="demo_tool.runner:main",
+            event_tool_call_id="call-1",
+            event_job_id="job-1",
+        )
+    finally:
+        sys.path[:] = old_sys_path
+        _cleanup_demo_modules()
+        _dev_session.reset_for_tests()
+
+    assert out["success"] is True
+    event_ctx = out["context"]["observability_events"]
+    assert event_ctx["available"] is True
+    assert event_ctx["published_count"] == 3
+    assert out["context"]["run_summary"]["event_count"] == 3
+
+    page = buffer.read(cursor=0, limit=10, drain=False)
+    streams = [event["stream"] for event in page["events"]]
+    assert streams == ["progress", "stdout", "stderr"]
+    assert {event["job_id"] for event in page["events"]} == {"job-1"}
+    assert {event["tool_call_id"] for event in page["events"]} == {"call-1"}
+    assert page["events"][1]["message"] == "stdout-event\n"
+
+
+def test_run_check_keeps_inline_output_when_session_events_unavailable(tmp_path: Path) -> None:
+    from dcc_mcp_maya import _dev_session
+
+    _dev_session.reset_for_tests()
+    old_sys_path = sys.path[:]
+    _cleanup_demo_modules()
+    _write_demo_package(tmp_path)
+
+    try:
+        _dev_session.attach_project(str(tmp_path), package_prefixes=["demo_tool"])
+        with patch.object(_dev_session, "_create_session_event_buffer", return_value=None):
+            out = _dev_session.run_check(target="demo_tool.runner:main")
+    finally:
+        sys.path[:] = old_sys_path
+        _cleanup_demo_modules()
+        _dev_session.reset_for_tests()
+
+    assert out["success"] is True
+    assert out["context"]["run"]["stdout"] == "runner-main 0\n"
+    assert out["context"]["observability_events"]["available"] is False
+    assert out["context"]["observability_events"]["published_count"] == 0
+
+
 def test_maya_dev_scripts_delegate_to_shared_session(tmp_path: Path) -> None:
     from dcc_mcp_maya import _dev_session
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -274,12 +274,16 @@ class _RecordingResourceHandle:
         self.scenes: List[Any] = []
         self.producers: Dict[str, Callable[[str], Dict[str, Any]]] = {}
         self.notifications: List[str] = []
+        self.session_event_buffers: List[Any] = []
 
     def set_scene(self, value: Any) -> None:
         self.scenes.append(value)
 
     def register_producer(self, scheme_or_uri: str, callable_: Callable[[str], Dict[str, Any]]) -> None:
         self.producers[scheme_or_uri] = callable_
+
+    def register_session_event_buffer(self, buffer: Any) -> None:
+        self.session_event_buffers.append(buffer)
 
     def notify_updated(self, uri: str) -> None:
         self.notifications.append(uri)
@@ -324,6 +328,8 @@ class TestMayaResourceBinderBind:
                 SCHEME_MAYA_PROJECT,
             ]
         )
+        assert server.resource_handle.session_event_buffers
+        assert binder.session_event_uri
 
     def test_bind_without_snapshot_provider_skips_initial_publish(self) -> None:
         server = _FakeServer()
@@ -331,6 +337,7 @@ class TestMayaResourceBinderBind:
         assert binder.bind(server) is True
         assert binder.scene_publish_count == 0
         assert server.resource_handle.scenes == []
+        assert server.resource_handle.session_event_buffers
 
     def test_bind_is_idempotent(self) -> None:
         server = _FakeServer()
@@ -339,6 +346,7 @@ class TestMayaResourceBinderBind:
         binder.bind(server)  # second call must be a no-op
         # Producers registered exactly once each.
         assert len(server.resource_handle.producers) == 3
+        assert len(server.resource_handle.session_event_buffers) == 1
         # Scene published exactly once.
         assert binder.scene_publish_count == 1
 


### PR DESCRIPTION
## Summary
- register a maya-dev `SessionEventBuffer` as an `events://session/*` MCP resource when core supports it
- publish `run_check` progress/stdout/stderr/traceback into bounded session events while preserving inline output and artifact refs
- expose optional session/tool-call/job/correlation ids for event metadata and document the updated maya-dev contract

## Validation
- `python -m pytest tests\test_maya_dev_skill.py tests\test_resources.py tests\test_lint_skills.py -q`
- `python -m ruff check src\dcc_mcp_maya\_dev_session.py src\dcc_mcp_maya\_resources.py tests\test_maya_dev_skill.py tests\test_resources.py`

Closes #279