### PR TITLE
fix: document sidecar runtime for module archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,23 @@ enough:
 mayapy -m pip install dcc-mcp-maya
 ```
 
+### Maya Module ZIPs
+
+Release module archives bundle the Maya plugin, `dcc-mcp-maya`, and the
+in-process Python bridge dependencies such as `dcc-mcp-core`. They do not bundle
+the external `dcc-mcp-server` sidecar binary used by default plugin gateway
+mode. On clean machines, install or provide the sidecar runtime before loading
+the plugin:
+
+```bash
+mayapy -m pip install "dcc-mcp-server>=0.17.23"
+mayapy -c "from dcc_mcp_maya.sidecar import resolve_sidecar_binary; print(resolve_sidecar_binary())"
+```
+
+Alternatively, set `DCC_MCP_SERVER_BIN` to the sidecar executable, put
+`dcc-mcp-server` on `PATH`, or set `DCC_MCP_MAYA_SIDECAR=0` before loading the
+plugin to use the legacy in-process gateway path.
+
 ### Maya Plugin
 
 1. Put `maya/plugin/dcc_mcp_maya_plugin.py` on `MAYA_PLUG_IN_PATH`.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -30,6 +30,13 @@ mayapy -c "import dcc_mcp_maya; print(dcc_mcp_maya.__version__)"
 Use `dcc-mcp-maya` without `[sidecar]` only when your environment already
 provides the `dcc-mcp-server` binary.
 
+Release module ZIPs follow the same rule: they include the Maya plugin,
+`dcc-mcp-maya`, and the in-process bridge dependencies such as `dcc-mcp-core`,
+but they do not bundle the external `dcc-mcp-server` sidecar binary. For clean
+module deployments, install `dcc-mcp-server>=0.17.23` into the matching
+`mayapy`, set `DCC_MCP_SERVER_BIN`, or put `dcc-mcp-server` on `PATH`. Verify
+with `mayapy -c "from dcc_mcp_maya.sidecar import resolve_sidecar_binary; print(resolve_sidecar_binary())"`.
+
 ## Method 2 — Maya Plugin
 
 This is the recommended GUI path. Copy the plugin file to a directory on

--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -837,7 +837,12 @@ def _maybe_spawn_sidecar() -> None:
         )
     except SidecarSpawnError as exc:
         logger.error(
-            "dcc-mcp-maya: sidecar spawn failed; continuing in-process only. Cause: %s",
+            "dcc-mcp-maya: sidecar spawn failed; continuing with the in-process "
+            "Maya server only. Default sidecar gateway startup requires the "
+            "dcc-mcp-server binary. Install with `mayapy -m pip install "
+            "dcc-mcp-server`, set DCC_MCP_SERVER_BIN, put dcc-mcp-server on "
+            "PATH, or set DCC_MCP_MAYA_SIDECAR=0 before loading the plugin to "
+            "use the legacy in-process gateway. Cause: %s",
             exc,
         )
         _sidecar_handle = None

--- a/packaging/README-pipeline.txt
+++ b/packaging/README-pipeline.txt
@@ -4,6 +4,12 @@ DCC-MCP-Maya — Pipeline Deployment
 This package is designed for network-share deployment in pipeline
 environments. No install scripts are included.
 
+The module content includes the Maya plugin, dcc-mcp-maya Python
+package, and the in-process bridge dependencies such as dcc-mcp-core.
+It does not bundle the external dcc-mcp-server sidecar binary. Default
+plugin gateway mode needs that binary to be available from the same
+environment that launches Maya.
+
 Deployment Options
 ------------------
 
@@ -32,6 +38,25 @@ To auto-load the plugin at Maya startup, copy scripts/userSetup.py
 to your Maya scripts directory, or source it from your existing
 userSetup.py.
 
+Sidecar runtime
+---------------
+Default plugin mode starts a dcc-mcp-server sidecar and exposes the
+gateway at http://127.0.0.1:9765/mcp. Provide dcc-mcp-server >= 0.17.23
+for every Maya environment that consumes this network module.
+
+Common deployment options:
+
+- Install into each target mayapy:
+    mayapy -m pip install "dcc-mcp-server>=0.17.23"
+- Set DCC_MCP_SERVER_BIN to a centrally managed dcc-mcp-server path.
+- Put dcc-mcp-server on PATH in the launcher that starts Maya.
+- Set DCC_MCP_MAYA_SIDECAR=0 before loading the plugin to use the
+  legacy in-process gateway path instead.
+
+Clean-machine verification:
+
+  mayapy -c "from dcc_mcp_maya.sidecar import resolve_sidecar_binary; print(resolve_sidecar_binary())"
+
 Configuration
 -------------
 Environment variables (optional):
