### PR TITLE
fix: update skill schema fields and render survival coverage

### DIFF
--- a/src/dcc_mcp_maya/skills/maya-dev/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-dev/tools.yaml
@@ -10,7 +10,7 @@ tools:
     read_only_hint: false
     idempotent_hint: true
   group: development
-  inputSchema:
+  input_schema:
     type: object
     required: [project_root]
     properties:
@@ -47,7 +47,7 @@ tools:
     read_only_hint: false
     idempotent_hint: true
   group: development
-  inputSchema:
+  input_schema:
     type: object
     properties:
       project_name:
@@ -75,7 +75,7 @@ tools:
   annotations:
     read_only_hint: false
   group: development
-  inputSchema:
+  input_schema:
     type: object
     properties:
       target:
@@ -120,7 +120,7 @@ tools:
   annotations:
     read_only_hint: false
   group: development
-  inputSchema:
+  input_schema:
     type: object
     required: [script_path]
     properties:
@@ -163,7 +163,7 @@ tools:
     read_only_hint: false
     idempotent_hint: true
   group: development
-  inputSchema:
+  input_schema:
     type: object
     properties:
       host:
@@ -210,7 +210,7 @@ tools:
     read_only_hint: true
     idempotent_hint: false
   group: development
-  inputSchema:
+  input_schema:
     type: object
     properties:
       object_name:
@@ -227,7 +227,7 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: development
-  inputSchema:
+  input_schema:
     type: object
     properties:
       object_name:
@@ -254,7 +254,7 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: development
-  inputSchema:
+  input_schema:
     type: object
     properties:
       query:
@@ -292,7 +292,7 @@ tools:
     read_only_hint: false
     idempotent_hint: false
   group: development
-  inputSchema:
+  input_schema:
     type: object
     required: [action]
     properties:
@@ -339,7 +339,7 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: development
-  inputSchema:
+  input_schema:
     type: object
     required: [node]
     properties:
@@ -356,7 +356,7 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: development
-  inputSchema:
+  input_schema:
     type: object
     properties:
       ref:
@@ -382,7 +382,7 @@ tools:
     read_only_hint: false
     idempotent_hint: false
   group: development
-  inputSchema:
+  input_schema:
     type: object
     properties:
       target:

--- a/src/dcc_mcp_maya/skills/maya-geometry/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-geometry/tools.yaml
@@ -7,7 +7,7 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: core
-  inputSchema:
+  input_schema:
     type: object
     required:
     - path
@@ -34,7 +34,7 @@ tools:
   annotations:
     destructive_hint: true
   group: geometry
-  inputSchema:
+  input_schema:
     type: object
     required:
     - path
@@ -107,7 +107,7 @@ tools:
   annotations:
     destructive_hint: true
   group: geometry
-  inputSchema:
+  input_schema:
     type: object
     required:
     - file_path
@@ -135,7 +135,7 @@ tools:
   annotations:
     destructive_hint: true
   group: geometry
-  inputSchema:
+  input_schema:
     type: object
     required:
     - path
@@ -174,7 +174,7 @@ tools:
   annotations:
     destructive_hint: true
   group: geometry
-  inputSchema:
+  input_schema:
     type: object
     required:
     - path

--- a/src/dcc_mcp_maya/skills/maya-material-library/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-material-library/tools.yaml
@@ -16,7 +16,7 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: shading-lighting
-  inputSchema:
+  input_schema:
     type: object
     required:
     - library_dir

--- a/src/dcc_mcp_maya/skills/maya-primitives/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-primitives/tools.yaml
@@ -4,7 +4,7 @@ tools:
   execution: sync
   affinity: main
   group: modeling
-  inputSchema:
+  input_schema:
     type: object
     properties:
       radius:
@@ -20,7 +20,7 @@ tools:
   execution: sync
   affinity: main
   group: modeling
-  inputSchema:
+  input_schema:
     type: object
     properties:
       width:
@@ -42,7 +42,7 @@ tools:
   execution: sync
   affinity: main
   group: modeling
-  inputSchema:
+  input_schema:
     type: object
     properties:
       radius:
@@ -64,7 +64,7 @@ tools:
   execution: sync
   affinity: main
   group: modeling
-  inputSchema:
+  input_schema:
     type: object
     properties:
       width:
@@ -93,7 +93,7 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: modeling
-  inputSchema:
+  input_schema:
     type: object
     required:
     - names
@@ -115,7 +115,7 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: modeling
-  inputSchema:
+  input_schema:
     type: object
     required:
     - object_name
@@ -133,7 +133,7 @@ tools:
   annotations:
     idempotent_hint: true
   group: modeling
-  inputSchema:
+  input_schema:
     type: object
     required:
     - old_name
@@ -150,7 +150,7 @@ tools:
   annotations:
     idempotent_hint: true
   group: modeling
