### PR TITLE
docs: document EXCLUDE_STUBS env var as generic DCC_MCP_<DCC>_* instance (#310)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ def create_sphere(radius: float = 1.0) -> dict:
   2. Alternatively: `search_skills` / `search_tools` → **`load_skill`** → optional `activate_group("extended")` → invoke the **typed** tool (validated `inputSchema`, e.g. `maya_mesh_ops__bevel_edge`). Treat `maya_scripting__execute_python` / `execute_mel` as **last resort** when no skill covers the task (bulk in-Maya loops, OpenMaya gaps, one-off experiments). Studios can hard-block arbitrary execution with `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON`, `DCC_MCP_MAYA_DISABLE_EXECUTE_MEL`, or `DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT` (see `README.md` / `llms.txt`).
   3. When using the **gateway**, read **`resources/read` `uri=gateway://docs/agent-workflows`** for MCP + resources + efficiency guidance; for Maya-heavy examples see `examples/workflows/maya_bulk_rbd_fbx.md`.
   4. **cmds documentation:** `resources/read` on `maya-cmds://help/<command>` or `maya-cmds://flags/<command>` (use the exact URI from `resources/list`).
-- **Token hygiene:** Set `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST=1` when your MCP host repeatedly syncs a large `tools/list`; discovery remains available via `dcc_capability_manifest` and gateway `/v1/search`.
+- **Token hygiene:** Set `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST=1` (Maya's instance of the generic core `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`, with `DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST` as the all-DCC global fallback) when your MCP host repeatedly syncs a large `tools/list`; discovery remains available via `dcc_capability_manifest` and gateway `/v1/search`.
 - **Always check cancellation in long-running loops:**
   ```python
   from dcc_mcp_maya import check_maya_cancelled
@@ -364,7 +364,7 @@ lookup failure).
 At startup only 2 skills are fully loaded: `maya-scripting` and `maya-scene` (core groups only).
 All other skills appear as `__skill__<name>` stubs (default behavior). Call `load_skill(name)` to activate on demand.
 
-**Note:** Set ``DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST=1`` to exclude ``__skill__*`` / ``__group__*`` stubs from ``tools/list`` (issue #174). Discovery is still possible via ``build_capability_manifest()`` and ``/v1/search``.
+**Note:** Set ``DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST=1`` — Maya's instance of the generic core ``DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`` (global fallback: ``DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST``) — to exclude ``__skill__*`` / ``__group__*`` stubs from ``tools/list`` (issue #174). Discovery is still possible via ``build_capability_manifest()`` and ``/v1/search``.
 
 ### Environment Variables
 | Variable | Default | Purpose |
@@ -387,7 +387,7 @@ All other skills appear as `__skill__<name>` stubs (default behavior). Call `loa
 | `DCC_MCP_MAYA_AUTO_DISMISS_CRASH_DIALOG` | `0` | `1` = auto-dismiss detected Maya Qt recovery dialogs after main-thread tool calls and surface `maya_recovered` in results / `scene://current`. |
 | `DCC_MCP_GATEWAY_PORT` | `9765` | Multi-instance gateway election port. `0` = disable. |
 | `DCC_MCP_REGISTRY_DIR` | OS temp dir | Shared service-discovery registry directory. |
-| `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | `1` = exclude ``__skill__*`` / ``__group__*`` stubs from ``tools/list`` (issue #174). Discovery still possible via capability manifest / ``/v1/search``. |
+| `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Maya's instance of the generic core `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`; `1` = exclude ``__skill__*`` / ``__group__*`` stubs from ``tools/list`` (issue #174). `DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST` is the all-DCC global fallback. Resolved entirely by `dcc-mcp-core`; discovery still possible via capability manifest / ``/v1/search``. |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | `1` / `true` / `yes` / `on` — refuse ``execute_python`` (skills-first policy). |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_MEL` | `0` | Same truthy tokens — refuse ``execute_mel`` only. |
 | `DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT` | `0` | Same truthy tokens — refuse **both** ``execute_python`` and ``execute_mel``. |

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Useful plugin defaults:
 | `DCC_MCP_SKILL_PATHS` | none | Global fallback skill search roots for all DCC adapters. |
 | `DCC_MCP_MINIMAL` | `1` | `0` loads the full tool surface at startup. |
 | `DCC_MCP_DEFAULT_TOOLS` | none | Comma-separated skill names to load at startup. |
-| `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Hide `__skill__*` / `__group__*` stubs from large `tools/list` syncs. |
+| `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Maya's instance of the generic core `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`. Hide `__skill__*` / `__group__*` stubs from large `tools/list` syncs. Global fallback: `DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST`. |
 | `DCC_MCP_MAYA_SIDECAR` | `1` | `0` disables the default plugin sidecar process. |
 | `DCC_MCP_SERVER_BIN` | auto | Override the `dcc-mcp-server` binary path. |
 | `DCC_MCP_GATEWAY_PORT` | `9765` plugin | Local standalone gateway port; `0` disables gateway mode. |

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -203,7 +203,7 @@ Returned by `server.start()` and `start_server()`.
 | `DCC_MCP_MAYA_ENABLE_GATEWAY_FAILOVER` | `1` | Enable automatic gateway failover election |
 | `DCC_MCP_MAYA_ENABLE_WORKFLOWS` | `0` | Enable core workflow tools |
 | `DCC_MCP_MAYA_READINESS_TIMEOUT_SECS` | — | Advisory timeout value for readiness consumers |
-| `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Hide unloaded skill/group stubs from `tools/list` |
+| `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Maya's instance of the generic core `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`; hide unloaded skill/group stubs from `tools/list`. Global fallback: `DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST` |
 | `DCC_MCP_MAYA_SIDECAR` | `1` | Set `0` to disable the default `dcc-mcp-server sidecar` from the Maya plugin |
 | `DCC_MCP_GATEWAY_PORT` | `9765` in plugin mode | Standalone gateway port; `0` disables gateway mode |
 | `DCC_MCP_GATEWAY_NAME` | `dcc-mcp-gateway@<hostname>` in sidecar mode | Human-readable standalone gateway label surfaced in admin, health, and CLI diagnostics |

--- a/docs/zh/api/server.md
+++ b/docs/zh/api/server.md
@@ -190,7 +190,7 @@ server.stop()
 | `DCC_MCP_MAYA_ENABLE_GATEWAY_FAILOVER` | `1` | 启用自动网关故障转移选举 |
 | `DCC_MCP_MAYA_ENABLE_WORKFLOWS` | `0` | 启用 core workflow tools |
 | `DCC_MCP_MAYA_READINESS_TIMEOUT_SECS` | — | readiness 消费方使用的建议超时时间 |
-| `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | 从 `tools/list` 隐藏未加载 skill/group stub |
+| `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | core 通用变量 `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST` 的 Maya 实例；从 `tools/list` 隐藏未加载 skill/group stub。全局兜底：`DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST` |
 | `DCC_MCP_MAYA_SIDECAR` | `1` | 设为 `0` 可禁用 Maya 插件默认启动的 `dcc-mcp-server sidecar` |
 | `DCC_MCP_GATEWAY_PORT` | 插件模式下为 `9765` | 网关竞争端口；设为 `0` 可禁用 |
 | `DCC_MCP_GATEWAY_NAME` | sidecar 模式下为 `dcc-mcp-gateway@<hostname>` | admin、health 和 CLI 诊断中展示的独立 gateway 名称 |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -453,6 +453,7 @@ tools:
 | `DCC_MCP_MAYA_JOB_STORAGE` | `<data_dir>/jobs.db` | per-process | SQLite job persistence path. `""`=disable. |
 | `DCC_MCP_MAYA_JOB_RECOVERY` | `drop` | per-process | `requeue`=resume idempotent interrupted jobs on startup. |
 | `DCC_MCP_MAYA_HOT_RELOAD` | `0` | per-process | `1`=watch bundled skills for edit-on-disk reload. |
+| `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | per-process | Maya's instance of the generic core `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`; `1`=exclude `__skill__*` / `__group__*` stubs from `tools/list` (issue #174). Resolved entirely by `dcc-mcp-core`. Global fallback: `DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST`. Discovery still via capability manifest / `/v1/search`. |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | per-process | `1`/`true`/`yes`/`on` — refuse `execute_python` (skills-first enforcement). |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_MEL` | `0` | per-process | Same truthy tokens — refuse `execute_mel` only. |
 | `DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT` | `0` | per-process | Same truthy tokens — refuse both `execute_python` and `execute_mel`. |

--- a/llms.txt
+++ b/llms.txt
@@ -198,6 +198,7 @@ Tool naming: `{skill_name.replace("-","_")}__{script_stem}` (e.g. `maya_scene__n
 | `DCC_MCP_GATEWAY_NAME` | `dcc-mcp-gateway@<hostname>` | Human-readable standalone gateway label |
 | `DCC_MCP_REGISTRY_DIR` | OS temp | Shared discovery registry |
 | `DCC_MCP_MAYA_HOT_RELOAD` | `0` | `1`=watch skills for disk changes |
+| `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Maya instance of generic core `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`; `1`=hide `__skill__*` / `__group__*` stubs from `tools/list` (global fallback `DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST`) |
 | `DCC_MCP_MAYA_DEV_ROOTS` | — | Optional path-list of trusted roots for `maya-dev` project attachment |
 | `DCC_MCP_MAYA_AUTO_DISMISS_CRASH_DIALOG` | `0` | `1`=best-effort dismiss detected Maya Qt recovery dialogs after `affinity: main` tool calls |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | `1`/`true`/`yes`/`on` — refuse `execute_python` (skills-first enforcement) |

--- a/src/dcc_mcp_maya/_env.py
+++ b/src/dcc_mcp_maya/_env.py
@@ -46,9 +46,14 @@ ENV_DISABLE_EXECUTE_PYTHON = "DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON"
 ENV_DISABLE_ARBITRARY_SCRIPT = "DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT"
 #: Optional per-tool opt-out for MEL when arbitrary script is otherwise allowed.
 ENV_DISABLE_EXECUTE_MEL = "DCC_MCP_MAYA_DISABLE_EXECUTE_MEL"
-#: Issue #174 / #238 — omit ``__skill__*`` / ``__group__*`` from ``tools/list``.
-#: Applied by core ``DccServerBase`` (``dcc-mcp-core>=0.17.3``); discovery via
-#: ``search_tools``, capability manifest, or gateway ``/v1/search``.
+#: Issue #174 / #238 / #310 — omit ``__skill__*`` / ``__group__*`` from
+#: ``tools/list``. This is Maya's instance of the generic core variable
+#: ``DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`` (global fallback:
+#: ``DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST``). The value is resolved entirely
+#: inside core ``DccServerBase`` (``dcc-mcp-core>=0.17.3``) — this adapter never
+#: reads it directly; the constant is kept only as a documentation anchor.
+#: Discovery stays available via ``search_tools``, capability manifest, or
+#: gateway ``/v1/search``.
 ENV_EXCLUDE_STUBS_FROM_TOOLS_LIST = "DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST"
 #: Default SQLite filename inside the platform data directory.
 DEFAULT_JOB_DB_FILENAME = "jobs.db"


### PR DESCRIPTION
Closes #310.

Re-frames \DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST\ as **Maya's instance of the generic** \DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST\, documents the all-DCC global fallback \DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST\, and notes the adapter never reads it directly (core resolves it).

- Synced AGENTS.md, README.md, llms.txt, llms-full.txt, docs/api/server.md + zh mirror.
- Audit: no Python code reads the var; the lone \_env.py\ constant is a doc anchor only — comment clarified.

Unblocks dropping core's \_LEGACY_MAYA_ENV\ defensive shim.