@@ -39,6 +64,8 @@ Environment variables (optional):
   DCC_MCP_MAYA_PORT        TCP port for the MCP server. Default: 0 (OS-assigned)
   DCC_MCP_MAYA_SERVER_NAME Server name in MCP initialize. Default: maya-mcp
   DCC_MCP_GATEWAY_PORT     Gateway port. Default: 9765
+  DCC_MCP_MAYA_SIDECAR     0 disables the default sidecar process
+  DCC_MCP_SERVER_BIN       Explicit path to the dcc-mcp-server binary
   DCC_MCP_MAYA_SKILL_PATHS Additional skill search paths (; separated)
   DCC_MCP_SKILL_PATHS      Global skill search paths (; separated)
 

--- a/packaging/README.txt
+++ b/packaging/README.txt
@@ -2,11 +2,17 @@ DCC-MCP-Maya — Maya Module Distribution
 ========================================
 
 Offline Maya .mod module package. Contains the MCP Streamable HTTP
-server plugin and all Python dependencies (including dcc-mcp-core).
+server plugin and the Python dependencies needed by the in-process
+Maya bridge (including dcc-mcp-core).
+
+This ZIP does not bundle the external dcc-mcp-server sidecar binary.
+Default plugin gateway mode needs that binary to be available from the
+same environment that launches Maya.
 
 Requirements
 ------------
 - Autodesk Maya 2022, 2023, 2024, 2025, or 2026 (matching platform ZIP; Maya 2022 requires python37/, available in Windows/Linux packages)
+- dcc-mcp-server >= 0.17.23 for default sidecar gateway mode, unless your studio provides the binary on PATH or via DCC_MCP_SERVER_BIN
 
 Installation
 ------------
@@ -18,6 +24,25 @@ Installation
 The installer generates a .mod file pointing to the extracted location
 and deploys userSetup.py to your Maya scripts directory. The module
 files stay where you extracted them — only the .mod pointer is copied.
+
+Sidecar runtime
+---------------
+Default plugin mode starts a dcc-mcp-server sidecar and exposes the
+gateway at http://127.0.0.1:9765/mcp. Install or provide the sidecar
+runtime before loading the plugin on a clean machine:
+
+  mayapy -m pip install "dcc-mcp-server>=0.17.23"
+
+Clean-machine verification:
+
+  mayapy -c "from dcc_mcp_maya.sidecar import resolve_sidecar_binary; print(resolve_sidecar_binary())"
+
+Alternative deployment options:
+
+- Set DCC_MCP_SERVER_BIN to the full dcc-mcp-server executable path.
+- Put dcc-mcp-server on PATH before launching Maya.
+- Set DCC_MCP_MAYA_SIDECAR=0 before loading the plugin to use the
+  legacy in-process gateway path instead.
 
 Uninstallation
 --------------
@@ -35,6 +60,8 @@ Environment variables (optional):
   DCC_MCP_MAYA_PORT        TCP port for the MCP server. Default: 0 (OS-assigned)
   DCC_MCP_MAYA_SERVER_NAME Server name in MCP initialize. Default: maya-mcp
   DCC_MCP_GATEWAY_PORT     Gateway port. Default: 9765
+  DCC_MCP_MAYA_SIDECAR     0 disables the default sidecar process
+  DCC_MCP_SERVER_BIN       Explicit path to the dcc-mcp-server binary
   DCC_MCP_MAYA_SKILL_PATHS Additional skill search paths (; separated)
   DCC_MCP_SKILL_PATHS      Global skill search paths (; separated)
 

--- a/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
@@ -23,7 +23,6 @@ metadata:
     search-hint: |-
       animate motion, keyframe, set key, timeline range, animation curve,
       curve tangent, bake constraint, bake simulation, anim file import export
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-attributes/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-attributes/SKILL.md
@@ -22,7 +22,6 @@ metadata:
     search-hint: |-
       get attribute, set attribute, add custom attribute, lock unlock attribute,
       list attributes, attribute value
-    depends: []
     tools: tools.yaml
 ---
 # maya-attributes (Scene stage)

--- a/src/dcc_mcp_maya/skills/maya-dev/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-dev/SKILL.md
@@ -24,7 +24,6 @@ metadata:
       develop maya tools, attach python project, hot reload modules, run
       project entrypoint, debugpy attach, capture maya ui screenshot, script
       stdout stderr traceback diagnostics
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-display/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-display/SKILL.md
@@ -21,7 +21,6 @@ metadata:
     search-hint: |-
       viewport visibility, display layer, show hide, layer assign,
       hide group, isolate selection
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-export-preset/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-export-preset/SKILL.md
@@ -23,7 +23,6 @@ metadata:
     search-hint: |-
       standardize export, export preset, FBX preset, Alembic preset,
       load export config, save export config, share export settings
