### PR TITLE
fix(server): use core hotreload API in start_server register_builtins=True branch

### DIFF
--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -1046,21 +1046,23 @@ def start_server(
                 minimal=minimal,
             )
 
-            # Hot-reload setup
+            # Hot-reload setup — reuse the core ``DccServerBase.enable_hot_reload``
+            # helper so this branch matches the factory-driven
+            # ``register_builtins=False`` branch below (core renamed the
+            # module to ``hotreload`` and the class to ``DccSkillHotReloader``
+            # — issue dcc-mcp-core#1391).
             effective_hot_reload = enable_hot_reload
             if not effective_hot_reload:
                 env_val = os.environ.get("DCC_MCP_MAYA_HOT_RELOAD", "").strip()
                 effective_hot_reload = env_val == "1"
             if effective_hot_reload:
                 try:
-                    # Optional core feature: keep this import local so normal startup
-                    # does not fail when a core build omits hot_reload support.
-                    from dcc_mcp_core.hot_reload import HotReloader  # noqa: PLC0415
-
-                    server._hot_reloader = HotReloader(server)  # type: ignore[attr-defined]
-                    server._hot_reloader.start()  # type: ignore[attr-defined]
-                except Exception as exc:
-                    logger.debug("Hot-reload setup failed: %s", exc)
+                    if server.enable_hot_reload():
+                        logger.info("[%s] Skill hot-reload enabled", server._dcc_name)
+                    else:
+                        logger.warning("[%s] Failed to enable skill hot-reload", server._dcc_name)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Error enabling hot-reload: %s", exc)
 
             handle = server.start()
             _server_instance = server

--- a/tests/test_basic_imports.py
+++ b/tests/test_basic_imports.py
@@ -150,5 +150,32 @@ def test_enable_hot_reload_on_server():
     assert hasattr(MayaMcpServer, "hot_reload_stats")
 
 
+def test_start_server_source_does_not_reference_legacy_hot_reload_module():
+    """Regression for dcc-mcp-core#1391.
+
+    The previous ``register_builtins=True`` branch in ``start_server`` imported
+    ``HotReloader`` from ``dcc_mcp_core.hot_reload`` — a module that no longer
+    exists (it was renamed to ``dcc_mcp_core.hotreload`` and the class to
+    ``DccSkillHotReloader``).  The broken import was swallowed by a bare
+    ``except Exception`` so ``enable_hot_reload=True`` failed silently in Maya.
+
+    Guard the source so future refactors cannot reintroduce the legacy name.
+    """
+    import inspect
+
+    from dcc_mcp_maya import server as server_module
+
+    source = inspect.getsource(server_module)
+    assert "dcc_mcp_core.hot_reload" not in source, (
+        "Legacy 'dcc_mcp_core.hot_reload' import path must not appear in "
+        "server.py; use dcc_mcp_core.hotreload.DccSkillHotReloader or call "
+        "server.enable_hot_reload() instead."
+    )
+    assert "HotReloader(" not in source, (
+        "Legacy 'HotReloader' class instantiation must not appear in "
+        "server.py; the class was renamed to 'DccSkillHotReloader' in core."
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes [dcc-mcp-core#1391](https://github.com/loonghao/dcc-mcp-core/issues/1391).

The `register_builtins=True` branch of `start_server` had a hand-rolled hot-reload bootstrap that imported `HotReloader` from `dcc_mcp_core.hot_reload` — a module path that no longer exists in dcc-mcp-core:

- module renamed: `dcc_mcp_core.hot_reload` → `dcc_mcp_core.hotreload`
- class renamed: `HotReloader` → `DccSkillHotReloader`
- constructor signature changed: now takes `dcc_name=...` plus `server=...`
- there is no `.start()` method anymore; the lifecycle helper is `DccServerBase.enable_hot_reload()`

Because the broken block lived inside `try/except Exception`, the failure surfaced only as a debug-level `"Hot-reload setup failed"` log line — `enable_hot_reload=True` looked like it worked but never watched anything.

## Fix

The sibling `register_builtins=False` branch already does this correctly: it delegates to `dcc_mcp_core.factory.create_dcc_server`, which calls `instance.enable_hot_reload()` (the inherited `DccServerBase` API that internally constructs the correct `DccSkillHotReloader`).

Make the `register_builtins=True` branch do the same thing:

```python
# before — broken (#1391)
from dcc_mcp_core.hot_reload import HotReloader  # ModuleNotFoundError
server._hot_reloader = HotReloader(server)       # also wrong class signature
server._hot_reloader.start()                     # method does not exist

# after
if server.enable_hot_reload():
    logger.info("[%s] Skill hot-reload enabled", server._dcc_name)
else:
    logger.warning("[%s] Failed to enable skill hot-reload", server._dcc_name)
```

The env-var fallback (`DCC_MCP_MAYA_HOT_RELOAD=1`) and the explicit `enable_hot_reload=True` kwarg both keep working with no surface change.

## Regression guard

Added `test_start_server_source_does_not_reference_legacy_hot_reload_module` to `tests/test_basic_imports.py`: it `inspect.getsource(server)` and asserts the legacy import path and the legacy class name no longer appear anywhere in `server.py`. Future refactors cannot silently reintroduce the bug.

## Validation

```text
.venv/Scripts/python.exe -m pytest tests/test_basic_imports.py tests/test_hotreload.py -v
=> 20 / 20 pass
   - test_start_server_source_does_not_reference_legacy_hot_reload_module  ✓
   - test_enable_hot_reload_on_server                                       ✓
   - test_hotreload_importable_from_core                                    ✓
   - test_hotreload_attributes_on_core_class                                ✓
   - TestDccSkillHotReloaderViaMaya  (10 tests)                             ✓
   - TestMayaServerHotReloadAPI       (4 tests)                             ✓
   - TestHotReloadIntegration         (2 tests)                             ✓
```

## Scope

Two files changed (`src/dcc_mcp_maya/server.py` +11 / -9, `tests/test_basic_imports.py` +27 / -1). No `dcc-mcp-core` change is needed — the new `hotreload` module already exposes `DccSkillHotReloader`, and `DccServerBase.enable_hot_reload()` has been present since core 0.13.x.
