### PR TITLE
fix: use core skill load transforms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 `dcc-mcp-maya` embeds a standards-compliant MCP Streamable HTTP server directly inside Autodesk Maya. It exposes 177 Maya operations as MCP tools that any AI agent (Claude, Cursor, Gemini, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
 **Current version:** 0.3.8 <!-- x-release-please-version -->
-**Core dependency:** `dcc-mcp-core>=0.17.34,<1.0.0`
+**Core dependency:** `dcc-mcp-core>=0.17.35,<1.0.0`
 **Python:** 3.7+
 **Maya:** 2020+
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Maya plugin starts a Rust `dcc-mcp-server` sidecar by default, so HTTP and g
 [![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-maya?label=Python)](https://pypi.org/project/dcc-mcp-maya/)
 [![Maya](https://img.shields.io/badge/Maya-2020%2B-37A5CC)](https://www.autodesk.com/products/maya/overview)
 [![MCP](https://img.shields.io/badge/MCP-Streamable%20HTTP-6f42c1)](https://modelcontextprotocol.io/)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.34-blue)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.35-blue)](https://github.com/loonghao/dcc-mcp-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ## Why Use It
@@ -175,7 +175,7 @@ mode. On clean machines, install or provide the sidecar runtime before loading
 the plugin:
 
 ```bash
-mayapy -m pip install "dcc-mcp-server>=0.17.34"
+mayapy -m pip install "dcc-mcp-server>=0.17.35"
 mayapy -c "from dcc_mcp_maya.sidecar import resolve_sidecar_binary; print(resolve_sidecar_binary())"
 ```
 
@@ -372,8 +372,8 @@ Windows symlinks require Developer Mode or an elevated shell. If symlinks are un
 
 - Autodesk Maya 2020+
 - Python 3.7+
-- `dcc-mcp-core>=0.17.34,<1.0.0`
-- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.17.34`
+- `dcc-mcp-core>=0.17.35,<1.0.0`
+- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.17.35`
 
 ## License
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,7 +14,7 @@ Embeds a standards-compliant MCP Streamable HTTP server (2025-03-26 spec) direct
 - **Repository:** https://github.com/loonghao/dcc-mcp-maya
 - **Python:** >=3.7
 - **Maya:** 2020+
-- **Core dependency:** `dcc-mcp-core>=0.17.34,<1.0.0`
+- **Core dependency:** `dcc-mcp-core>=0.17.35,<1.0.0`
 - **Entry point:** `dcc_mcp.adapters` → `maya = "dcc_mcp_maya:MayaMcpServer"`
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 **Repo:** https://github.com/loonghao/dcc-mcp-maya
 **Python:** >=3.7
 **Maya:** 2020+
-**Core dep:** `dcc-mcp-core>=0.17.34,<1.0.0`
+**Core dep:** `dcc-mcp-core>=0.17.35,<1.0.0`
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,12 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.17.34+: public DccServerBase get_skill/load_skill_object for
-    # adapter-facing SkillMetadata overrides, plus Claude-safe underscore names
+    # 0.17.35+: public DccServerBase skill-load transform hooks for
+    # adapter-facing SkillMetadata policies, plus Claude-safe underscore names
     # for built-in jobs/project tools, registry write hardening, runtime
     # observation contracts, and gateway diagnostics.
     # abi3 (cp38+) on 3.8+; separate cp37 wheels on Python 3.7 (Maya 2022).
-    "dcc-mcp-core>=0.17.34,<1.0.0",
+    "dcc-mcp-core>=0.17.35,<1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -43,7 +43,7 @@ dev = [
     "pytest-timeout>=2.1.0",
     "pytest-xdist>=3.0",
     "requests>=2.28.0",
-    "dcc-mcp-server>=0.17.34",
+    "dcc-mcp-server>=0.17.35",
     "ruff>=0.8.0",
     "hatchling",
     "build",
@@ -51,7 +51,7 @@ dev = [
     "pyyaml>=5.0",  # YAML parsing for SKILL.md test validation
 ]
 sidecar = [
-    "dcc-mcp-server>=0.17.34",
+    "dcc-mcp-server>=0.17.35",
 ]
 
 [project.urls]

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -32,7 +32,6 @@ from typing import Any, List, Optional
 
 # Import third-party modules
 from dcc_mcp_core import DccServerOptions, HostExecutionBridge, scan_and_load_strict
-from dcc_mcp_core._server.minimal_mode import apply_minimal_mode
 from dcc_mcp_core.factory import create_dcc_server
 from dcc_mcp_core.server_base import DccServerBase
 
@@ -513,112 +512,33 @@ class MayaMcpServer(DccServerBase):
 
     def _register_core_builtin_actions(self, context: _registration.RegistrationContext) -> None:
         minimal_mode = self._build_minimal_mode_config(context.minimal)
-        if not self._uses_standalone_affinity_override():
-            super().register_builtin_actions(
-                extra_skill_paths=context.extra_skill_paths,
-                include_bundled=context.include_bundled,
-                minimal_mode=minimal_mode,
-            )
-            return
+        self._configure_skill_load_transform()
 
         super().register_builtin_actions(
             extra_skill_paths=context.extra_skill_paths,
             include_bundled=context.include_bundled,
-            minimal_mode=None,
+            minimal_mode=minimal_mode,
         )
-        prepared = self._prepare_standalone_skill_metadata_overrides()
-        if prepared:
-            logger.info(
-                "[%s] Prepared %d discovered skill(s) for standalone affinity overrides",
-                self._dcc_name,
-                prepared,
-            )
-        if minimal_mode is not None:
-            loaded = apply_minimal_mode(self, minimal_mode, dcc_name=self._dcc_name)
-            logger.info(
-                "[%s] Minimal mode: %d skill(s) loaded eagerly via core skill objects",
-                self._dcc_name,
-                loaded,
-            )
-
-    @property
-    def catalog(self) -> Any | None:
-        """Expose a usable core catalog handle when the runtime provides one."""
-        catalog = getattr(self._server, "catalog", None)
-        if hasattr(catalog, "deactivate_group"):
-            return catalog
-        return None
 
     def _uses_standalone_affinity_override(self) -> bool:
         dispatcher = getattr(self, "_host_dispatcher", None)
         return type(dispatcher).__name__ in {"MayaStandaloneDispatcher", "PyStandaloneDispatcher"}
 
-    def _prepare_standalone_skill_metadata_overrides(self) -> int:
-        """Persist standalone affinity overrides for core-managed stub loading."""
-        skill_names = self._discovered_skill_names()
-        prepared = 0
-        for skill_name in skill_names:
-            skill = self.get_skill(skill_name)
-            if skill is None or not self._disable_tool_affinity_enforcement(skill):
-                continue
-            try:
-                if self.load_skill_object(skill):
-                    prepared += 1
-                else:
-                    logger.warning(
-                        "[%s] Could not prepare standalone affinity overrides for %r",
-                        self._dcc_name,
-                        skill_name,
-                    )
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "[%s] Could not prepare standalone affinity overrides for %r: %s",
-                    self._dcc_name,
-                    skill_name,
-                    exc,
-                )
-
-        for skill_name in skill_names:
-            if not self.is_skill_loaded(skill_name):
-                continue
-            try:
-                self.unload_skill(skill_name)
-            except Exception as exc:  # noqa: BLE001
-                logger.debug(
-                    "[%s] cleanup unload after standalone affinity prepare failed for %r: %s",
-                    self._dcc_name,
-                    skill_name,
-                    exc,
-                )
-        return prepared
-
-    def _discovered_skill_names(self) -> tuple[str, ...]:
-        names: list[str] = []
-        for item in self.list_skills():
-            name = item.get("name") if isinstance(item, dict) else getattr(item, "name", None)
-            if name:
-                names.append(str(name))
-        return tuple(dict.fromkeys(names))
-
-    def _load_skill_via_core_object(self, skill_name: str) -> bool:
+    def _configure_skill_load_transform(self) -> None:
+        """Install Maya's standalone policy through core's skill-load hook."""
         if not self._uses_standalone_affinity_override():
-            return super().load_skill(skill_name)
+            self.clear_skill_load_transform()
+            return
 
-        skill = self.get_skill(skill_name)
-        if skill is None:
-            logger.debug("[%s] get_skill(%r) returned no skill", self._dcc_name, skill_name)
-            return False
-        changed = self._disable_tool_affinity_enforcement(skill)
-        logger.debug(
-            "[%s] load_skill(%r) using core skill object affinity overrides changed=%s",
-            self._dcc_name,
-            skill_name,
-            changed,
-        )
-        return bool(self.load_skill_object(skill))
+        if self.set_skill_load_transform(self._standalone_skill_load_transform):
+            logger.info("[%s] Standalone skill-load transform installed", self._dcc_name)
+            return
+
+        logger.warning("[%s] Standalone skill-load transform unavailable", self._dcc_name)
 
     @staticmethod
-    def _disable_tool_affinity_enforcement(skill: Any) -> bool:
+    def _standalone_skill_load_transform(skill: Any) -> None:
+        """Let core load main-affinity Maya tools inline in mayapy standalone mode."""
         changed = False
         tools = list(getattr(skill, "tools", ()) or ())
         for tool in tools:
@@ -628,7 +548,6 @@ class MayaMcpServer(DccServerBase):
             changed = True
         if changed:
             setattr(skill, "tools", tools)
-        return changed
 
     def _register_recipes_tools(self, context: _registration.RegistrationContext) -> None:
         """Register ``recipes__*`` tools so ``metadata.dcc-mcp.recipes`` files are agent-readable."""
@@ -767,7 +686,7 @@ class MayaMcpServer(DccServerBase):
         publish can invoke :meth:`publish_capability_snapshot` directly.
         """
         try:
-            return self._load_skill_via_core_object(skill_name)
+            return bool(super().load_skill(skill_name))
         except Exception as exc:  # noqa: BLE001
             logger.debug("[%s] load_skill(%r) failed: %s", self._dcc_name, skill_name, exc)
             return False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -352,7 +352,7 @@ class TestMayaMcpServerApi:
         finally:
             server.stop()
 
-    def test_standalone_affinity_override_uses_core_skill_object(self):
+    def test_standalone_skill_load_transform_disables_affinity_enforcement(self):
         """mayapy direct HTTP adjusts detached core skill metadata before loading."""
         srv_mod = _import_server()
 
@@ -364,37 +364,12 @@ class TestMayaMcpServerApi:
             def __init__(self):
                 self.tools = [Tool(True), Tool(False)]
 
-        class Inner:
-            def __init__(self):
-                self.skill = Skill()
-                self.loaded = None
+        skill = Skill()
 
-            def get_skill(self, name):
-                assert name == "maya-scene"
-                return self.skill
+        assert srv_mod.MayaMcpServer._standalone_skill_load_transform(skill) is None
+        assert [tool.enforce_thread_affinity for tool in skill.tools] == [False, False]
 
-            def load_skill_object(self, skill):
-                self.loaded = skill
-                return True
-
-            def load_skill(self, name):  # pragma: no cover - must not be used
-                raise AssertionError(f"unexpected direct load_skill({name!r})")
-
-        server = object.__new__(srv_mod.MayaMcpServer)
-        server._dcc_name = "maya"
-        server._host_dispatcher = type("MayaStandaloneDispatcher", (), {})()
-        server._server = Inner()
-        server._skill_client = MagicMock()
-        server._skill_client.get_skill.side_effect = server._server.get_skill
-        server._skill_client.load_skill_object.side_effect = server._server.load_skill_object
-
-        assert server._load_skill_via_core_object("maya-scene") is True
-        assert server._server.loaded is server._server.skill
-        server._skill_client.get_skill.assert_called_once_with("maya-scene")
-        server._skill_client.load_skill_object.assert_called_once_with(server._server.skill)
-        assert [tool.enforce_thread_affinity for tool in server._server.skill.tools] == [False, False]
-
-    def test_standalone_affinity_prepare_persists_for_core_catalog_load(self):
+    def test_standalone_transform_persists_for_core_catalog_load(self):
         """Core-owned MCP load_skill sees Maya standalone metadata overrides too."""
         srv_mod = _import_server()
 

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -68,6 +68,8 @@ def _make_bare_server(builtin_dir=None):
     srv._standalone_main_thread = False
     srv._execution_bridge = None
     srv._inprocess_executor_registered = False
+    srv._skill_client = MagicMock()
+    srv._skill_client.clear_skill_load_transform.return_value = True
     return srv
 
 


### PR DESCRIPTION
## Summary
- bump the Maya adapter core/server floor to 0.17.35
- replace standalone skill metadata preloading with core's skill-load transform hook
- keep minimal-mode loading on the core-owned path and update tests/docs

## Tests
- uv run --extra dev python -m pytest tests -q
- uv run --extra dev python -m ruff check src tests
- uv run --extra dev python -m ruff format --check src tests