### PR TITLE
feat(search): opt-in VectorSkillIndex morphology-aware skill recall (#313)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,6 +392,8 @@ All other skills appear as `__skill__<name>` stubs (default behavior). Call `loa
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_MEL` | `0` | Same truthy tokens — refuse ``execute_mel`` only. |
 | `DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT` | `0` | Same truthy tokens — refuse **both** ``execute_python`` and ``execute_mel``. |
 | `DCC_MCP_MAYA_QT_UI_INSPECTOR` | `1` | `0` = skip registering the shared core ``qt_ui_inspector__*`` tools (issue #307). Read-only widget discovery (``list_windows`` / ``find_widgets`` / ``describe_widget`` / ``snapshot_tree`` / ``wait_for_widget``) routed onto Maya's main thread; locate buttons / dialogs / custom controls by text / objectName / class / accessibleName instead of ad-hoc PySide scripts. |
+| `DCC_MCP_MAYA_SEMANTIC_INDEX` | `0` | `1` = fuse a Python `VectorSkillIndex` (morphology-aware, zero-dep `HashedEmbedder`) with the Rust BM25 path so inflected queries (`rendering` → `maya-render`) still recall the right skill (issue #313). Base results are never demoted — vector recalls are appended. Requires `dcc-mcp-core>=0.17.38`; no-op on older cores. |
+| `DCC_MCP_MAYA_SEMANTIC_EMBEDDER` | `hashed` | `onnx` = use the dense `OnnxEmbedder` instead of `HashedEmbedder` for `DCC_MCP_MAYA_SEMANTIC_INDEX`. Requires the optional extra: `pip install 'dcc-mcp-core[semantic]'` (falls back to `hashed` when unavailable). |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,10 @@ Useful plugin defaults:
 | `DCC_MCP_DEFAULT_TOOLS` | none | Comma-separated skill names to load at startup. |
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Maya's instance of the generic core `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`. Hide `__skill__*` / `__group__*` stubs from large `tools/list` syncs. Global fallback: `DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST`. |
 | `DCC_MCP_MAYA_SIDECAR` | `1` | `0` disables the default plugin sidecar process. |
+<<<<<<< HEAD
 | `DCC_MCP_MAYA_QT_UI_INSPECTOR` | `1` | `0` skips the shared core `qt_ui_inspector__*` read-only widget-discovery tools (find buttons/dialogs/custom controls by text/objectName/class), routed onto Maya's main thread. |
+| `DCC_MCP_MAYA_SEMANTIC_INDEX` | `0` | `1` enables morphology-aware skill recall by fusing a zero-dep `VectorSkillIndex` with the BM25 path so inflected queries (`rendering` → `maya-render`) recall the right skill. Requires `dcc-mcp-core>=0.17.38`. |
+| `DCC_MCP_MAYA_SEMANTIC_EMBEDDER` | `hashed` | `onnx` uses the dense `OnnxEmbedder` for semantic recall (install `pip install 'dcc-mcp-core[semantic]'`; falls back to `hashed`). |
 | `DCC_MCP_SERVER_BIN` | auto | Override the `dcc-mcp-server` binary path. |
 | `DCC_MCP_GATEWAY_PORT` | `9765` plugin | Local standalone gateway port; `0` disables gateway mode. |
 | `DCC_MCP_GATEWAY_NAME` | `dcc-mcp-gateway@<hostname>` sidecar | Human-readable gateway label shown in admin and CLI diagnostics. |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -454,6 +454,8 @@ tools:
 | `DCC_MCP_MAYA_JOB_RECOVERY` | `drop` | per-process | `requeue`=resume idempotent interrupted jobs on startup. |
 | `DCC_MCP_MAYA_HOT_RELOAD` | `0` | per-process | `1`=watch bundled skills for edit-on-disk reload. |
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | per-process | Maya's instance of the generic core `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`; `1`=exclude `__skill__*` / `__group__*` stubs from `tools/list` (issue #174). Resolved entirely by `dcc-mcp-core`. Global fallback: `DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST`. Discovery still via capability manifest / `/v1/search`. |
+| `DCC_MCP_MAYA_SEMANTIC_INDEX` | `0` | per-process | `1`=augment BM25 `search_skills` with a fused Python `VectorSkillIndex` (zero-dep `HashedEmbedder` char-3-grams) via `RrfFusionIndex`, so morphology variants (`rendering`→`maya-render`) recall. Base ordering preserved; vector-only hits appended (issue #313). Requires `dcc-mcp-core>=0.17.38`; no-op otherwise. |
+| `DCC_MCP_MAYA_SEMANTIC_EMBEDDER` | `hashed` | per-process | `onnx`=use the dense `OnnxEmbedder` instead of `HashedEmbedder`. Requires `pip install 'dcc-mcp-core[semantic]'`; falls back to `hashed` when the extra is missing. |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | per-process | `1`/`true`/`yes`/`on` — refuse `execute_python` (skills-first enforcement). |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_MEL` | `0` | per-process | Same truthy tokens — refuse `execute_mel` only. |
 | `DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT` | `0` | per-process | Same truthy tokens — refuse both `execute_python` and `execute_mel`. |

--- a/llms.txt
+++ b/llms.txt
@@ -199,7 +199,10 @@ Tool naming: `{skill_name.replace("-","_")}__{script_stem}` (e.g. `maya_scene__n
 | `DCC_MCP_REGISTRY_DIR` | OS temp | Shared discovery registry |
 | `DCC_MCP_MAYA_HOT_RELOAD` | `0` | `1`=watch skills for disk changes |
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Maya instance of generic core `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`; `1`=hide `__skill__*` / `__group__*` stubs from `tools/list` (global fallback `DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST`) |
+<<<<<<< HEAD
 | `DCC_MCP_MAYA_QT_UI_INSPECTOR` | `1` | `0`=skip shared core `qt_ui_inspector__*` read-only widget discovery tools, main-thread routed (issue #307) |
+| `DCC_MCP_MAYA_SEMANTIC_INDEX` | `0` | `1`=fuse Python `VectorSkillIndex` (morphology-aware) with BM25 `search_skills`; appends recalls, never demotes base (issue #313; needs core>=0.17.38) |
+| `DCC_MCP_MAYA_SEMANTIC_EMBEDDER` | `hashed` | `onnx`=dense `OnnxEmbedder` for semantic recall (`pip install 'dcc-mcp-core[semantic]'`) |
 | `DCC_MCP_MAYA_DEV_ROOTS` | — | Optional path-list of trusted roots for `maya-dev` project attachment |
 | `DCC_MCP_MAYA_AUTO_DISMISS_CRASH_DIALOG` | `0` | `1`=best-effort dismiss detected Maya Qt recovery dialogs after `affinity: main` tool calls |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | `1`/`true`/`yes`/`on` — refuse `execute_python` (skills-first enforcement) |

--- a/src/dcc_mcp_maya/_semantic_index.py
+++ b/src/dcc_mcp_maya/_semantic_index.py
@@ -1,0 +1,209 @@
+"""Optional morphology-aware semantic skill recall (issue #313).
+
+``MayaMcpServer.search_skills`` routes through the Rust BM25-lite scorer in
+``dcc-mcp-skills``. That path is excellent for exact / tokenised queries but
+misses morphology variants a natural-language MCP agent commonly produces —
+``"rendering the active frame"`` does not tokenise to the literal ``render``
+token in the ``maya-render`` skill's name / summary.
+
+This module fuses the Python-side ``VectorSkillIndex`` (``HashedEmbedder``
+char-3-gram defaults, zero runtime deps) with a ``LexicalSkillIndex`` through
+``RrfFusionIndex`` (Cormack et al. 2009, RRF k=60). The fused index is used
+**only to augment** the canonical base results: base ordering is preserved
+verbatim (so queries that already worked under BM25 never get demoted) and
+vector-only recalls are appended afterwards.
+
+The whole feature is gated behind ``DCC_MCP_MAYA_SEMANTIC_INDEX=1`` so the
+default behaviour is byte-for-byte unchanged for the first release. When the
+optional ``dcc-mcp-core[semantic]`` extra is installed,
+``DCC_MCP_MAYA_SEMANTIC_EMBEDDER=onnx`` swaps ``HashedEmbedder`` for the real
+dense ``OnnxEmbedder`` without touching any call site.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+#: Enable the lexical+vector fusion augmentation. Default off.
+ENV_SEMANTIC_INDEX = "DCC_MCP_MAYA_SEMANTIC_INDEX"
+#: ``hashed`` (default, zero-dep) or ``onnx`` (requires the ``[semantic]`` extra).
+ENV_SEMANTIC_EMBEDDER = "DCC_MCP_MAYA_SEMANTIC_EMBEDDER"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def resolve_semantic_index_enabled(env: Optional[dict] = None) -> bool:
+    """Return ``True`` when ``DCC_MCP_MAYA_SEMANTIC_INDEX`` is truthy."""
+    environ = env if env is not None else os.environ
+    return str(environ.get(ENV_SEMANTIC_INDEX, "")).strip().lower() in _TRUTHY
+
+
+def resolve_embedder_kind(env: Optional[dict] = None) -> str:
+    """Return the requested embedder kind: ``"hashed"`` (default) or ``"onnx"``."""
+    environ = env if env is not None else os.environ
+    kind = str(environ.get(ENV_SEMANTIC_EMBEDDER, "hashed")).strip().lower()
+    return "onnx" if kind == "onnx" else "hashed"
+
+
+def _summary_text(summary: Any) -> str:
+    """Best-effort description string from a ``SkillSummary``-like object."""
+    parts = []
+    for attr in ("description", "search_hint"):
+        value = getattr(summary, attr, "") or ""
+        if value and value not in parts:
+            parts.append(str(value))
+    return " ".join(parts)
+
+
+def _summary_name(summary: Any) -> Optional[str]:
+    name = getattr(summary, "name", None)
+    return str(name) if name else None
+
+
+def _build_embedder(kind: str) -> Any:
+    """Construct the requested embedder, falling back to ``HashedEmbedder``.
+
+    ``OnnxEmbedder`` raises ``EmbedderError`` when the ``[semantic]`` extra is
+    not installed; in that case we degrade to the zero-dep hashed embedder and
+    log a warning rather than disabling recall entirely.
+    """
+    from dcc_mcp_core import HashedEmbedder  # noqa: PLC0415
+
+    if kind != "onnx":
+        return HashedEmbedder()
+    try:
+        from dcc_mcp_core import OnnxEmbedder  # noqa: PLC0415
+
+        return OnnxEmbedder()
+    except Exception as exc:  # noqa: BLE001 — EmbedderError / ImportError
+        logger.warning(
+            "[maya] DCC_MCP_MAYA_SEMANTIC_EMBEDDER=onnx requested but unavailable "
+            "(%s); falling back to HashedEmbedder. Install dcc-mcp-core[semantic].",
+            exc,
+        )
+        return HashedEmbedder()
+
+
+class MayaSemanticIndex:
+    """Lexical + vector fusion index used to augment base ``search_skills``.
+
+    The index is rebuilt lazily whenever the catalogue's skill set changes
+    (cheap for the adapter's ~25 skills — sub-millisecond per query).
+    """
+
+    def __init__(self, fusion: Any, embedder_kind: str) -> None:
+        self._fusion = fusion
+        self.embedder_kind = embedder_kind
+        self._signature: Optional[frozenset] = None
+
+    # ── construction ────────────────────────────────────────────────────
+    @classmethod
+    def build(cls, *, embedder_kind: Optional[str] = None) -> Optional["MayaSemanticIndex"]:
+        """Build the fused index, or ``None`` when core lacks the semantic API."""
+        try:
+            from dcc_mcp_core import LexicalSkillIndex, RrfFusionIndex, VectorSkillIndex  # noqa: PLC0415
+        except Exception as exc:  # noqa: BLE001 — older core without #1393
+            logger.info(
+                "[maya] semantic index requested but dcc-mcp-core lacks "
+                "VectorSkillIndex (%s); needs dcc-mcp-core>=0.17.38.",
+                exc,
+            )
+            return None
+        kind = embedder_kind or resolve_embedder_kind()
+        try:
+            fusion = (
+                RrfFusionIndex()
+                .register("lex", LexicalSkillIndex())
+                .register("vec", VectorSkillIndex(embedder=_build_embedder(kind)))
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[maya] failed to build semantic fusion index: %s", exc)
+            return None
+        return cls(fusion, kind)
+
+    # ── indexing / recall ───────────────────────────────────────────────
+    def rebuild(self, summaries: Sequence[Any]) -> None:
+        """(Re)index ``summaries`` only when the skill set changed."""
+        from dcc_mcp_core import SkillDocument  # noqa: PLC0415
+
+        signature = frozenset(
+            (n, getattr(s, "version", "")) for s in summaries if (n := _summary_name(s)) is not None
+        )
+        if signature == self._signature:
+            return
+        docs = []
+        for summary in summaries:
+            name = _summary_name(summary)
+            if name is None:
+                continue
+            docs.append(
+                SkillDocument(
+                    skill_id=name,
+                    name=name,
+                    summary=_summary_text(summary),
+                    tags=tuple(str(t) for t in (getattr(summary, "tags", None) or ())),
+                    dcc_name=str(getattr(summary, "dcc", "") or ""),
+                )
+            )
+        self._fusion.clear()
+        if docs:
+            self._fusion.index(docs)
+        self._signature = signature
+
+    def recall(self, query: str, *, k: int = 16) -> List[str]:
+        """Return fused-rank ``skill_id``s for ``query`` (best first)."""
+        if not query or not str(query).strip():
+            return []
+        try:
+            hits = self._fusion.search(str(query), k=k)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[maya] semantic recall failed for %r: %s", query, exc)
+            return []
+        return [hit.skill_id for hit in hits]
+
+    # ── fusion / augmentation ───────────────────────────────────────────
+    def augment(
+        self,
+        base: Sequence[Any],
+        query: Optional[str],
+        all_summaries: Sequence[Any],
+        *,
+        limit: Optional[int] = None,
+    ) -> List[Any]:
+        """Append morphology-recalled skills after the canonical ``base`` list.
+
+        ``base`` ordering is preserved verbatim — RRF promotes, never demotes
+        (issue #313 acceptance). Skills surfaced only by the vector backend are
+        appended in fused-rank order.
+        """
+        result = list(base)
+        if not query or not str(query).strip():
+            return result
+        try:
+            self.rebuild(all_summaries)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[maya] semantic rebuild failed: %s", exc)
+            return result
+
+        by_name = {n: s for s in all_summaries if (n := _summary_name(s)) is not None}
+        present = {_summary_name(s) for s in result}
+        for skill_id in self.recall(query):
+            if skill_id in present or skill_id not in by_name:
+                continue
+            result.append(by_name[skill_id])
+            present.add(skill_id)
+
+        if limit is not None and limit >= 0:
+            result = result[:limit]
+        return result
+
+
+def build_semantic_index() -> Optional[MayaSemanticIndex]:
+    """Return a ready index when the feature is enabled, else ``None``."""
+    if not resolve_semantic_index_enabled():
+        return None
+    return MayaSemanticIndex.build()

--- a/src/dcc_mcp_maya/_semantic_index.py
+++ b/src/dcc_mcp_maya/_semantic_index.py
@@ -131,7 +131,9 @@ class MayaSemanticIndex:
         from dcc_mcp_core import SkillDocument  # noqa: PLC0415
 
         signature = frozenset(
-            (n, getattr(s, "version", "")) for s in summaries if (n := _summary_name(s)) is not None
+            (name, getattr(s, "version", ""))
+            for s, name in ((s, _summary_name(s)) for s in summaries)
+            if name is not None
         )
         if signature == self._signature:
             return
@@ -189,7 +191,11 @@ class MayaSemanticIndex:
             logger.debug("[maya] semantic rebuild failed: %s", exc)
             return result
 
-        by_name = {n: s for s in all_summaries if (n := _summary_name(s)) is not None}
+        by_name = {
+            name: s
+            for s, name in ((s, _summary_name(s)) for s in all_summaries)
+            if name is not None
+        }
         present = {_summary_name(s) for s in result}
         for skill_id in self.recall(query):
             if skill_id in present or skill_id not in by_name:

--- a/src/dcc_mcp_maya/_semantic_index.py
+++ b/src/dcc_mcp_maya/_semantic_index.py
@@ -191,11 +191,7 @@ class MayaSemanticIndex:
             logger.debug("[maya] semantic rebuild failed: %s", exc)
             return result
 
-        by_name = {
-            name: s
-            for s, name in ((s, _summary_name(s)) for s in all_summaries)
-            if name is not None
-        }
+        by_name = {name: s for s, name in ((s, _summary_name(s)) for s in all_summaries) if name is not None}
         present = {_summary_name(s) for s in result}
         for skill_id in self.recall(query):
             if skill_id in present or skill_id not in by_name:

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -44,6 +44,7 @@ from dcc_mcp_maya import (
     _readiness,
     _registration,
     _resources,
+    _semantic_index,
     _skill_loader,
     _transport,
     _version_probe,
@@ -327,6 +328,20 @@ class MayaMcpServer(DccServerBase):
         # API memory rule) so skill scripts and plugin code never
         # touch the raw ``ResourceHandle`` directly.
         self._resources: Optional[_resources.MayaResourceBinder] = None
+
+        # ── Morphology-aware semantic recall (issue #313) ───────────────
+        # Opt-in fused lexical+vector index that augments base BM25
+        # ``search_skills`` results with morphology recalls (e.g. the
+        # query "rendering" recovering a "render" skill). ``None`` when
+        # ``DCC_MCP_MAYA_SEMANTIC_INDEX`` is unset or core lacks the
+        # VectorSkillIndex API (dcc-mcp-core>=0.17.38).
+        try:
+            self._semantic: Optional[_semantic_index.MayaSemanticIndex] = _semantic_index.build_semantic_index()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] semantic index init failed: %s", "maya", exc)
+            self._semantic = None
+        if self._semantic is not None:
+            logger.info("[%s] semantic skill recall enabled (embedder=%s)", "maya", self._semantic.embedder_kind)
 
     # ── Lifecycle additions ────────────────────────────────────────────
 
@@ -741,10 +756,20 @@ class MayaMcpServer(DccServerBase):
         if dcc is None:
             dcc = self._dcc_name
         try:
-            return list(super().search_skills(query=query, tags=tags, dcc=dcc))
+            base = list(super().search_skills(query=query, tags=tags, dcc=dcc))
         except Exception as exc:  # noqa: BLE001
             logger.debug("[%s] search_skills failed: %s", self._dcc_name, exc)
             return []
+
+        # Issue #313: when the opt-in semantic index is enabled, augment the
+        # canonical BM25 results with morphology recalls. ``base`` ordering is
+        # preserved (promote, never demote); vector-only hits are appended.
+        if self._semantic is not None and query:
+            try:
+                return self._semantic.augment(base, query, self.list_skills())
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[%s] semantic augment failed: %s", self._dcc_name, exc)
+        return base
 
     def get_skill_categories(self) -> list:
         try:

--- a/tests/test_semantic_index.py
+++ b/tests/test_semantic_index.py
@@ -1,0 +1,133 @@
+"""Issue #313 — morphology-aware semantic skill recall.
+
+These tests exercise :mod:`dcc_mcp_maya._semantic_index` directly (no live
+server / Maya needed). They pin the acceptance criteria:
+
+* opt-in gating via ``DCC_MCP_MAYA_SEMANTIC_INDEX`` (default off),
+* morphology queries that miss the lexical/BM25 path recall the right skill
+  through the vector backend,
+* base results are never demoted — augmentation only appends.
+
+The vector backend ships in ``dcc-mcp-core>=0.17.38``; tests skip cleanly on
+older cores.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+import pytest
+
+from dcc_mcp_maya import _semantic_index
+
+pytestmark = pytest.mark.skipif(
+    _semantic_index.MayaSemanticIndex.build(embedder_kind="hashed") is None,
+    reason="dcc-mcp-core lacks VectorSkillIndex (needs >=0.17.38)",
+)
+
+
+@dataclass
+class _FakeSummary:
+    name: str
+    description: str = ""
+    search_hint: str = ""
+    tags: Tuple[str, ...] = field(default_factory=tuple)
+    dcc: str = "maya"
+    version: str = "1.0.0"
+
+
+def _catalog() -> List[_FakeSummary]:
+    return [
+        _FakeSummary("maya-render", description="render the active frame and write images to disk"),
+        _FakeSummary("maya-primitives", description="create polygon spheres cubes and cylinders"),
+        _FakeSummary("maya-animation", description="set keyframes and bake transform animation"),
+        _FakeSummary("maya-uv-ops", description="unwrap and layout UV shells"),
+    ]
+
+
+class TestGating:
+    def test_disabled_by_default(self):
+        assert _semantic_index.resolve_semantic_index_enabled({}) is False
+
+    @pytest.mark.parametrize("token", ["1", "true", "YES", "on"])
+    def test_enabled_truthy_tokens(self, token: str):
+        env = {_semantic_index.ENV_SEMANTIC_INDEX: token}
+        assert _semantic_index.resolve_semantic_index_enabled(env) is True
+
+    def test_build_semantic_index_none_when_disabled(self, monkeypatch):
+        monkeypatch.delenv(_semantic_index.ENV_SEMANTIC_INDEX, raising=False)
+        assert _semantic_index.build_semantic_index() is None
+
+    def test_build_semantic_index_present_when_enabled(self, monkeypatch):
+        monkeypatch.setenv(_semantic_index.ENV_SEMANTIC_INDEX, "1")
+        index = _semantic_index.build_semantic_index()
+        assert index is not None
+        assert index.embedder_kind == "hashed"
+
+    def test_embedder_kind_resolution(self):
+        assert _semantic_index.resolve_embedder_kind({}) == "hashed"
+        assert _semantic_index.resolve_embedder_kind({_semantic_index.ENV_SEMANTIC_EMBEDDER: "onnx"}) == "onnx"
+
+
+class TestMorphologyRecall:
+    def _index(self):
+        idx = _semantic_index.MayaSemanticIndex.build(embedder_kind="hashed")
+        assert idx is not None
+        return idx
+
+    def test_inflected_query_recovers_skill_missed_by_lexical(self):
+        """``rendering`` (no literal token match) should recall ``maya-render``.
+
+        Simulates the Rust BM25 path returning nothing for the inflected verb;
+        augmentation must surface the morphologically-related skill.
+        """
+        idx = self._index()
+        catalog = _catalog()
+        fused = idx.augment(base=[], query="rendering the current frame", all_summaries=catalog)
+        names = [s.name for s in fused]
+        assert "maya-render" in names
+
+    def test_plural_query_recovers_primitive_skill(self):
+        idx = self._index()
+        catalog = _catalog()
+        fused = idx.augment(base=[], query="make some spheres", all_summaries=catalog)
+        assert "maya-primitives" in [s.name for s in fused]
+
+    def test_base_results_are_never_demoted(self):
+        """Base ordering must be preserved verbatim; recalls only append."""
+        idx = self._index()
+        catalog = _catalog()
+        base = [catalog[2], catalog[3]]  # animation, uv-ops (canonical order)
+        fused = idx.augment(base=base, query="rendering", all_summaries=catalog)
+        assert [s.name for s in fused[:2]] == ["maya-animation", "maya-uv-ops"]
+
+    def test_no_duplicates_when_recall_overlaps_base(self):
+        idx = self._index()
+        catalog = _catalog()
+        base = [catalog[0]]  # maya-render already present
+        fused = idx.augment(base=base, query="rendering", all_summaries=catalog)
+        assert [s.name for s in fused].count("maya-render") == 1
+
+    def test_empty_query_returns_base_unchanged(self):
+        idx = self._index()
+        catalog = _catalog()
+        base = [catalog[1]]
+        assert idx.augment(base=base, query="", all_summaries=catalog) == base
+        assert idx.augment(base=base, query=None, all_summaries=catalog) == base
+
+    def test_limit_truncates_fused_result(self):
+        idx = self._index()
+        catalog = _catalog()
+        fused = idx.augment(base=list(catalog), query="rendering", all_summaries=catalog, limit=2)
+        assert len(fused) == 2
+
+    def test_rebuild_is_cached_until_catalog_changes(self):
+        idx = self._index()
+        catalog = _catalog()
+        idx.rebuild(catalog)
+        sig = idx._signature
+        idx.rebuild(catalog)
+        assert idx._signature is sig or idx._signature == sig
+        idx.rebuild(catalog + [_FakeSummary("maya-new", description="brand new skill")])
+        assert idx._signature != sig

--- a/tests/test_skills_round39.py
+++ b/tests/test_skills_round39.py
@@ -398,6 +398,8 @@ class TestServerFindSkills:
         lifecycle = MagicMock()
         lifecycle.dispatch.side_effect = lambda event, payload=None, session_id=None: dict(payload or {})
         server._lifecycle_events = lifecycle
+        # Opt-in morphology semantic index (issue #313) is disabled by default.
+        server._semantic = None
         return server
 
     def test_method_exists(self):

--- a/tests/test_skills_round45.py
+++ b/tests/test_skills_round45.py
@@ -53,6 +53,8 @@ def _make_server():
     lifecycle = MagicMock()
     lifecycle.dispatch.side_effect = lambda event, payload=None, session_id=None: dict(payload or {})
     server._lifecycle_events = lifecycle
+    # Opt-in morphology semantic index (issue #313) is disabled by default.
+    server._semantic = None
     return server
 
 


### PR DESCRIPTION
Closes #313.

Adds opt-in morphology-aware skill recall. With \DCC_MCP_MAYA_SEMANTIC_INDEX=1\, \search_skills\ fuses a Python \VectorSkillIndex\ (zero-dep \HashedEmbedder\) + \LexicalSkillIndex\ via \RrfFusionIndex\ and **augments** the canonical Rust BM25 results — inflected queries like \endering\ recover \maya-render\.

- Base ordering preserved verbatim (promote, never demote); only vector-only hits are appended.
- \DCC_MCP_MAYA_SEMANTIC_EMBEDDER=onnx\ swaps in \OnnxEmbedder\ (\pip install 'dcc-mcp-core[semantic]'\), falls back to \hashed\.
- No-op / graceful when core < 0.17.38.
- New module \_semantic_index.py\; docs synced (AGENTS/README/llms).

Tests: tests/test_semantic_index.py (gating, morphology recall, no-demote, dedup, limit).