### PR TITLE
feat(ui): adopt shared core qt-ui-inspector skill for Maya (#307)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,6 +391,32 @@ All other skills appear as `__skill__<name>` stubs (default behavior). Call `loa
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | `1` / `true` / `yes` / `on` — refuse ``execute_python`` (skills-first policy). |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_MEL` | `0` | Same truthy tokens — refuse ``execute_mel`` only. |
 | `DCC_MCP_MAYA_DISABLE_ARBITRARY_SCRIPT` | `0` | Same truthy tokens — refuse **both** ``execute_python`` and ``execute_mel``. |
+| `DCC_MCP_MAYA_QT_UI_INSPECTOR` | `1` | `0` = skip registering the shared core ``qt_ui_inspector__*`` tools (issue #307). Read-only widget discovery (``list_windows`` / ``find_widgets`` / ``describe_widget`` / ``snapshot_tree`` / ``wait_for_widget``) routed onto Maya's main thread; locate buttons / dialogs / custom controls by text / objectName / class / accessibleName instead of ad-hoc PySide scripts. |
+
+---
+
+## Qt UI Inspection (issue #307)
+
+Maya adopts the DCC-agnostic **`qt-ui-inspector`** tools from `dcc-mcp-core`
+(`register_qt_ui_inspector`). Use these read-only tools to find Maya windows,
+shelves, dialogs, custom buttons, menus, tree/table views, and line edits by
+`objectName` / class / `accessibleName` **before** falling back to
+`execute_python` + ad-hoc PySide enumeration:
+
+| Tool | Purpose |
+|------|---------|
+| `qt_ui_inspector__list_windows` | Enumerate top-level Qt windows. |
+| `qt_ui_inspector__find_widgets` | Search by object name (exact/substring/regex) and/or class. |
+| `qt_ui_inspector__describe_widget` | Structured state for one widget (class, geometry, flags, accessible name, bounded properties). |
+| `qt_ui_inspector__snapshot_tree` | Walk the widget tree with depth/node budgets. |
+| `qt_ui_inspector__wait_for_widget` | Poll for a widget to appear/enable within a timeout. |
+
+All five run on Maya's main thread and return a structured
+`qt-binding-unavailable` / `qt-no-application` envelope when Qt or a running
+`QApplication` is missing, so an unavailable inspector reports a clear
+capability message instead of silently encouraging ad-hoc scripting. Mutation
+tools (`set_text` / `select_option` with explicit locator/value separation and
+post-action verification) are a follow-up in the shared core skill.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Useful plugin defaults:
 | `DCC_MCP_DEFAULT_TOOLS` | none | Comma-separated skill names to load at startup. |
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Maya's instance of the generic core `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`. Hide `__skill__*` / `__group__*` stubs from large `tools/list` syncs. Global fallback: `DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST`. |
 | `DCC_MCP_MAYA_SIDECAR` | `1` | `0` disables the default plugin sidecar process. |
+| `DCC_MCP_MAYA_QT_UI_INSPECTOR` | `1` | `0` skips the shared core `qt_ui_inspector__*` read-only widget-discovery tools (find buttons/dialogs/custom controls by text/objectName/class), routed onto Maya's main thread. |
 | `DCC_MCP_SERVER_BIN` | auto | Override the `dcc-mcp-server` binary path. |
 | `DCC_MCP_GATEWAY_PORT` | `9765` plugin | Local standalone gateway port; `0` disables gateway mode. |
 | `DCC_MCP_GATEWAY_NAME` | `dcc-mcp-gateway@<hostname>` sidecar | Human-readable gateway label shown in admin and CLI diagnostics. |

--- a/llms.txt
+++ b/llms.txt
@@ -199,6 +199,7 @@ Tool naming: `{skill_name.replace("-","_")}__{script_stem}` (e.g. `maya_scene__n
 | `DCC_MCP_REGISTRY_DIR` | OS temp | Shared discovery registry |
 | `DCC_MCP_MAYA_HOT_RELOAD` | `0` | `1`=watch skills for disk changes |
 | `DCC_MCP_MAYA_EXCLUDE_STUBS_FROM_TOOLS_LIST` | `0` | Maya instance of generic core `DCC_MCP_<DCC>_EXCLUDE_STUBS_FROM_TOOLS_LIST`; `1`=hide `__skill__*` / `__group__*` stubs from `tools/list` (global fallback `DCC_MCP_EXCLUDE_STUBS_FROM_TOOLS_LIST`) |
+| `DCC_MCP_MAYA_QT_UI_INSPECTOR` | `1` | `0`=skip shared core `qt_ui_inspector__*` read-only widget discovery tools, main-thread routed (issue #307) |
 | `DCC_MCP_MAYA_DEV_ROOTS` | — | Optional path-list of trusted roots for `maya-dev` project attachment |
 | `DCC_MCP_MAYA_AUTO_DISMISS_CRASH_DIALOG` | `0` | `1`=best-effort dismiss detected Maya Qt recovery dialogs after `affinity: main` tool calls |
 | `DCC_MCP_MAYA_DISABLE_EXECUTE_PYTHON` | `0` | `1`/`true`/`yes`/`on` — refuse `execute_python` (skills-first enforcement) |

--- a/src/dcc_mcp_maya/_qt_inspector.py
+++ b/src/dcc_mcp_maya/_qt_inspector.py
@@ -1,0 +1,118 @@
+"""Adopt the shared core ``qt-ui-inspector`` skill in Maya (issue #307).
+
+``dcc-mcp-core`` ships a DCC-agnostic, read-only Qt UI inspector
+(``register_qt_ui_inspector``) exposing five tools — ``list_windows``,
+``find_widgets``, ``describe_widget``, ``snapshot_tree``,
+``wait_for_widget``. Maya is the first adapter to adopt it so agents can
+locate custom shelves, dialogs, buttons, tree/table views, etc. **by text /
+objectName / class / accessibleName** instead of generating ad-hoc PySide
+enumeration scripts through ``execute_python``.
+
+Two Maya-specific concerns are handled here:
+
+* **Main-thread affinity.** ``QApplication.allWidgets()`` / ``topLevelWidgets()``
+  must be read on Maya's UI thread. MCP tool handlers run on a tokio worker
+  thread, so each inspector handler is wrapped to marshal onto Maya's main
+  thread via the same single-writer pump ``execute_python`` uses
+  (``maya.utils.executeInMainThreadWithResult``). In headless ``mayapy`` /
+  pytest the wrapper runs inline.
+* **Clear capability message.** The core tools already return structured
+  ``qt-binding-unavailable`` / ``qt-no-application`` envelopes when Qt or a
+  running ``QApplication`` is missing, so an unavailable inspector reports a
+  readiness message instead of silently encouraging ad-hoc scripting.
+
+Operator opt-out: ``DCC_MCP_MAYA_QT_UI_INSPECTOR=0``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+#: Set to a falsey token to skip registering the Qt UI inspector tools.
+ENV_QT_UI_INSPECTOR = "DCC_MCP_MAYA_QT_UI_INSPECTOR"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def resolve_qt_ui_inspector_enabled(env: Any = None) -> bool:
+    """Return ``True`` unless ``DCC_MCP_MAYA_QT_UI_INSPECTOR`` is falsey."""
+    environ = env if env is not None else os.environ
+    return str(environ.get(ENV_QT_UI_INSPECTOR, "1")).strip().lower() in _TRUTHY
+
+
+def _marshal_to_main(fn: Callable[[], Any]) -> Any:
+    """Run ``fn`` on Maya's main thread when a UI bridge is available.
+
+    Mirrors ``execute_python``'s dispatch: inline when already on the main
+    thread or when no Maya UI bridge exists (``mayapy`` / pytest), otherwise
+    queued through the process-wide single-writer pump.
+    """
+    if threading.current_thread() is threading.main_thread():
+        return fn()
+    try:
+        from dcc_mcp_maya import _main_thread_queue  # noqa: PLC0415
+
+        utils = _main_thread_queue._import_maya_utils()  # noqa: SLF001
+        if utils is None or not hasattr(utils, "executeInMainThreadWithResult"):
+            return fn()
+        return _main_thread_queue.get_queue().submit(fn).result()
+    except Exception as exc:  # noqa: BLE001 — degrade to inline rather than fail the call
+        logger.debug("[maya] qt inspector main-thread marshalling failed, running inline: %s", exc)
+        return fn()
+
+
+def _wrap_main_thread(handler: Callable[[Any], Any]) -> Callable[[Any], Any]:
+    def wrapper(params: Any) -> Any:
+        return _marshal_to_main(lambda: handler(params))
+
+    return wrapper
+
+
+class _MainThreadHandlerProxy:
+    """Server proxy that wraps every registered handler in main-thread routing.
+
+    ``register_qt_ui_inspector`` uses only ``server.registry`` and
+    ``server.register_handler`` — both are forwarded; ``register_handler``
+    additionally wraps the handler so the read happens on Maya's UI thread.
+    """
+
+    def __init__(self, server: Any) -> None:
+        self._server = server
+
+    @property
+    def registry(self) -> Any:
+        return self._server.registry
+
+    def register_handler(self, name: str, handler: Callable[[Any], Any]) -> Any:
+        return self._server.register_handler(name, _wrap_main_thread(handler))
+
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - passthrough
+        return getattr(self._server, item)
+
+
+def register_maya_qt_ui_inspector(inner_server: Any, *, dcc_name: str = "maya") -> bool:
+    """Register the shared ``qt_ui_inspector__*`` tools on the inner MCP server.
+
+    Returns ``True`` when the core inspector was registered, ``False`` when
+    disabled by env var or unavailable in the installed core.
+    """
+    if not resolve_qt_ui_inspector_enabled():
+        logger.info("[%s] qt-ui-inspector disabled via %s", dcc_name, ENV_QT_UI_INSPECTOR)
+        return False
+    try:
+        from dcc_mcp_core.skills.qt_ui_inspector import register_qt_ui_inspector  # noqa: PLC0415
+    except Exception as exc:  # noqa: BLE001 — older core without the shared skill
+        logger.info("[%s] qt-ui-inspector unavailable in installed dcc-mcp-core: %s", dcc_name, exc)
+        return False
+    try:
+        register_qt_ui_inspector(_MainThreadHandlerProxy(inner_server), dcc_name=dcc_name)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[%s] qt-ui-inspector registration failed: %s", dcc_name, exc)
+        return False
+    logger.info("[%s] qt-ui-inspector tools registered (main-thread routed)", dcc_name)
+    return True

--- a/src/dcc_mcp_maya/_registration.py
+++ b/src/dcc_mcp_maya/_registration.py
@@ -90,6 +90,15 @@ class StrictSkillScanPhase(RegistrationPhase):
         )
 
 
+class QtUiInspectorPhase(RegistrationPhase):
+    """Register the shared core ``qt_ui_inspector__*`` tools (issue #307)."""
+
+    name = "qt_ui_inspector"
+
+    def run(self, context: RegistrationContext) -> None:
+        context.server._register_qt_ui_inspector()  # noqa: SLF001
+
+
 class CapabilityManifestPhase(RegistrationPhase):
     name = "capability_manifest"
 
@@ -117,6 +126,7 @@ def default_registration_phases() -> Sequence[RegistrationPhase]:
         RecipesToolsPhase(),
         SkillReferenceDocsPhase(),
         StrictSkillScanPhase(),
+        QtUiInspectorPhase(),
         CapabilityManifestPhase(),
         ProjectToolsPhase(),
         ResourcesPhase(),

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -40,6 +40,7 @@ from dcc_mcp_maya import (
     _env,
     _executor,
     _project_tools,
+    _qt_inspector,
     _readiness,
     _registration,
     _resources,
@@ -612,6 +613,19 @@ class MayaMcpServer(DccServerBase):
     ) -> None:
         if _env.resolve_strict_skill_scan(strict_scan):
             self._strict_skill_scan(extra_skill_paths, include_bundled)
+
+    def _register_qt_ui_inspector(self) -> None:
+        """Adopt the shared core ``qt_ui_inspector__*`` tools (issue #307).
+
+        Registered on the inner MCP server with Maya main-thread routing so
+        widget reads happen on the UI thread. Read-only; self-reports a clear
+        ``qt-binding-unavailable`` / ``qt-no-application`` envelope when Qt is
+        not present rather than encouraging ad-hoc PySide scripts.
+        """
+        try:
+            _qt_inspector.register_maya_qt_ui_inspector(self._server, dcc_name=self._dcc_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] qt-ui-inspector registration failed: %s", "maya", exc)
 
     def _register_capability_manifest_tool(self) -> None:
         try:

--- a/tests/test_qt_ui_inspector_adoption.py
+++ b/tests/test_qt_ui_inspector_adoption.py
@@ -1,0 +1,113 @@
+"""Issue #307 — Maya adopts the shared core qt-ui-inspector skill.
+
+Verifies the adapter registers the five read-only ``qt_ui_inspector__*``
+tools on the inner MCP server, wraps each handler in Maya main-thread
+routing, and surfaces a clear capability envelope when no QApplication is
+running (the pytest case) instead of crashing or encouraging ad-hoc scripts.
+
+No live Maya / QApplication needed — a fake inner server captures the
+registrations.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable, Dict, List
+
+import pytest
+
+from dcc_mcp_maya import _qt_inspector
+
+_HAS_INSPECTOR = True
+try:  # pragma: no cover - import guard
+    from dcc_mcp_core.skills.qt_ui_inspector import register_qt_ui_inspector  # noqa: F401
+except Exception:  # noqa: BLE001
+    _HAS_INSPECTOR = False
+
+pytestmark = pytest.mark.skipif(not _HAS_INSPECTOR, reason="installed dcc-mcp-core lacks qt-ui-inspector")
+
+_EXPECTED_TOOLS = {
+    "qt_ui_inspector__list_windows",
+    "qt_ui_inspector__find_widgets",
+    "qt_ui_inspector__describe_widget",
+    "qt_ui_inspector__snapshot_tree",
+    "qt_ui_inspector__wait_for_widget",
+}
+
+
+class _FakeRegistry:
+    def __init__(self) -> None:
+        self.registered: List[str] = []
+
+    def register(self, *, name: str, **_kwargs: Any) -> None:
+        self.registered.append(name)
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.registry = _FakeRegistry()
+        self.handlers: Dict[str, Callable[[Any], Any]] = {}
+
+    def register_handler(self, name: str, handler: Callable[[Any], Any]) -> None:
+        self.handlers[name] = handler
+
+
+class TestRegistration:
+    def test_registers_all_five_tools(self):
+        server = _FakeServer()
+        assert _qt_inspector.register_maya_qt_ui_inspector(server, dcc_name="maya") is True
+        assert _EXPECTED_TOOLS <= set(server.registry.registered)
+        assert _EXPECTED_TOOLS <= set(server.handlers)
+
+    def test_env_opt_out_skips_registration(self, monkeypatch):
+        monkeypatch.setenv(_qt_inspector.ENV_QT_UI_INSPECTOR, "0")
+        server = _FakeServer()
+        assert _qt_inspector.register_maya_qt_ui_inspector(server, dcc_name="maya") is False
+        assert server.registry.registered == []
+
+    def test_handlers_return_structured_result_never_raise(self):
+        """The inspector must always return a structured dict — a clear
+        capability envelope when Qt/QApplication is missing, a normal result
+        otherwise — never raise into the host."""
+        server = _FakeServer()
+        _qt_inspector.register_maya_qt_ui_inspector(server, dcc_name="maya")
+        out = server.handlers["qt_ui_inspector__list_windows"]({})
+        assert isinstance(out, dict)
+        assert "success" in out
+
+
+class TestMainThreadRouting:
+    def test_handler_runs_through_marshal(self, monkeypatch):
+        """The registered handler must funnel through ``_marshal_to_main``."""
+        server = _FakeServer()
+        _qt_inspector.register_maya_qt_ui_inspector(server, dcc_name="maya")
+
+        seen: List[bool] = []
+        real = _qt_inspector._marshal_to_main
+
+        def _spy(fn):
+            seen.append(True)
+            return real(fn)
+
+        monkeypatch.setattr(_qt_inspector, "_marshal_to_main", _spy)
+        server.handlers["qt_ui_inspector__find_widgets"]({"object_name": "x"})
+        assert seen == [True]
+
+    def test_marshal_runs_inline_on_main_thread(self):
+        assert threading.current_thread() is threading.main_thread()
+        assert _qt_inspector._marshal_to_main(lambda: 41 + 1) == 42
+
+    def test_marshal_runs_inline_without_maya_bridge(self, monkeypatch):
+        """Off the main thread but no Maya UI bridge → run inline (mayapy/pytest)."""
+        from dcc_mcp_maya import _main_thread_queue
+
+        monkeypatch.setattr(_main_thread_queue, "_import_maya_utils", lambda: None)
+        result: List[Any] = []
+
+        def _worker():
+            result.append(_qt_inspector._marshal_to_main(lambda: "ran"))
+
+        t = threading.Thread(target=_worker)
+        t.start()
+        t.join(timeout=5.0)
+        assert result == ["ran"]

--- a/tests/test_registration_phases.py
+++ b/tests/test_registration_phases.py
@@ -28,6 +28,7 @@ def test_default_registration_phases_are_ordered() -> None:
         "recipes_tools",
         "skill_reference_docs",
         "strict_skill_scan",
+        "qt_ui_inspector",
         "capability_manifest",
         "project_tools",
         "resources",


### PR DESCRIPTION
Closes #307 (read-only inspector adoption).

Maya is the first adapter to adopt the shared DCC-agnostic \qt_ui_inspector__*\ tools from dcc-mcp-core:

- Registers \list_windows\ / \ind_widgets\ / \describe_widget\ / \snapshot_tree\ / \wait_for_widget\ on the inner MCP server.
- Each handler is **routed onto Maya's main thread** via the same single-writer pump \xecute_python\ uses (Qt reads off-thread crash Maya).
- Agents can locate buttons/dialogs/custom controls by text/objectName/class/accessibleName instead of ad-hoc PySide scripts.
- Clear \qt-binding-unavailable\ / \qt-no-application\ capability envelope when Qt is missing.
- Opt-out: \DCC_MCP_MAYA_QT_UI_INSPECTOR=0\.

Mutation tools (\set_text\/\select_option\ with locator/value separation + verification) belong in the shared core skill and are noted as a follow-up.

Tests: tests/test_qt_ui_inspector_adoption.py (registration, env opt-out, main-thread routing, structured envelope).