### PR TITLE
fix(scripting): deprecate script_path alias in execute_python/execute_mel (#311)

### DIFF
--- a/src/dcc_mcp_maya/skills/maya-scripting/scripts/execute_mel.py
+++ b/src/dcc_mcp_maya/skills/maya-scripting/scripts/execute_mel.py
@@ -6,20 +6,32 @@ from __future__ import annotations
 # Import built-in modules
 import os
 import re
+import warnings
 from typing import Any, Dict, Optional
 
 # Import local modules
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+_SCRIPT_PATH_DEPRECATION = "`script_path` is deprecated, use `file_path` instead."
+
 
 def _resolve_script_file_path(params: Dict[str, Any]) -> Optional[str]:
-    for key in ("file_path", "script_path"):
-        raw = params.get(key)
-        if raw is None:
-            continue
-        s = str(raw).strip()
-        if s:
-            return s
+    file_path = params.get("file_path")
+    if file_path is not None:
+        cleaned = str(file_path).strip()
+        if cleaned:
+            return cleaned
+    # ``script_path`` is the deprecated alias kept for one release while
+    # callers migrate to ``file_path`` (issue #311). It only resolves when
+    # ``file_path`` is empty, and emits a ``DeprecationWarning`` so external
+    # MCP clients still sending it get a clear migration signal before the
+    # alias is dropped here and in the dcc-mcp-core wire schema.
+    script_path = params.get("script_path")
+    if script_path is not None:
+        cleaned = str(script_path).strip()
+        if cleaned:
+            warnings.warn(_SCRIPT_PATH_DEPRECATION, DeprecationWarning, stacklevel=2)
+            return cleaned
     return None
 
 

--- a/src/dcc_mcp_maya/skills/maya-scripting/scripts/execute_python.py
+++ b/src/dcc_mcp_maya/skills/maya-scripting/scripts/execute_python.py
@@ -65,7 +65,10 @@ import json
 import os
 import threading
 import traceback
+import warnings
 from typing import Any, Dict, Optional, Tuple
+
+_SCRIPT_PATH_DEPRECATION = "`script_path` is deprecated, use `file_path` instead."
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
@@ -385,13 +388,22 @@ def _should_marshal_to_maya_main_thread() -> bool:
 
 
 def _resolve_script_file_path(params: Dict[str, Any]) -> Optional[str]:
-    for key in ("file_path", "script_path"):
-        raw = params.get(key)
-        if raw is None:
-            continue
-        s = str(raw).strip()
-        if s:
-            return s
+    file_path = params.get("file_path")
+    if file_path is not None:
+        cleaned = str(file_path).strip()
+        if cleaned:
+            return cleaned
+    # ``script_path`` is the deprecated alias kept for one release while
+    # callers migrate to ``file_path`` (issue #311). It only resolves when
+    # ``file_path`` is empty, and emits a ``DeprecationWarning`` so external
+    # MCP clients still sending it get a clear migration signal before the
+    # alias is dropped here and in the dcc-mcp-core wire schema.
+    script_path = params.get("script_path")
+    if script_path is not None:
+        cleaned = str(script_path).strip()
+        if cleaned:
+            warnings.warn(_SCRIPT_PATH_DEPRECATION, DeprecationWarning, stacklevel=2)
+            return cleaned
     return None
 
 

--- a/src/dcc_mcp_maya/skills/maya-scripting/scripts/execute_python.py
+++ b/src/dcc_mcp_maya/skills/maya-scripting/scripts/execute_python.py
@@ -68,11 +68,11 @@ import traceback
 import warnings
 from typing import Any, Dict, Optional, Tuple
 
-_SCRIPT_PATH_DEPRECATION = "`script_path` is deprecated, use `file_path` instead."
-
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 from dcc_mcp_maya._cmds_file_guard import MayaFilePromptBlockedError, guard_cmds_file
+
+_SCRIPT_PATH_DEPRECATION = "`script_path` is deprecated, use `file_path` instead."
 
 # Maya's main thread is the only thread that can safely touch the scene
 # graph / call ``maya.cmds`` / load native plug-ins. The ``execute_python``

--- a/tests/test_script_path_deprecation.py
+++ b/tests/test_script_path_deprecation.py
@@ -1,0 +1,91 @@
+"""Issue #311 — ``script_path`` is a deprecated alias for ``file_path``.
+
+``execute_python`` / ``execute_mel`` keep accepting ``script_path`` for one
+release so external MCP clients do not break, but they now emit a
+``DeprecationWarning`` pointing callers at ``file_path``. This is the
+predecessor cleanup that unblocks dropping the alias from the dcc-mcp-core
+``DccApiExecutor`` wire schema (dcc-mcp-core#1391 / #1392).
+
+The tests below exercise the shared ``_resolve_script_file_path`` resolver in
+both skill scripts without requiring a live Maya — the warning fires purely
+from parameter resolution.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_skill_script
+
+_MIGRATION = "script_path` is deprecated, use `file_path`"
+
+
+def _resolver(script_name: str):
+    mod = load_skill_script("maya-scripting", script_name)
+    return mod._resolve_script_file_path
+
+
+@pytest.mark.parametrize("script_name", ["execute_python", "execute_mel"])
+class TestScriptPathDeprecation:
+    def test_script_path_emits_deprecation_warning(self, script_name: str):
+        resolve = _resolver(script_name)
+        with pytest.warns(DeprecationWarning, match="script_path"):
+            resolved = resolve({"script_path": "/abs/path/to/thing"})
+        assert resolved == "/abs/path/to/thing"
+
+    def test_warning_message_includes_migration_string(self, script_name: str):
+        resolve = _resolver(script_name)
+        with pytest.warns(DeprecationWarning) as record:
+            resolve({"script_path": "/abs/path/to/thing"})
+        assert any(_MIGRATION in str(w.message) for w in record)
+
+    def test_file_path_is_silent(self, script_name: str):
+        resolve = _resolver(script_name)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            resolved = resolve({"file_path": "/abs/path/to/thing"})
+        assert resolved == "/abs/path/to/thing"
+
+    def test_file_path_wins_and_is_silent_when_both_present(self, script_name: str):
+        resolve = _resolver(script_name)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            resolved = resolve({"file_path": "/keep/me", "script_path": "/old/alias"})
+        assert resolved == "/keep/me"
+
+    def test_inline_code_path_is_silent(self, script_name: str):
+        """Inline ``code`` callers never touch the file resolver / warning."""
+        resolve = _resolver(script_name)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert resolve({"code": "1 + 1"}) is None
+
+    def test_empty_script_path_is_silent(self, script_name: str):
+        resolve = _resolver(script_name)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert resolve({"script_path": "   "}) is None
+
+
+def test_execute_python_file_path_runs_without_warning(tmp_path: Path):
+    mod = load_skill_script("maya-scripting", "execute_python")
+    f = tmp_path / "demo.py"
+    f.write_text("print('from-file-path')\n", encoding="utf-8")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        out = mod.execute_python(file_path=str(f))
+    assert out.get("success") is True
+    assert "from-file-path" in (out.get("context") or {}).get("stdout", "")
+
+
+def test_execute_python_script_path_still_runs_with_warning(tmp_path: Path):
+    mod = load_skill_script("maya-scripting", "execute_python")
+    f = tmp_path / "demo.py"
+    f.write_text("print('from-script-path-alias')\n", encoding="utf-8")
+    with pytest.warns(DeprecationWarning, match="script_path"):
+        out = mod.execute_python(script_path=str(f))
+    assert out.get("success") is True
+    assert "from-script-path-alias" in (out.get("context") or {}).get("stdout", "")


### PR DESCRIPTION
Closes #311.

Keep accepting the deprecated `script_path` alias for one release, but emit a `DeprecationWarning` (\script_path\ is deprecated, use \ile_path\) when callers pass it instead of `file_path`. `file_path` still wins and stays silent; inline `code` paths are untouched.

This unblocks dropping `script_path` from the dcc-mcp-core `DccApiExecutor` wire schema (dcc-mcp-core#1391 / #1392).

Tests: tests/test_script_path_deprecation.py (warns for script_path, silent for file_path/code; both scripts).