### PR TITLE
chore: update setup-python in multi-instance workflow

### DIFF
--- a/.github/workflows/multi-instance-tests.yml
+++ b/.github/workflows/multi-instance-tests.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'


### PR DESCRIPTION
## Summary
- update the multi-instance workflow's two setup-python steps from v4 to v6
- leave Python and Maya coverage matrices unchanged

## Validation
- git diff --check
- rg "actions/setup-python@v4" .github/workflows

Refs #2