-    depends: []
     tools: tools.yaml
 ---
 # maya-export-preset (Interchange stage)

--- a/src/dcc_mcp_maya/skills/maya-expressions/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-expressions/SKILL.md
@@ -21,7 +21,6 @@ metadata:
     search-hint: |-
       procedural animation, expression node, drive attribute, expression node,
       expression-driven motion, drive translateX with sin
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-geometry/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-geometry/SKILL.md
@@ -27,7 +27,6 @@ metadata:
       export FBX, import FBX, export OBJ, file_exists, geometry round trip,
       scene interchange, FBXExport options, bake animation FBX. Use
       maya-scene save_scene for .ma/.mb scene saves.
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
     recipes: references/IO_CHECKLIST.md

--- a/src/dcc_mcp_maya/skills/maya-light-rig/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-light-rig/SKILL.md
@@ -23,7 +23,6 @@ metadata:
     search-hint: |-
       lighting template, three point rig, key fill rim, HDRI dome,
       studio setup, environment light
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-material-library/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-material-library/SKILL.md
@@ -22,7 +22,6 @@ metadata:
     search-hint: |-
       reuse material, material preset, shader library, share material,
       load preset, save preset, JSON shader
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-materials/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-materials/SKILL.md
@@ -23,7 +23,6 @@ metadata:
     search-hint: |-
       assign shader, basic material, surface shader, lambert blinn,
       create material, shading group, shadingEngine, sets surfaceShader
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/SKILL.md
@@ -26,7 +26,6 @@ metadata:
     search-hint: |-
       edit mesh, modify polygons, bevel edge, extrude face, bridge, combine,
       separate, cleanup, boolean, subdivide, smooth topology
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-node-graph/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/SKILL.md
@@ -23,7 +23,6 @@ metadata:
     search-hint: |-
       node connection, attribute link, DG topology, construction history,
       list connections, transfer attributes, smooth subdivide
-    depends: []
     tools: tools.yaml
 ---
 # maya-node-graph (Scene stage)

--- a/src/dcc_mcp_maya/skills/maya-pipeline/metadata/depends.md
+++ b/src/dcc_mcp_maya/skills/maya-pipeline/metadata/depends.md
@@ -1,0 +1,4 @@
+# Dependencies
+# Skills that should be loaded before this skill for the full workflow.
+
+- maya-geometry

--- a/src/dcc_mcp_maya/skills/maya-pose-library/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-pose-library/SKILL.md
@@ -21,7 +21,6 @@ metadata:
     search-hint: |-
       save pose, load pose, mirror pose, character pose preset, pose library,
       pose JSON, reuse pose
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
@@ -25,7 +25,6 @@ metadata:
       create sphere cube cylinder plane, set transform, get transform, rename,
       delete object, primitive geometry, basic shape, polySphere polyCube,
       batch primitives, random transforms, many cubes procedural
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-render-farm/metadata/depends.md
+++ b/src/dcc_mcp_maya/skills/maya-render-farm/metadata/depends.md
@@ -1,0 +1,4 @@
+# Dependencies
+# Skills that should be loaded before this skill for the full workflow.
+
+- maya-render

--- a/src/dcc_mcp_maya/skills/maya-render/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-render/SKILL.md
@@ -23,7 +23,6 @@ metadata:
     search-hint: |-
       final output, preview render, playblast, viewport capture, render globals,
       set render settings, image format, frame range render
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-rigging/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-rigging/SKILL.md
@@ -23,7 +23,6 @@ metadata:
     search-hint: |-
       build character rig, skeleton setup, IK chain, skin bind, blendshape,
       control curve, deformer, joint hierarchy, weight paint
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-scene-assembly/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scene-assembly/SKILL.md
@@ -24,7 +24,6 @@ metadata:
     search-hint: |-
       assemble environment, large scene, assembly definition, assembly reference,
       LOD switch, representation swap, GPU cache representation
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-scene/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scene/SKILL.md
@@ -22,7 +22,6 @@ metadata:
     search-hint: |-
       manage scene file, open save scene, hierarchy query, selection,
       camera list, frame rate, locator, group parent, freeze pivot, bounding box
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-scripting/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-scripting/SKILL.md
@@ -25,7 +25,6 @@ metadata:
       last resort after load_skill, no-matching-tool, bulk loop in maya,
       MEL Python escape hatch, inspect api, cmds help, signature,
       flag list, introspect only
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
     recipes: references/RECIPES.md

