### PR TITLE
test: honor tools/list pagination

### DIFF
--- a/tests/_transport_support.py
+++ b/tests/_transport_support.py
@@ -13,7 +13,7 @@ import time
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from dcc_mcp_maya.sidecar._resolver import SidecarBinaryError, resolve_sidecar_binary
 
@@ -98,6 +98,38 @@ def mcp_initialize(mcp_url: str, *, client_name: str = "maya-transport-test") ->
         expect_response=False,
     )
     return session_id
+
+
+def mcp_list_all_tools(
+    mcp_url: str,
+    *,
+    session_id: Optional[str] = None,
+    request_id: int = 100,
+    max_pages: int = 50,
+) -> List[Dict[str, Any]]:
+    """Walk every ``tools/list`` cursor page and return all advertised tools."""
+    tools: List[Dict[str, Any]] = []
+    cursor: Optional[str] = None
+    for page in range(max_pages):
+        params: Dict[str, Any] = {}
+        if cursor:
+            params["cursor"] = cursor
+        response = mcp_post(
+            mcp_url,
+            {
+                "jsonrpc": "2.0",
+                "id": request_id + page,
+                "method": "tools/list",
+                "params": params,
+            },
+            session_id=session_id,
+        )
+        result = response.get("result") or {}
+        tools.extend(result.get("tools") or [])
+        cursor = result.get("nextCursor")
+        if not cursor:
+            return tools
+    raise RuntimeError("tools/list pagination exceeded {} pages".format(max_pages))
 
 
 def rest_get_json(base_url: str, endpoint: str) -> Dict[str, Any]:

--- a/tests/test_maya_http_transport.py
+++ b/tests/test_maya_http_transport.py
@@ -29,6 +29,7 @@ from tests._transport_support import (
     QtJsonLineStubServer,
     allocate_ephemeral_port,
     mcp_initialize,
+    mcp_list_all_tools,
     mcp_post,
     mcp_url_from_registry_entry,
     qt_stub_factory,
@@ -388,12 +389,9 @@ class TestInProcessHttpApi:
                 base = mcp_url.rsplit("/", 1)[0]
                 assert rest_get_json(base, "/v1/healthz").get("ok") is True
 
-            listing = mcp_post(
-                mcp_url,
-                {"jsonrpc": "2.0", "id": 20, "method": "tools/list", "params": {}},
-                session_id=session,
-            )
-            names = {tool["name"] for tool in listing["result"]["tools"]}
+            # ``tools/list`` is paginated; loaded tools are not guaranteed to land on page 1.
+            tools = mcp_list_all_tools(mcp_url, session_id=session, request_id=20)
+            names = {tool["name"] for tool in tools}
             assert {
                 "playblast",
                 _qualified_action_name("maya-render", "playblast"),


### PR DESCRIPTION
## Summary
- add a shared MCP helper that walks all `tools/list` cursor pages
- update the render HTTP survival regression to assert against the complete advertised tool surface

## Validation
- `python -m ruff check tests/_transport_support.py tests/test_maya_http_transport.py`
- `python -m pytest tests/test_maya_http_transport.py::TestInProcessHttpApi::test_capture_then_playblast_keeps_http_server_responsive -q --tb=short`
- `python -m pytest`