-  inputSchema:
+  input_schema:
     type: object
     required:
     - object_name

--- a/src/dcc_mcp_maya/skills/maya-render/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render/tools.yaml
@@ -9,8 +9,13 @@ tools:
   execution: async
   affinity: main
   timeout_hint_secs: 600
+  annotations:
+    read_only_hint: false
+    destructive_hint: false
+    idempotent_hint: false
+    open_world_hint: false
   group: rendering
-  inputSchema:
+  input_schema:
     type: object
     properties:
       width:
@@ -61,8 +66,13 @@ tools:
   execution: async
   affinity: main
   timeout_hint_secs: 600
+  annotations:
+    read_only_hint: false
+    destructive_hint: false
+    idempotent_hint: false
+    open_world_hint: false
   group: rendering
-  inputSchema:
+  input_schema:
     type: object
     properties:
       width:

--- a/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
@@ -44,7 +44,7 @@ tools:
   annotations:
     read_only_hint: true
     idempotent_hint: true
-  inputSchema:
+  input_schema:
     type: object
     required:
     - pattern
@@ -79,7 +79,7 @@ tools:
   description: Group a list of objects under a new transform node.
   execution: sync
   affinity: main
-  inputSchema:
+  input_schema:
     type: object
     required:
     - objects
@@ -129,7 +129,7 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
-  inputSchema:
+  input_schema:
     type: object
     properties:
       force:
@@ -149,7 +149,7 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: scene-management
-  inputSchema:
+  input_schema:
     type: object
     required:
     - file_path
@@ -180,7 +180,7 @@ tools:
   affinity: main
   timeout_hint_secs: 120
   group: scene-management
-  inputSchema:
+  input_schema:
     type: object
     properties:
       file_path:

--- a/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
@@ -9,7 +9,7 @@ tools:
     destructive_hint: true
     read_only_hint: false
   group: core
-  inputSchema:
+  input_schema:
     type: object
     properties:
       code:
@@ -33,7 +33,7 @@ tools:
     destructive_hint: true
     read_only_hint: false
   group: core
-  inputSchema:
+  input_schema:
     type: object
     properties:
       code:
@@ -79,7 +79,7 @@ tools:
     destructive_hint: true
     read_only_hint: false
   group: core
-  inputSchema:
+  input_schema:
     type: object
     required:
     - name
@@ -110,7 +110,7 @@ tools:
     read_only_hint: false
     idempotent_hint: true
   group: core
-  inputSchema:
+  input_schema:
     type: object
     required:
     - action
@@ -141,7 +141,7 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: core
-  inputSchema:
+  input_schema:
     type: object
     required:
     - node_name

--- a/tests/test_http_dynamic_skill_api.py
+++ b/tests/test_http_dynamic_skill_api.py
@@ -80,7 +80,7 @@ def _write_skill(root: Path, name: str, scripts: Dict[str, str]) -> Path:
                 "  execution: sync",
                 "  affinity: any",
                 "  group: core",
-                "  inputSchema:",
+                "  input_schema:",
                 "    type: object",
                 "    additionalProperties: true",
             ]

--- a/tests/test_maya_http_transport.py
+++ b/tests/test_maya_http_transport.py
@@ -156,7 +156,7 @@ def _write_echo_skill(root: Path, name: str) -> Path:
                 execution: sync
                 affinity: any
                 group: core