--- a/src/dcc_mcp_maya/skills/maya-shot-export/metadata/depends.md
+++ b/src/dcc_mcp_maya/skills/maya-shot-export/metadata/depends.md
@@ -1,0 +1,4 @@
+# Dependencies
+# Skills that should be loaded before this skill for the full workflow.
+
+- maya-geometry

--- a/src/dcc_mcp_maya/skills/maya-texture-bake/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-texture-bake/SKILL.md
@@ -23,7 +23,6 @@ metadata:
     search-hint: |-
       bake texture map, AO normal, ambient occlusion, high to low res,
       static map, transfer maps, bake lighting
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/SKILL.md
@@ -21,7 +21,6 @@ metadata:
     search-hint: |-
       layout UVs, unfold UV, texture coordinates, UV projection, automatic UV,
       planar projection, UV set, normalize UV
-    depends: []
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/tests/test_assemble_mod.py
+++ b/tests/test_assemble_mod.py
@@ -219,6 +219,16 @@ class TestGenerateModuleInfo:
         assert info["supported_maya_versions"] == ["2022", "2023", "2024", "2025", "2026"]
 
 
+class TestPackagingReadmes:
+    def test_module_readmes_document_external_sidecar_runtime(self):
+        for name in ("README.txt", "README-pipeline.txt"):
+            text = (PROJECT_ROOT / "packaging" / name).read_text(encoding="utf-8")
+            assert "does not bundle the external dcc-mcp-server sidecar binary" in text
+            assert "DCC_MCP_SERVER_BIN" in text
+            assert "DCC_MCP_MAYA_SIDECAR=0" in text
+            assert "resolve_sidecar_binary" in text
+
+
 def _setup_project(tmp_path: Path) -> Path:
     project = tmp_path / "project"
     project.mkdir()

--- a/tests/test_plugin_env_vars.py
+++ b/tests/test_plugin_env_vars.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 # Import built-in modules
 import importlib
 import importlib.util
+import logging
 import os
 import sys
 import threading
@@ -342,6 +343,20 @@ class TestSidecarUsesCoreRegistryDefaults:
 
         _, kwargs = sidecar_pkg.start_sidecar.call_args
         assert "registry_dir" not in kwargs
+
+    def test_sidecar_spawn_failure_log_names_clean_machine_remedies(self, plugin_module, monkeypatch, caplog):
+        """A missing dcc-mcp-server binary should point operators at the external runtime."""
+        sidecar_pkg = self._arm_plugin(plugin_module, monkeypatch)
+        sidecar_pkg.start_sidecar.side_effect = sidecar_pkg.SidecarSpawnError("missing dcc-mcp-server")
+
+        with caplog.at_level(logging.ERROR, logger=plugin_module.logger.name):
+            plugin_module._maybe_spawn_sidecar()
+
+        assert plugin_module._sidecar_handle is None
+        assert "Default sidecar gateway startup requires the dcc-mcp-server binary" in caplog.text
+        assert "mayapy -m pip install dcc-mcp-server" in caplog.text
+        assert "DCC_MCP_SERVER_BIN" in caplog.text
+        assert "DCC_MCP_MAYA_SIDECAR=0" in caplog.text
 
     def test_sidecar_passes_debug_identity_to_binary(self, plugin_module, monkeypatch):
         """Maya should label both the per-DCC sidecar and standalone gateway."""


### PR DESCRIPTION
## Summary
- document that module ZIPs bundle the in-process bridge dependencies but not the external `dcc-mcp-server` sidecar binary
- make sidecar spawn failures point clean-machine operators to `dcc-mcp-server`, `DCC_MCP_SERVER_BIN`, PATH, or `DCC_MCP_MAYA_SIDECAR=0`
- clean skill dependency metadata so `dcc-mcp-cli lint` reports zero dependency warnings

## Tests
- `python -m ruff check src\ tests\ maya\plugin\dcc_mcp_maya_plugin.py`
- `python -m ruff format --check src\ tests\ maya\plugin\dcc_mcp_maya_plugin.py`
- `python tools\check_doc_parity.py`
- `python tools\lint_skills.py --error-only`
- `dcc-mcp-cli lint src/dcc_mcp_maya/skills`
- `PYTHONPATH=src;tests DCC_MCP_ALLOW_AMBIENT_PYTHON=1 python -m pytest -q`

Closes #294