### PR TITLE
fix: restore standalone skill affinity overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 `dcc-mcp-maya` embeds a standards-compliant MCP Streamable HTTP server directly inside Autodesk Maya. It exposes 177 Maya operations as MCP tools that any AI agent (Claude, Cursor, Gemini, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
 **Current version:** 0.3.8 <!-- x-release-please-version -->
-**Core dependency:** `dcc-mcp-core>=0.17.31,<1.0.0`
+**Core dependency:** `dcc-mcp-core>=0.17.34,<1.0.0`
 **Python:** 3.7+
 **Maya:** 2020+
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Maya plugin starts a Rust `dcc-mcp-server` sidecar by default, so HTTP and g
 [![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-maya?label=Python)](https://pypi.org/project/dcc-mcp-maya/)
 [![Maya](https://img.shields.io/badge/Maya-2020%2B-37A5CC)](https://www.autodesk.com/products/maya/overview)
 [![MCP](https://img.shields.io/badge/MCP-Streamable%20HTTP-6f42c1)](https://modelcontextprotocol.io/)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.31-blue)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.34-blue)](https://github.com/loonghao/dcc-mcp-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ## Why Use It
@@ -175,7 +175,7 @@ mode. On clean machines, install or provide the sidecar runtime before loading
 the plugin:
 
 ```bash
-mayapy -m pip install "dcc-mcp-server>=0.17.31"
+mayapy -m pip install "dcc-mcp-server>=0.17.34"
 mayapy -c "from dcc_mcp_maya.sidecar import resolve_sidecar_binary; print(resolve_sidecar_binary())"
 ```
 
@@ -372,8 +372,8 @@ Windows symlinks require Developer Mode or an elevated shell. If symlinks are un
 
 - Autodesk Maya 2020+
 - Python 3.7+
-- `dcc-mcp-core>=0.17.31,<1.0.0`
-- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.17.31`
+- `dcc-mcp-core>=0.17.34,<1.0.0`
+- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.17.34`
 
 ## License
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,7 +14,7 @@ Embeds a standards-compliant MCP Streamable HTTP server (2025-03-26 spec) direct
 - **Repository:** https://github.com/loonghao/dcc-mcp-maya
 - **Python:** >=3.7
 - **Maya:** 2020+
-- **Core dependency:** `dcc-mcp-core>=0.17.31,<1.0.0`
+- **Core dependency:** `dcc-mcp-core>=0.17.34,<1.0.0`
 - **Entry point:** `dcc_mcp.adapters` → `maya = "dcc_mcp_maya:MayaMcpServer"`
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 **Repo:** https://github.com/loonghao/dcc-mcp-maya
 **Python:** >=3.7
 **Maya:** 2020+
-**Core dep:** `dcc-mcp-core>=0.17.31,<1.0.0`
+**Core dep:** `dcc-mcp-core>=0.17.34,<1.0.0`
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,12 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.17.31+: public DccServerBase get_skill/load_skill_object for
+    # 0.17.34+: public DccServerBase get_skill/load_skill_object for
     # adapter-facing SkillMetadata overrides, plus Claude-safe underscore names
     # for built-in jobs/project tools, registry write hardening, runtime
     # observation contracts, and gateway diagnostics.
     # abi3 (cp38+) on 3.8+; separate cp37 wheels on Python 3.7 (Maya 2022).
-    "dcc-mcp-core>=0.17.31,<1.0.0",
+    "dcc-mcp-core>=0.17.34,<1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -43,7 +43,7 @@ dev = [
     "pytest-timeout>=2.1.0",
     "pytest-xdist>=3.0",
     "requests>=2.28.0",
-    "dcc-mcp-server>=0.17.31",
+    "dcc-mcp-server>=0.17.34",
     "ruff>=0.8.0",
     "hatchling",
     "build",
@@ -51,7 +51,7 @@ dev = [
     "pyyaml>=5.0",  # YAML parsing for SKILL.md test validation
 ]
 sidecar = [
-    "dcc-mcp-server>=0.17.31",
+    "dcc-mcp-server>=0.17.34",
 ]
 
 [project.urls]

--- a/src/dcc_mcp_maya/_readiness.py
+++ b/src/dcc_mcp_maya/_readiness.py
@@ -208,11 +208,10 @@ class ReadinessBinder:
     # ── Public API ──────────────────────────────────────────────────────
 
     def report(self) -> dict:
-        """Return the current readiness snapshot as a dict.
+        """Return the current three-state readiness snapshot as a dict.
 
-        Delegates to :meth:`dcc_mcp_core.ReadinessProbe.report`. Maya
-        drives ``process`` / ``dispatcher`` / ``dcc``; newer core releases
-        may include additional diagnostic bits.
+        Delegates to :meth:`dcc_mcp_core.ReadinessProbe.report`.  Keys:
+        ``process`` / ``dispatcher`` / ``dcc``.
         """
         return self.probe.report()
 

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -32,7 +32,6 @@ from typing import Any, List, Optional
 
 # Import third-party modules
 from dcc_mcp_core import DccServerOptions, HostExecutionBridge, scan_and_load_strict
-from dcc_mcp_core._server.minimal_mode import apply_minimal_mode
 from dcc_mcp_core.factory import create_dcc_server
 from dcc_mcp_core.server_base import DccServerBase
 
@@ -512,124 +511,11 @@ class MayaMcpServer(DccServerBase):
         return self
 
     def _register_core_builtin_actions(self, context: _registration.RegistrationContext) -> None:
-        minimal_mode = self._build_minimal_mode_config(context.minimal)
-        if not self._uses_standalone_affinity_override():
-            super().register_builtin_actions(
-                extra_skill_paths=context.extra_skill_paths,
-                include_bundled=context.include_bundled,
-                minimal_mode=minimal_mode,
-            )
-            return
-
         super().register_builtin_actions(
             extra_skill_paths=context.extra_skill_paths,
             include_bundled=context.include_bundled,
-            minimal_mode=None,
+            minimal_mode=self._build_minimal_mode_config(context.minimal),
         )
-        prepared = self._prepare_standalone_skill_metadata_overrides()
-        if prepared:
-            logger.info(
-                "[%s] Prepared %d discovered skill(s) for standalone affinity overrides",
-                self._dcc_name,
-                prepared,
-            )
-        if minimal_mode is not None:
-            loaded = apply_minimal_mode(self, minimal_mode, dcc_name=self._dcc_name)
-            logger.info(
-                "[%s] Minimal mode: %d skill(s) loaded eagerly via core skill objects",
-                self._dcc_name,
-                loaded,
-            )
-
-    @property
-    def catalog(self) -> Any | None:
-        """Expose a usable core catalog handle when the runtime provides one."""
-        catalog = getattr(self._server, "catalog", None)
-        if hasattr(catalog, "deactivate_group"):
-            return catalog
-        return None
-
-    def _uses_standalone_affinity_override(self) -> bool:
-        dispatcher = getattr(self, "_host_dispatcher", None)
-        return type(dispatcher).__name__ in {"MayaStandaloneDispatcher", "PyStandaloneDispatcher"}
-
-    def _prepare_standalone_skill_metadata_overrides(self) -> int:
-        """Persist standalone affinity overrides for core-managed stub loading."""
-        skill_names = self._discovered_skill_names()
-        prepared = 0
-        for skill_name in skill_names:
-            skill = self.get_skill(skill_name)
-            if skill is None or not self._disable_tool_affinity_enforcement(skill):
-                continue
-            try:
-                if self.load_skill_object(skill):
-                    prepared += 1
-                else:
-                    logger.warning(
-                        "[%s] Could not prepare standalone affinity overrides for %r",
-                        self._dcc_name,
-                        skill_name,
-                    )
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "[%s] Could not prepare standalone affinity overrides for %r: %s",
-                    self._dcc_name,
-                    skill_name,
-                    exc,
-                )
-
-        for skill_name in skill_names:
-            if not self.is_skill_loaded(skill_name):
-                continue
-            try:
-                self.unload_skill(skill_name)
-            except Exception as exc:  # noqa: BLE001
-                logger.debug(
-                    "[%s] cleanup unload after standalone affinity prepare failed for %r: %s",
-                    self._dcc_name,
-                    skill_name,
-                    exc,
-                )
-        return prepared
-
-    def _discovered_skill_names(self) -> tuple[str, ...]:
-        names: list[str] = []
-        for item in self.list_skills():
-            name = item.get("name") if isinstance(item, dict) else getattr(item, "name", None)
-            if name:
-                names.append(str(name))
-        return tuple(dict.fromkeys(names))
-
-    def _load_skill_via_core_object(self, skill_name: str) -> bool:
-        if not self._uses_standalone_affinity_override():
-            return super().load_skill(skill_name)
-
-        skill = self.get_skill(skill_name)
-        if skill is None:
-            logger.debug("[%s] get_skill(%r) returned no skill", self._dcc_name, skill_name)
-            return False
-        changed = self._disable_tool_affinity_enforcement(skill)
-        logger.debug(
-            "[%s] load_skill(%r) using core skill object affinity overrides changed=%s",
-            self._dcc_name,
-            skill_name,
-            changed,
-        )
-        self.load_skill_object(skill)
-        return True
-
-    @staticmethod
-    def _disable_tool_affinity_enforcement(skill: Any) -> bool:
-        changed = False
-        tools = list(getattr(skill, "tools", ()) or ())
-        for tool in tools:
-            if getattr(tool, "enforce_thread_affinity", None) is not True:
-                continue
-            setattr(tool, "enforce_thread_affinity", False)
-            changed = True
-        if changed:
-            setattr(skill, "tools", tools)
-        return changed
 
     def _register_recipes_tools(self, context: _registration.RegistrationContext) -> None:
         """Register ``recipes__*`` tools so ``metadata.dcc-mcp.recipes`` files are agent-readable."""
@@ -758,10 +644,14 @@ class MayaMcpServer(DccServerBase):
         publish can invoke :meth:`publish_capability_snapshot` directly.
         """
         try:
-            return self._load_skill_via_core_object(skill_name)
+            skill_client = getattr(self, "_skill_client", None) or self._server
+            if skill_client is None:
+                return False
+            skill_client.load_skill(skill_name)
         except Exception as exc:  # noqa: BLE001
             logger.debug("[%s] load_skill(%r) failed: %s", self._dcc_name, skill_name, exc)
             return False
+        return True
 
     def unload_skill(self, skill_name: str) -> bool:
         """Unload *skill_name*.

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -524,11 +524,7 @@ class MayaMcpServer(DccServerBase):
         except ImportError as exc:
             logger.debug("[%s] recipes tools skipped (import): %s", self._dcc_name, exc)
             return
-        try:
-            skills = self._scan_skill_metadata_for_sidecars(context)
-            register_recipes_tools(self._server, skills=skills, dcc_name=self._dcc_name)
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("[%s] register_recipes_tools failed: %s", self._dcc_name, exc)
+        self._register_skill_metadata_tools(self._server, context, register_recipes_tools, "recipes")
 
     def _register_skill_reference_docs_tools(self, context: _registration.RegistrationContext) -> None:
         """Register ``skill_refs__*`` for arbitrary reference Markdown/text beside a skill."""
@@ -537,11 +533,25 @@ class MayaMcpServer(DccServerBase):
         except ImportError as exc:
             logger.debug("[%s] skill_refs tools skipped (import): %s", self._dcc_name, exc)
             return
+        self._register_skill_metadata_tools(
+            self._server,
+            context,
+            register_skill_reference_docs_tools,
+            "skill_refs",
+        )
+
+    def _register_skill_metadata_tools(
+        self,
+        server: Any,
+        context: _registration.RegistrationContext,
+        register_fn,
+        kind: str,
+    ) -> None:
         try:
             skills = self._scan_skill_metadata_for_sidecars(context)
-            register_skill_reference_docs_tools(self._server, skills=skills, dcc_name=self._dcc_name)
+            register_fn(server, skills=skills, dcc_name=self._dcc_name)
         except Exception as exc:  # noqa: BLE001
-            logger.debug("[%s] register_skill_reference_docs_tools failed: %s", self._dcc_name, exc)
+            logger.debug("[%s] %s tools failed: %s", self._dcc_name, kind, exc)
 
     def _scan_skill_metadata_for_sidecars(self, context: _registration.RegistrationContext) -> List[Any]:
         """Return ``SkillMetadata`` list aligned with ``collect_skill_search_paths`` (read-only scan)."""

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -32,6 +32,7 @@ from typing import Any, List, Optional
 
 # Import third-party modules
 from dcc_mcp_core import DccServerOptions, HostExecutionBridge, scan_and_load_strict
+from dcc_mcp_core._server.minimal_mode import apply_minimal_mode
 from dcc_mcp_core.factory import create_dcc_server
 from dcc_mcp_core.server_base import DccServerBase
 
@@ -511,11 +512,123 @@ class MayaMcpServer(DccServerBase):
         return self
 
     def _register_core_builtin_actions(self, context: _registration.RegistrationContext) -> None:
+        minimal_mode = self._build_minimal_mode_config(context.minimal)
+        if not self._uses_standalone_affinity_override():
+            super().register_builtin_actions(
+                extra_skill_paths=context.extra_skill_paths,
+                include_bundled=context.include_bundled,
+                minimal_mode=minimal_mode,
+            )
+            return
+
         super().register_builtin_actions(
             extra_skill_paths=context.extra_skill_paths,
             include_bundled=context.include_bundled,
-            minimal_mode=self._build_minimal_mode_config(context.minimal),
+            minimal_mode=None,
         )
+        prepared = self._prepare_standalone_skill_metadata_overrides()
+        if prepared:
+            logger.info(
+                "[%s] Prepared %d discovered skill(s) for standalone affinity overrides",
+                self._dcc_name,
+                prepared,
+            )
+        if minimal_mode is not None:
+            loaded = apply_minimal_mode(self, minimal_mode, dcc_name=self._dcc_name)
+            logger.info(
+                "[%s] Minimal mode: %d skill(s) loaded eagerly via core skill objects",
+                self._dcc_name,
+                loaded,
+            )
+
+    @property
+    def catalog(self) -> Any | None:
+        """Expose a usable core catalog handle when the runtime provides one."""
+        catalog = getattr(self._server, "catalog", None)
+        if hasattr(catalog, "deactivate_group"):
+            return catalog
+        return None
+
+    def _uses_standalone_affinity_override(self) -> bool:
+        dispatcher = getattr(self, "_host_dispatcher", None)
+        return type(dispatcher).__name__ in {"MayaStandaloneDispatcher", "PyStandaloneDispatcher"}
+
+    def _prepare_standalone_skill_metadata_overrides(self) -> int:
+        """Persist standalone affinity overrides for core-managed stub loading."""
+        skill_names = self._discovered_skill_names()
+        prepared = 0
+        for skill_name in skill_names:
+            skill = self.get_skill(skill_name)
+            if skill is None or not self._disable_tool_affinity_enforcement(skill):
+                continue
+            try:
+                if self.load_skill_object(skill):
+                    prepared += 1
+                else:
+                    logger.warning(
+                        "[%s] Could not prepare standalone affinity overrides for %r",
+                        self._dcc_name,
+                        skill_name,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[%s] Could not prepare standalone affinity overrides for %r: %s",
+                    self._dcc_name,
+                    skill_name,
+                    exc,
+                )
+
+        for skill_name in skill_names:
+            if not self.is_skill_loaded(skill_name):
+                continue
+            try:
+                self.unload_skill(skill_name)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "[%s] cleanup unload after standalone affinity prepare failed for %r: %s",
+                    self._dcc_name,
+                    skill_name,
+                    exc,
+                )
+        return prepared
+
+    def _discovered_skill_names(self) -> tuple[str, ...]:
+        names: list[str] = []
+        for item in self.list_skills():
+            name = item.get("name") if isinstance(item, dict) else getattr(item, "name", None)
+            if name:
+                names.append(str(name))
+        return tuple(dict.fromkeys(names))
+
+    def _load_skill_via_core_object(self, skill_name: str) -> bool:
+        if not self._uses_standalone_affinity_override():
+            return super().load_skill(skill_name)
+
+        skill = self.get_skill(skill_name)
+        if skill is None:
+            logger.debug("[%s] get_skill(%r) returned no skill", self._dcc_name, skill_name)
+            return False
+        changed = self._disable_tool_affinity_enforcement(skill)
+        logger.debug(
+            "[%s] load_skill(%r) using core skill object affinity overrides changed=%s",
+            self._dcc_name,
+            skill_name,
+            changed,
+        )
+        return bool(self.load_skill_object(skill))
+
+    @staticmethod
+    def _disable_tool_affinity_enforcement(skill: Any) -> bool:
+        changed = False
+        tools = list(getattr(skill, "tools", ()) or ())
+        for tool in tools:
+            if getattr(tool, "enforce_thread_affinity", None) is not True:
+                continue
+            setattr(tool, "enforce_thread_affinity", False)
+            changed = True
+        if changed:
+            setattr(skill, "tools", tools)
+        return changed
 
     def _register_recipes_tools(self, context: _registration.RegistrationContext) -> None:
         """Register ``recipes__*`` tools so ``metadata.dcc-mcp.recipes`` files are agent-readable."""
@@ -654,14 +767,10 @@ class MayaMcpServer(DccServerBase):
         publish can invoke :meth:`publish_capability_snapshot` directly.
         """
         try:
-            skill_client = getattr(self, "_skill_client", None) or self._server
-            if skill_client is None:
-                return False
-            skill_client.load_skill(skill_name)
+            return self._load_skill_via_core_object(skill_name)
         except Exception as exc:  # noqa: BLE001
             logger.debug("[%s] load_skill(%r) failed: %s", self._dcc_name, skill_name, exc)
             return False
-        return True
 
     def unload_skill(self, skill_name: str) -> bool:
         """Unload *skill_name*.

--- a/tests/_transport_support.py
+++ b/tests/_transport_support.py
@@ -123,6 +123,7 @@ def wait_for_sidecar_registry_row(
     timeout: float = 8.0,
     *,
     host_rpc_uri: Optional[str] = None,
+    require_dialable_port: bool = True,
 ) -> Dict[str, Any]:
     services_path = registry_dir / "services.json"
     deadline = time.monotonic() + timeout
@@ -134,13 +135,13 @@ def wait_for_sidecar_registry_row(
             except (json.JSONDecodeError, OSError) as exc:
                 last_err = exc
             else:
-                for entry in _iter_registry_entries(payload):
+                for entry in iter_registry_entries(payload):
                     metadata = entry.get("metadata") or {}
                     if metadata.get("dcc_mcp_role") != "per-dcc-sidecar":
                         continue
                     if host_rpc_uri is not None and metadata.get("host_rpc_uri") != host_rpc_uri:
                         continue
-                    if not _entry_has_dialable_mcp_port(entry):
+                    if require_dialable_port and not _entry_has_dialable_mcp_port(entry):
                         continue
                     return entry
         time.sleep(0.05)
@@ -226,7 +227,7 @@ def _dialable_loopback_mcp_url(url: str) -> str:
     return urllib.parse.urlunsplit((parsed.scheme or "http", netloc, path, parsed.query, parsed.fragment))
 
 
-def _iter_registry_entries(payload: object) -> Iterator[Dict[str, Any]]:
+def iter_registry_entries(payload: object) -> Iterator[Dict[str, Any]]:
     if isinstance(payload, list):
         for item in payload:
             if isinstance(item, dict):
@@ -241,10 +242,10 @@ def _iter_registry_entries(payload: object) -> Iterator[Dict[str, Any]]:
             for item in services.values():
                 if isinstance(item, dict):
                     yield item
-        else:
-            for value in payload.values():
-                if isinstance(value, dict) and "dcc_type" in value:
-                    yield value
+    else:
+        for value in payload.values():
+            if isinstance(value, dict) and "dcc_type" in value:
+                yield value
 
 
 class ParentSurrogate:

--- a/tests/_transport_support.py
+++ b/tests/_transport_support.py
@@ -126,12 +126,12 @@ def wait_for_sidecar_registry_row(
 ) -> Dict[str, Any]:
     services_path = registry_dir / "services.json"
     deadline = time.monotonic() + timeout
-    last_err = None
+    last_err: Optional[Exception] = None
     while time.monotonic() < deadline:
         if services_path.is_file():
             try:
                 payload = json.loads(services_path.read_text(encoding="utf-8"))
-            except json.JSONDecodeError as exc:
+            except (json.JSONDecodeError, OSError) as exc:
                 last_err = exc
             else:
                 for entry in _iter_registry_entries(payload):
@@ -150,9 +150,18 @@ def wait_for_sidecar_registry_row(
             services_path,
             host_rpc_uri,
             last_err,
-            services_path.read_text(encoding="utf-8") if services_path.is_file() else "<missing>",
+            _maybe_read_text(services_path),
         )
     )
+
+
+def _maybe_read_text(path: Path) -> str:
+    if not path.is_file():
+        return "<missing>"
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return "<unreadable: {!r}>".format(exc)
 
 
 def wait_for_tcp_url(url: str, timeout: float = 8.0) -> str:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -74,67 +74,6 @@ def test_dispatcher_shutdown_log_skips_closed_stream(capsys):
         srv_mod.logger.removeHandler(handler)
 
 
-def _core_supports_nested_dcc_mcp_metadata():
-    """True iff the installed dcc-mcp-core honours nested ``metadata.dcc-mcp``.
-
-    After the sibling-file migration, every SKILL.md uses the nested
-    mapping form (``metadata: { dcc-mcp: { tools: "tools.yaml", ... } }``).
-    Cores older than dcc-mcp-core#385 silently drop these overrides,
-    which makes the server-level assertions about ``__skill__`` stubs
-    and group activation meaningless. We probe by scanning a temp skill
-    and checking whether the override is actually applied.
-    """
-    import tempfile
-    from pathlib import Path
-
-    try:
-        from dcc_mcp_core import scan_and_load
-    except ImportError:
-        return False
-
-    with tempfile.TemporaryDirectory() as tmp:
-        probe = Path(tmp) / "probe-skill"
-        probe.mkdir()
-        (probe / "tools.yaml").write_text(
-            "tools:\n  - name: ping\n    description: probe tool\n",
-            encoding="utf-8",
-        )
-        (probe / "SKILL.md").write_text(
-            "---\n"
-            "name: probe-skill\n"
-            "description: probe for nested dcc-mcp metadata support\n"
-            "metadata:\n"
-            "  dcc-mcp:\n"
-            "    dcc: maya\n"
-            "    tools: tools.yaml\n"
-            "---\n# body\n",
-            encoding="utf-8",
-        )
-        try:
-            skills, _ = scan_and_load(extra_paths=[tmp], dcc_name="maya")
-        except Exception:
-            return False
-        for s in skills:
-            if s.name == "probe-skill":
-                tools = getattr(s, "tools", None)
-                if callable(tools):
-                    tools = tools()
-                return bool(tools)
-    return False
-
-
-_CORE_SUPPORTS_NESTED_META = _core_supports_nested_dcc_mcp_metadata()
-
-_skip_without_nested_meta = pytest.mark.skipif(
-    not _CORE_SUPPORTS_NESTED_META,
-    reason=(
-        "Installed dcc-mcp-core does not support nested metadata.dcc-mcp "
-        "(requires dcc-mcp-core#385 / >= 0.15). Skipping assertions that "
-        "depend on skill tools/groups being visible to the scanner."
-    ),
-)
-
-
 def _builtin_skills_dir():
     """Return the built-in skills directory, resolving it from the package."""
     from pathlib import Path
@@ -396,99 +335,20 @@ class TestMayaMcpServerApi:
         assert type(dispatcher).__name__ == "MayaUiDispatcher"
         assert isinstance(server._auto_ui_pump, FailingPump)
 
-    def test_standalone_affinity_override_uses_core_skill_object(self):
-        """mayapy direct HTTP adjusts detached core skill metadata before loading."""
+    def test_core_builtin_registration_uses_normal_minimal_mode_path(self):
+        """Core-owned minimal-mode loading should not require local skill manifest rewriting."""
         srv_mod = _import_server()
-
-        class Tool:
-            def __init__(self, enforce_thread_affinity):
-                self.enforce_thread_affinity = enforce_thread_affinity
-
-        class Skill:
-            def __init__(self):
-                self.tools = [Tool(True), Tool(False)]
-
-        class Inner:
-            def __init__(self):
-                self.skill = Skill()
-                self.loaded = None
-
-            def get_skill(self, name):
-                assert name == "maya-scene"
-                return self.skill
-
-            def load_skill_object(self, skill):
-                self.loaded = skill
-
-            def load_skill(self, name):  # pragma: no cover - must not be used
-                raise AssertionError(f"unexpected YAML-backed load_skill({name!r})")
-
-        server = object.__new__(srv_mod.MayaMcpServer)
-        server._dcc_name = "maya"
-        server._host_dispatcher = type("MayaStandaloneDispatcher", (), {})()
-        server._server = Inner()
-        server._skill_client = MagicMock()
-        server._skill_client.get_skill.side_effect = server._server.get_skill
-        server._skill_client.load_skill_object.side_effect = server._server.load_skill_object
-
-        assert server._load_skill_via_core_object("maya-scene") is True
-        assert server._server.loaded is server._server.skill
-        server._skill_client.get_skill.assert_called_once_with("maya-scene")
-        server._skill_client.load_skill_object.assert_called_once_with(server._server.skill)
-        assert [tool.enforce_thread_affinity for tool in server._server.skill.tools] == [False, False]
-
-    def test_standalone_affinity_prepare_persists_for_core_catalog_load(self):
-        """Core-owned MCP load_skill sees Maya standalone metadata overrides too."""
-        srv_mod = _import_server()
-
-        dispatcher = type("MayaStandaloneDispatcher", (), {})()
-        server = srv_mod.MayaMcpServer(
-            port=0,
-            enable_gateway_failover=False,
-            gateway_port=0,
-            host_dispatcher=dispatcher,
-        )
-        try:
-            server.register_builtin_actions(minimal=True)
-            loaded = server._server.load_skill("maya-primitives")
-            assert "maya_primitives__create_sphere" in loaded
-            meta = server._server.registry.get_action("maya_primitives__create_sphere")
-            assert meta is not None
-            assert meta["thread_affinity"] == "main"
-            assert meta.get("enforce_thread_affinity", False) is False
-        finally:
-            server.stop()
-
-    def test_standalone_registration_discovers_bundled_skills_without_pyyaml(self):
-        """Clean release archives do not need PyYAML to expose Maya skills."""
-        srv_mod = _import_server()
-        dispatcher = type("MayaStandaloneDispatcher", (), {})()
-
-        with patch.dict(sys.modules, {"yaml": None}):
-            server = srv_mod.MayaMcpServer(
-                port=0,
-                enable_gateway_failover=False,
-                gateway_port=0,
-                host_dispatcher=dispatcher,
-            )
-            try:
-                server.register_builtin_actions(minimal=True)
-                assert server._registration_report.outcomes[0].success is True
-                skills = server.list_skills()
-                assert any(skill.get("name") == "maya-scene" for skill in skills)
-                assert server.load_skill("maya-scene") is True
-                assert any("maya_scene__get_session_info" in str(action) for action in server.list_actions())
-            finally:
-                server.stop()
-
-    def test_affinity_override_skipped_for_host_dispatcher(self):
-        """Only standalone dispatchers need object-level affinity overrides."""
-        srv_mod = _import_server()
-
         server = srv_mod.MayaMcpServer(port=0, enable_gateway_failover=False, gateway_port=0)
-        server._host_dispatcher = object()
         try:
-            assert server._uses_standalone_affinity_override() is False
+            context = srv_mod._registration.RegistrationContext(
+                server=server,
+                extra_skill_paths=[_builtin_skills_dir()],
+                include_bundled=True,
+                minimal=True,
+            )
+            server._register_core_builtin_actions(context)
+            skill_names = [s.name if hasattr(s, "name") else s["name"] for s in server._server.list_skills()]
+            assert "maya-scripting" in skill_names
         finally:
             server.stop()
 
@@ -705,7 +565,7 @@ class TestMayaMcpServerHttp:
             for n in names
             if n not in core_meta_tools and not n.startswith(reserved_prefix) and not n.startswith("maya-")
         }
-        skill_tools = skill_stubs | prefixed_tools | bare_skill_tools
+        skill_tools = set().union(skill_stubs, prefixed_tools, bare_skill_tools)
         assert len(skill_tools) >= 3, (
             f"Expected >=3 maya skill tools (stubs/prefixed/bare), got {len(skill_tools)}: {names}"
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -352,6 +352,103 @@ class TestMayaMcpServerApi:
         finally:
             server.stop()
 
+    def test_standalone_affinity_override_uses_core_skill_object(self):
+        """mayapy direct HTTP adjusts detached core skill metadata before loading."""
+        srv_mod = _import_server()
+
+        class Tool:
+            def __init__(self, enforce_thread_affinity):
+                self.enforce_thread_affinity = enforce_thread_affinity
+
+        class Skill:
+            def __init__(self):
+                self.tools = [Tool(True), Tool(False)]
+
+        class Inner:
+            def __init__(self):
+                self.skill = Skill()
+                self.loaded = None
+
+            def get_skill(self, name):
+                assert name == "maya-scene"
+                return self.skill
+
+            def load_skill_object(self, skill):
+                self.loaded = skill
+                return True
+
+            def load_skill(self, name):  # pragma: no cover - must not be used
+                raise AssertionError(f"unexpected direct load_skill({name!r})")
+
+        server = object.__new__(srv_mod.MayaMcpServer)
+        server._dcc_name = "maya"
+        server._host_dispatcher = type("MayaStandaloneDispatcher", (), {})()
+        server._server = Inner()
+        server._skill_client = MagicMock()
+        server._skill_client.get_skill.side_effect = server._server.get_skill
+        server._skill_client.load_skill_object.side_effect = server._server.load_skill_object
+
+        assert server._load_skill_via_core_object("maya-scene") is True
+        assert server._server.loaded is server._server.skill
+        server._skill_client.get_skill.assert_called_once_with("maya-scene")
+        server._skill_client.load_skill_object.assert_called_once_with(server._server.skill)
+        assert [tool.enforce_thread_affinity for tool in server._server.skill.tools] == [False, False]
+
+    def test_standalone_affinity_prepare_persists_for_core_catalog_load(self):
+        """Core-owned MCP load_skill sees Maya standalone metadata overrides too."""
+        srv_mod = _import_server()
+
+        dispatcher = type("MayaStandaloneDispatcher", (), {})()
+        server = srv_mod.MayaMcpServer(
+            port=0,
+            enable_gateway_failover=False,
+            gateway_port=0,
+            host_dispatcher=dispatcher,
+        )
+        try:
+            server.register_builtin_actions(minimal=True)
+            loaded = server._server.load_skill("maya-primitives")
+            assert "maya_primitives__create_sphere" in loaded
+            meta = server._server.registry.get_action("maya_primitives__create_sphere")
+            assert meta is not None
+            assert meta["thread_affinity"] == "main"
+            assert meta.get("enforce_thread_affinity", False) is False
+        finally:
+            server.stop()
+
+    def test_standalone_registration_discovers_bundled_skills_without_pyyaml(self):
+        """Clean release archives do not need PyYAML to expose Maya skills."""
+        srv_mod = _import_server()
+        dispatcher = type("MayaStandaloneDispatcher", (), {})()
+
+        with patch.dict(sys.modules, {"yaml": None}):
+            server = srv_mod.MayaMcpServer(
+                port=0,
+                enable_gateway_failover=False,
+                gateway_port=0,
+                host_dispatcher=dispatcher,
+            )
+            try:
+                server.register_builtin_actions(minimal=True)
+                assert server._registration_report.outcomes[0].success is True
+                skills = server.list_skills()
+                assert any(skill.get("name") == "maya-scene" for skill in skills)
+                assert server.load_skill("maya-scene") is True
+                assert any("maya_scene__get_session_info" in str(action) for action in server.list_actions())
+            finally:
+                server.stop()
+
+    def test_affinity_override_skipped_for_host_dispatcher(self):
+        """Only standalone dispatchers need object-level affinity overrides."""
+        srv_mod = _import_server()
+
+        server = srv_mod.MayaMcpServer(port=0, enable_gateway_failover=False, gateway_port=0)
+        server._host_dispatcher = object()
+        try:
+            assert server._uses_standalone_affinity_override() is False
+        finally:
+            server.stop()
+
 
 # ── Issue #138: strict skill scan opt-in ──────────────────────────────────────
 

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -62,9 +62,10 @@ def _make_bare_server(builtin_dir=None):
 
     srv._config = McpHttpConfig()
     srv._server = MagicMock()
-    # Core 0.14.20 register_builtin_actions touches these attributes; normally
+    # DccServerBase.register_builtin_actions touches these attributes; normally
     # populated by DccServerBase.__init__, which we bypass here.
     srv._dcc_dispatcher = None
+    srv._standalone_main_thread = False
     srv._execution_bridge = None
     srv._inprocess_executor_registered = False
     return srv
@@ -124,15 +125,12 @@ class TestLoadSkillFailure:
         server = _make_bare_server()
 
         mock_mcp_server = MagicMock()
-        mock_mcp_server.discover.return_value = 1
         mock_mcp_server.list_skills.return_value = []
         server._server = mock_mcp_server
 
-        # minimal=False → _load_all_discovered_skills is called but list_skills
-        # returns empty, so load_skill is never called
         result = server.register_builtin_actions(minimal=False)
         assert result is server
-        mock_mcp_server.discover.assert_called_once()
+        assert server._registration_report.success is True
         mock_mcp_server.load_skill.assert_not_called()
 
     def test_register_builtin_actions_keeps_working_when_discover_succeeds(self):
@@ -140,12 +138,11 @@ class TestLoadSkillFailure:
         server = _make_bare_server()
 
         mock_mcp_server = MagicMock()
-        mock_mcp_server.discover.return_value = 2
         server._server = mock_mcp_server
 
         result = server.register_builtin_actions()
         assert result is server
-        mock_mcp_server.discover.assert_called_once()
+        assert server._registration_report.success is True
 
 
 # ── start_server with extra_skill_paths ───────────────────────────────────────

--- a/tests/test_sidecar_shim_lifecycle.py
+++ b/tests/test_sidecar_shim_lifecycle.py
@@ -64,6 +64,7 @@ from dcc_mcp_maya.sidecar import (
     start_sidecar,
     stop_sidecar,
 )
+from tests._transport_support import iter_registry_entries, wait_for_sidecar_registry_row
 
 # ── shared fixtures ──────────────────────────────────────────────
 
@@ -230,55 +231,6 @@ def isolated_registry_dir(tmp_path: Path) -> Path:
     return registry
 
 
-def _wait_for_registry_row(registry_dir: Path, timeout: float = 5.0) -> dict:
-    """Poll ``services.json`` until a per-dcc-sidecar row appears."""
-    services_path = registry_dir / "services.json"
-    deadline = time.monotonic() + timeout
-    last_err = None
-    while time.monotonic() < deadline:
-        if services_path.is_file():
-            try:
-                payload = json.loads(services_path.read_text())
-            except json.JSONDecodeError as exc:
-                last_err = exc
-            else:
-                for entry in _iter_entries(payload):
-                    metadata = entry.get("metadata") or {}
-                    if metadata.get("dcc_mcp_role") == "per-dcc-sidecar":
-                        return entry
-        time.sleep(0.05)
-    raise AssertionError(
-        f"per-dcc-sidecar row never appeared in {services_path} within "
-        f"{timeout}s. Last JSON error: {last_err}. "
-        f"Final contents: {services_path.read_text() if services_path.is_file() else '<missing>'}"
-    )
-
-
-def _iter_entries(payload: object) -> Iterator[dict]:
-    """Yield service entries regardless of which container shape the
-    Rust ``FileRegistry`` flushed (``services.json`` schema has changed
-    a few times — be liberal in what we accept)."""
-    if isinstance(payload, list):
-        for item in payload:
-            if isinstance(item, dict):
-                yield item
-    elif isinstance(payload, dict):
-        services = payload.get("services")
-        if isinstance(services, list):
-            for item in services:
-                if isinstance(item, dict):
-                    yield item
-        elif isinstance(services, dict):
-            for item in services.values():
-                if isinstance(item, dict):
-                    yield item
-        else:
-            # Top-level mapping of key -> entry
-            for value in payload.values():
-                if isinstance(value, dict) and "dcc_type" in value:
-                    yield value
-
-
 def _wait_for_proc_exit(handle: SidecarHandle, timeout: float = 5.0) -> int:
     """Block until the sidecar subprocess exits; return its exit code."""
     deadline = time.monotonic() + timeout
@@ -352,7 +304,7 @@ class TestSidecarLifecycle:
             start_qt_server_fn=_qt_stub_factory(fake_qt_server),
         )
         try:
-            entry = _wait_for_registry_row(isolated_registry_dir)
+            entry = wait_for_sidecar_registry_row(isolated_registry_dir, timeout=5.0, require_dialable_port=False)
             assert entry["dcc_type"] == "maya"
             assert entry["pid"] == parent_surrogate.pid, (
                 "FileRegistry row's pid must equal the parent we asked the "
@@ -389,7 +341,7 @@ class TestSidecarLifecycle:
             registry_dir=isolated_registry_dir,
             start_qt_server_fn=_qt_stub_factory(fake_qt_server),
         )
-        _wait_for_registry_row(isolated_registry_dir)
+        wait_for_sidecar_registry_row(isolated_registry_dir, timeout=5.0, require_dialable_port=False)
 
         parent_surrogate.kill()
 
@@ -407,7 +359,7 @@ class TestSidecarLifecycle:
             payload = json.loads(services_path.read_text())
             survivors = [
                 entry
-                for entry in _iter_entries(payload)
+                for entry in iter_registry_entries(payload)
                 if (entry.get("metadata") or {}).get("dcc_mcp_role") == "per-dcc-sidecar"
             ]
             assert survivors == [], (
@@ -433,7 +385,7 @@ class TestSidecarLifecycle:
             start_qt_server_fn=_qt_stub_factory(fake_qt_server),
         )
         try:
-            entry = _wait_for_registry_row(isolated_registry_dir)
+            entry = wait_for_sidecar_registry_row(isolated_registry_dir, timeout=5.0, require_dialable_port=False)
             assert entry.get("display_name") == "Maya-Test"
             assert entry.get("adapter_version") == "0.0.0-test"
             assert entry.get("adapter_dcc") == "maya"


### PR DESCRIPTION
This PR moves the Maya adapter to the current `dcc-mcp-core>=0.17.34` baseline and restores the standalone/mayapy skill-object affinity override path that core now exposes publicly.

- Uses `DccServerBase.get_skill()` / `load_skill_object()` to persist standalone `enforce_thread_affinity=False` metadata without mutating YAML files
- Applies minimal mode after standalone metadata preparation so direct MCP `load_skill` calls see the same override
- Keeps normal host-dispatcher registration on the upstream core-owned minimal-mode path
- Updates core/server dependency docs to 0.17.34
- Covers the mayapy/direct HTTP regression with focused standalone affinity tests and fixes the core 0.17.34 test fixture state bit

Local verification:
- `python -m ruff check src/ tests/`
- `python -m ruff format --check src/ tests/`
- `python -m pytest tests/test_server.py tests/test_server_coverage.py -q`
- `python -m pytest tests/ --ignore=tests/e2e --ignore=tests/e2e_standalone -q`