-                inputSchema:
+                input_schema:
                   type: object
                   additionalProperties: true
             """
@@ -179,6 +179,72 @@ def _write_echo_skill(root: Path, name: str) -> Path:
     return pkg
 
 
+def _write_render_smoke_skill(root: Path) -> Path:
+    pkg = root / "maya-render"
+    (pkg / "scripts").mkdir(parents=True)
+    (pkg / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            ---
+            name: maya-render
+            description: Render transport regression skill.
+            license: MIT
+            metadata:
+              dcc-mcp:
+                dcc: maya
+                layer: domain
+                version: 1.0.0
+                tools: tools.yaml
+            ---
+
+            # maya-render
+            """
+        ),
+        encoding="utf-8",
+    )
+    (pkg / "tools.yaml").write_text(
+        textwrap.dedent(
+            """\
+            tools:
+              - name: capture_viewport
+                description: Test capture path.
+                execution: async
+                affinity: main
+                timeout_hint_secs: 600
+                group: rendering
+                input_schema:
+                  type: object
+                  additionalProperties: true
+              - name: playblast
+                description: Test playblast path.
+                execution: async
+                affinity: main
+                timeout_hint_secs: 600
+                group: rendering
+                input_schema:
+                  type: object
+                  additionalProperties: true
+            """
+        ),
+        encoding="utf-8",
+    )
+    (pkg / "groups.yaml").write_text(
+        "groups:\n- name: rendering\n  description: rendering\n  default_active: true\n  tools:\n  - capture_viewport\n  - playblast\n",
+        encoding="utf-8",
+    )
+    for stem in ("capture_viewport", "playblast"):
+        (pkg / "scripts" / "{}.py".format(stem)).write_text(
+            textwrap.dedent(
+                """\
+                def main(**kwargs):
+                    return {{"success": True, "message": "{stem}", "context": {{"args": kwargs}}}}
+                """
+            ).format(stem=stem),
+            encoding="utf-8",
+        )
+    return pkg
+
+
 def _extract_tool_payload(result: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(result, dict) and "success" in result:
         return result
@@ -186,8 +252,15 @@ def _extract_tool_payload(result: Dict[str, Any]) -> Dict[str, Any]:
     if content and isinstance(content[0], dict):
         text = content[0].get("text") or ""
         if text:
-            return json.loads(text)
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                return {"message": text}
     return result
+
+
+def _structured_tool_payload(result: Dict[str, Any]) -> Dict[str, Any]:
+    return result.get("structuredContent") or result.get("structured_content") or {}
 
 
 @pytest.fixture(scope="module")
@@ -268,6 +341,68 @@ class TestInProcessHttpApi:
             assert output["success"] is True
         else:
             assert called
+
+    def test_capture_then_playblast_keeps_http_server_responsive(self, tmp_path):
+        """Regression for issue #235: render capture -> playblast must not kill HTTP."""
+        skill_pkg = _write_render_smoke_skill(tmp_path)
+        server = MayaMcpServer(port=0, enable_gateway_failover=False, gateway_port=0)
+        server.register_builtin_actions(
+            extra_skill_paths=[str(skill_pkg.parent)],
+            include_bundled=False,
+            minimal=False,
+        )
+        assert server.load_skill("maya-render")
+        handle = server.start()
+        try:
+            mcp_url = handle.mcp_url()
+            session = mcp_initialize(mcp_url, client_name="maya-render-survival")
+
+            for idx, action in enumerate(
+                (
+                    _qualified_action_name("maya-render", "capture_viewport"),
+                    _qualified_action_name("maya-render", "playblast"),
+                ),
+                start=10,
+            ):
+                response = mcp_post(
+                    mcp_url,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": idx,
+                        "method": "tools/call",
+                        "params": {"name": action, "arguments": {"width": 1280, "height": 720}},
+                    },
+                    session_id=session,
+                )
+                assert "result" in response, response
+                result = response["result"]
+                structured = _structured_tool_payload(result)
+                if structured.get("status") == "pending":
+                    assert structured.get("job_id"), structured
+                    payload = _extract_tool_payload(result)
+                    assert "queued" in payload.get("message", "").lower(), payload
+                else:
+                    payload = _extract_tool_payload(result)
+                    assert payload.get("success") is True, payload
+
+                base = mcp_url.rsplit("/", 1)[0]
+                assert rest_get_json(base, "/v1/healthz").get("ok") is True
+
+            listing = mcp_post(
+                mcp_url,
+                {"jsonrpc": "2.0", "id": 20, "method": "tools/list", "params": {}},
+                session_id=session,
+            )
+            names = {tool["name"] for tool in listing["result"]["tools"]}
+            assert {
+                "playblast",
+                _qualified_action_name("maya-render", "playblast"),
+            } & names
+
+            base = mcp_url.rsplit("/", 1)[0]
+            assert rest_get_json(base, "/v1/healthz").get("ok") is True
+        finally:
+            server.stop()
 
 
 @pytest.fixture

--- a/tests/test_skill_rest_mcp_parity.py
+++ b/tests/test_skill_rest_mcp_parity.py
@@ -619,6 +619,19 @@ def _iter_bundled_tools_yaml() -> Iterable[Tuple[str, Dict[str, Any]]]:
         yield skill_name, data
 
 
+def test_bundled_tools_yaml_use_core_schema_field_names():
+    """tools.yaml must use core's snake_case schema keys, not MCP wire keys."""
+    offenders = []
+    for skill_name, data in _iter_bundled_tools_yaml():
+        for tool in data.get("tools", []) or []:
+            name = tool.get("name")
+            if "inputSchema" in tool:
+                offenders.append(("inputSchema", skill_name, name))
+            if "outputSchema" in tool:
+                offenders.append(("outputSchema", skill_name, name))
+    assert not offenders, "tools.yaml must use input_schema/output_schema: {}".format(offenders)
+
+
 def test_bundled_tools_yaml_have_no_bloated_descriptions():
     """Prevent future PRs from inflating tools.yaml descriptions.
 
@@ -645,7 +658,7 @@ def test_bundled_tools_yaml_inputschema_budget():
     offenders = []
     for skill_name, data in _iter_bundled_tools_yaml():
         for tool in data.get("tools", []) or []:
-            schema = tool.get("inputSchema") or {}
+            schema = tool.get("input_schema") or {}
             if not schema:
                 continue
             encoded = json.dumps(schema, separators=(",", ":"))

--- a/tests/test_skills_scripting_enhancements.py
+++ b/tests/test_skills_scripting_enhancements.py
@@ -721,10 +721,13 @@ class TestToolsYamlContract:
         path = Path(__file__).parent.parent / "src" / "dcc_mcp_maya" / "skills" / "maya-scripting" / "tools.yaml"
         return yaml.safe_load(path.read_text(encoding="utf-8"))
 
+    def _input_schema(self, tool: dict) -> dict:
+        return tool.get("input_schema", {})
+
     def test_execute_python_advertises_result_type_param(self):
         data = self._load_tools()
         tool = next(t for t in data["tools"] if t["name"] == "execute_python")
-        props = tool.get("inputSchema", {}).get("properties", {})
+        props = self._input_schema(tool).get("properties", {})
         assert "result_type" in props, "execute_python must advertise the result_type selector"
         assert props["result_type"].get("type") == "string"
         assert set(props["result_type"].get("enum", [])) >= {"NONE", "VALUE", "JSON", "REPR"}
@@ -733,14 +736,14 @@ class TestToolsYamlContract:
         """Regression guard: the deferred / settrace path was removed in #248."""
         data = self._load_tools()
         tool = next(t for t in data["tools"] if t["name"] == "execute_python")
-        props = tool.get("inputSchema", {}).get("properties", {})
+        props = self._input_schema(tool).get("properties", {})
         assert "defer" not in props
         assert "timeout_secs" not in props
 
     def test_execute_python_schema_keeps_file_path(self):
         data = self._load_tools()
         tool = next(t for t in data["tools"] if t["name"] == "execute_python")
-        props = tool.get("inputSchema", {}).get("properties", {})
+        props = self._input_schema(tool).get("properties", {})
         assert "file_path" in props
         assert "script_path" in props
 
@@ -759,24 +762,26 @@ class TestToolsYamlContract:
         data = self._load_tools()
         tool = next((t for t in data["tools"] if t["name"] == "write_module"), None)
         assert tool is not None, "write_module must be declared in tools.yaml"
-        props = tool.get("inputSchema", {}).get("properties", {})
+        schema = self._input_schema(tool)
+        props = schema.get("properties", {})
         assert {"name", "source", "overwrite"} <= set(props.keys())
-        assert "name" in tool["inputSchema"].get("required", [])
-        assert "source" in tool["inputSchema"].get("required", [])
+        assert "name" in schema.get("required", [])
+        assert "source" in schema.get("required", [])
 
     def test_io_is_declared_with_action_multiplexer(self):
         data = self._load_tools()
         tool = next((t for t in data["tools"] if t["name"] == "io"), None)
         assert tool is not None, "io must be declared in tools.yaml"
-        props = tool.get("inputSchema", {}).get("properties", {})
+        schema = self._input_schema(tool)
+        props = schema.get("properties", {})
         assert "action" in props
         assert set(props["action"].get("enum", [])) >= {"install", "uninstall", "get", "clear", "status"}
-        assert "action" in tool["inputSchema"].get("required", [])
+        assert "action" in schema.get("required", [])
 
     def test_execute_mel_schema_has_file_path(self):
         data = self._load_tools()
         tool = next(t for t in data["tools"] if t["name"] == "execute_mel")
-        props = tool.get("inputSchema", {}).get("properties", {})
+        props = self._input_schema(tool).get("properties", {})
         assert "file_path" in props
 
 


### PR DESCRIPTION
## Summary
- add an MCP HTTP regression for `capture_viewport` -> `playblast` so issue #235 keeps a live server check through `tools/list` and `/v1/healthz`
- migrate bundled `tools.yaml` schema declarations from stale `inputSchema` to current core `input_schema`, with a regression test that blocks camelCase schema keys in skill metadata
- mark the render capture/playblast tools with supported MCP annotations instead of adding the stale `risk_class` / `high-crash` field

## Validation
- `python tools\lint_skill_affinity.py`
- `python tools\lint_skills.py --error-only`
- `pytest tests\test_capability_manifest.py tests\test_skill_affinity.py tests\test_http_dynamic_skill_api.py tests\test_maya_http_transport.py tests\test_skill_rest_mcp_parity.py::test_bundled_tools_yaml_use_core_schema_field_names tests\test_skill_rest_mcp_parity.py::test_bundled_tools_yaml_inputschema_budget tests\test_skill_rest_mcp_parity.py::test_bundled_tools_declare_execution_and_affinity -q` (43 passed, 1 xfailed)