### PR TITLE
feat(skills): add typed maya-procedural-rig workflow skill (#306)

### DIFF
--- a/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
@@ -2,7 +2,7 @@
 
 > Cross-skill navigation map. Read this before deciding which skill to load.
 
-The 25 bundled skills are organised into **five stages** that match the
+The 26 bundled skills are organised into **five stages** that match the
 mental model of a Maya pipeline. Each skill carries the stage in its
 SKILL.md frontmatter under `metadata.dcc-mcp.stage`.
 
@@ -14,7 +14,7 @@ SKILL.md frontmatter under `metadata.dcc-mcp.stage`.
 | `scene` | Scene file lifecycle, DAG navigation, attributes, node graph, viewport visibility. | partial (`maya-scene` only) | `maya-scene`, `maya-scene-assembly`, `maya-display`, `maya-attributes`, `maya-node-graph` |
 | `authoring` | Create / edit content: meshes, UVs, materials, rigs, animation, dynamics, light rigs. | no | `maya-primitives`, `maya-mesh-ops`, `maya-uv-ops`, `maya-materials`, `maya-material-library`, `maya-texture-bake`, `maya-rigging`, `maya-animation`, `maya-dynamics`, `maya-pose-library`, `maya-expressions`, `maya-light-rig` |
 | `interchange` | Move geometry / scenes across DCCs (FBX, OBJ, presets, save). | no | `maya-geometry`, `maya-export-preset` |
-| `pipeline` | Production pipeline: project, publish, shot export, render, render farm, development diagnostics. | no | `maya-dev`, `maya-pipeline`, `maya-shot-export`, `maya-render`, `maya-render-farm` |
+| `pipeline` | Production pipeline: project, publish, shot export, render, render farm, development diagnostics, procedural workflow chains. | no | `maya-dev`, `maya-pipeline`, `maya-shot-export`, `maya-render`, `maya-render-farm`, `maya-procedural-rig` |
 
 ## Deciding which skill to load
 
@@ -51,6 +51,7 @@ Full rationale: repo root `AGENTS.md` § *Bulk import, export, and naming*; exam
 | Create a three-point light rig and tweak intensity | `maya-light-rig` |
 | Snapshot the viewport or write a playblast sequence | `maya-render` (`playblast`, `capture_viewport`, `capture_playblast_sequence`) |
 | Develop and debug a Maya Python tool inside the live session | `maya-dev` (`attach_project` → `run_check`; optional `start_debugpy`) |
+| Generate a full animated/shaded sphere demo scene, playblast, and export it | `maya-procedural-rig` (`create_sphere_layout` → `assign_palette_materials` → `create_rig_joints` → `bind_objects_to_joints` → `keyframe_orbit_animation` → `create_playblast` → `export_scene_artifact`) |
 
 ## Side-Effect Taxonomy
 

--- a/src/dcc_mcp_maya/skills/maya-procedural-rig/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-procedural-rig/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: maya-procedural-rig
+description: |-
+  Pipeline stage — typed, schema-validated procedural workflow that chains
+  staged tools end to end: lay out spheres, shade them from a palette, build a
+  radial joint skeleton, bind, keyframe an orbit/bounce/spin animation, capture
+  a playblast, and export an interchange file. Use this instead of one big
+  execute_python loop when you want validated parameters, structured results,
+  and a reproducible stage-by-stage chain. For arbitrary modelling code drop
+  into maya-scripting; for one-off primitives use maya-primitives.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: maya
+    layer: domain
+    stage: pipeline
+    version: 1.0.0
+    tags:
+    - maya
+    - procedural
+    - workflow
+    - rig
+    - animation
+    - playblast
+    - export
+    search-hint: |-
+      procedural workflow, sphere layout, generate spheres, palette materials,
+      auto rig joints, bind to joints, orbit animation, bounce spin keyframes,
+      playblast preview, export fbx obj, staged pipeline, chain tools end to end,
+      demo scene generator, motion graphics spheres
+    tools: tools.yaml
+    groups: groups.yaml
+---
+# maya-procedural-rig (Pipeline stage)
+
+A typed, end-to-end procedural workflow. Each tool is a discrete, validated
+stage that hands its results to the next one through structured context, so an
+agent can build a complete animated, shaded, rigged demo scene and export it
+**without** falling back to one large `execute_python` script (and losing input
+validation, `ToolAnnotations`, and structured envelopes).
+
+## The workflow chain
+
+| Stage | Tool | Consumes | Produces |
+|-------|------|----------|----------|
+| 1. Layout | `create_sphere_layout` | — | `object_names` |
+| 2. Shade | `assign_palette_materials` | `objects` | `assignments` |
+| 3. Skeleton | `create_rig_joints` | `objects` | `root_joint`, `joints` |
+| 4. Bind | `bind_objects_to_joints` | `objects`, `joints` | `bindings` |
+| 5. Animate | `keyframe_orbit_animation` | `nodes` (joints) | frame range |
+| 6. Preview | `create_playblast` | timeline | `output_path` |
+| 7. Export | `export_scene_artifact` | scene / selection | `output_path` |
+
+Each result carries a `prompt` pointing at the next stage, so the chain is
+discoverable from any starting point.
+
+## When to use this skill (vs alternatives)
+
+| Goal | Use |
+|------|-----|
+| Generate a full animated/shaded sphere demo scene + playblast + export | **maya-procedural-rig** |
+| Just create a few primitives | maya-primitives |
+| Hand-author a complex rig | maya-rigging |
+| Fine-grained animation curves | maya-animation |
+| Arbitrary procedural code | maya-scripting + execute_python |
+
+## Scripts
+
+- `create_sphere_layout` — Distribute polygon spheres (sphere / grid / line)
+- `assign_palette_materials` — One Lambert per object from a generated palette
+- `create_rig_joints` — Root joint + per-object child joints
+- `bind_objects_to_joints` — Constraint / parent binding in parallel order
+- `keyframe_orbit_animation` — Orbit / bounce / spin keyframes over a range
+- `create_playblast` — Capture a viewport preview to disk
+- `export_scene_artifact` — Export the scene or selection (ma/mb/obj/fbx)

--- a/src/dcc_mcp_maya/skills/maya-procedural-rig/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-procedural-rig/groups.yaml
@@ -1,0 +1,12 @@
+groups:
+- name: procedural
+  description: Staged procedural rig / animation / playblast / export workflow tools
+  default_active: true
+  tools:
+  - assign_palette_materials
+  - bind_objects_to_joints
+  - create_playblast
+  - create_rig_joints
+  - create_sphere_layout
+  - export_scene_artifact
+  - keyframe_orbit_animation

--- a/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/assign_palette_materials.py
+++ b/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/assign_palette_materials.py
@@ -1,0 +1,112 @@
+"""Assign a generated colour palette across a set of objects (issue #306).
+
+Stage two of the procedural workflow: shade the objects produced by
+``create_sphere_layout`` with deterministic per-object Lambert materials so the
+playblast at the end of the chain is visually legible.
+"""
+
+from __future__ import annotations
+
+import colorsys
+import random
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya.api import maya_error, maya_from_exception, maya_success
+
+_PALETTES = ("rainbow", "random", "mono")
+
+
+def _palette_colors(palette: str, count: int, seed: int, base_hue: float) -> List[List[float]]:
+    rng = random.Random(seed)
+    colors: List[List[float]] = []
+    for i in range(count):
+        if palette == "rainbow":
+            hue = (i / float(max(1, count))) % 1.0
+            colors.append(list(colorsys.hsv_to_rgb(hue, 0.85, 0.95)))
+        elif palette == "mono":
+            value = 0.35 + 0.6 * (i / float(max(1, count - 1))) if count > 1 else 0.8
+            colors.append(list(colorsys.hsv_to_rgb(base_hue, 0.7, value)))
+        else:  # random
+            colors.append(list(colorsys.hsv_to_rgb(rng.random(), 0.8, 0.9)))
+    return colors
+
+
+def assign_palette_materials(
+    objects: List[str],
+    palette: str = "rainbow",
+    seed: int = 0,
+    base_hue: float = 0.58,
+    material_prefix: str = "procMat",
+) -> dict:
+    """Create and assign one Lambert material per object from a palette.
+
+    Args:
+        objects: Transform names to shade (typically from create_sphere_layout).
+        palette: ``rainbow``, ``random``, or ``mono``.
+        seed: Seed for the ``random`` palette (deterministic).
+        base_hue: Hue (0-1) used as the anchor for the ``mono`` palette.
+        material_prefix: Prefix for created shading-node names.
+
+    Returns:
+        ToolResult dict with ``context.assignments`` and ``context.material_count``.
+    """
+    if palette not in _PALETTES:
+        return maya_error(
+            "Invalid palette",
+            "palette must be one of {}".format(", ".join(_PALETTES)),
+        )
+    if not objects:
+        return maya_error("No objects", "objects must contain at least one name")
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+    except ImportError:
+        return maya_error(
+            "Maya not available",
+            "maya.cmds could not be imported",
+            possible_solutions=["Run inside Maya or mayapy"],
+        )
+
+    try:
+        missing = [obj for obj in objects if not cmds.objExists(obj)]
+        if missing:
+            return maya_error(
+                "Objects not found",
+                "missing: {}".format(", ".join(missing)),
+                possible_solutions=["Run create_sphere_layout first and reuse object_names"],
+            )
+
+        colors = _palette_colors(palette, len(objects), seed, base_hue)
+        assignments = []
+        for i, obj in enumerate(objects):
+            shader = cmds.shadingNode("lambert", asShader=True, name="{}{}".format(material_prefix, i + 1))
+            sg = cmds.sets(renderable=True, noSurfaceShader=True, empty=True, name="{}SG".format(shader))
+            cmds.connectAttr("{}.outColor".format(shader), "{}.surfaceShader".format(sg), force=True)
+            r, g, b = colors[i]
+            cmds.setAttr("{}.color".format(shader), r, g, b, type="double3")
+            cmds.sets(obj, edit=True, forceElement=sg)
+            assignments.append({"object": obj, "material": shader, "color": [round(r, 3), round(g, 3), round(b, 3)]})
+
+        return maya_success(
+            "Assigned {} materials using the {} palette".format(len(assignments), palette),
+            prompt="Continue with create_rig_joints to build a skeleton over these objects.",
+            assignments=assignments,
+            material_count=len(assignments),
+            palette=palette,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return maya_from_exception(exc, message="Failed to assign palette materials")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`assign_palette_materials`."""
+    return assign_palette_materials(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/bind_objects_to_joints.py
+++ b/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/bind_objects_to_joints.py
@@ -1,0 +1,94 @@
+"""Bind objects to joints in parallel order (issue #306).
+
+Stage four: attach each object to its matching joint so animating the joints
+drives the geometry. Supports constraint-based or parent-based binding.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya.api import maya_error, maya_from_exception, maya_success
+
+_BIND_MODES = ("parentConstraint", "parent", "point")
+
+
+def bind_objects_to_joints(
+    objects: List[str],
+    joints: List[str],
+    bind_mode: str = "parentConstraint",
+    maintain_offset: bool = True,
+) -> dict:
+    """Bind ``objects[i]`` to ``joints[i]`` using the chosen mode.
+
+    Args:
+        objects: Transform names to bind (parallel to ``joints``).
+        joints: Joint names driving each object (parallel to ``objects``).
+        bind_mode: ``parentConstraint``, ``point``, or ``parent`` (re-parent).
+        maintain_offset: Keep the current relative offset for constraints.
+
+    Returns:
+        ToolResult dict with ``context.bindings`` and ``context.bound_count``.
+    """
+    if bind_mode not in _BIND_MODES:
+        return maya_error(
+            "Invalid bind_mode",
+            "bind_mode must be one of {}".format(", ".join(_BIND_MODES)),
+        )
+    if not objects or not joints:
+        return maya_error("Missing input", "objects and joints must both be non-empty")
+    if len(objects) != len(joints):
+        return maya_error(
+            "Length mismatch",
+            "objects ({}) and joints ({}) must be the same length".format(len(objects), len(joints)),
+        )
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+    except ImportError:
+        return maya_error(
+            "Maya not available",
+            "maya.cmds could not be imported",
+            possible_solutions=["Run inside Maya or mayapy"],
+        )
+
+    try:
+        bindings = []
+        for obj, jnt in zip(objects, joints):
+            if not cmds.objExists(obj) or not cmds.objExists(jnt):
+                return maya_error(
+                    "Node not found",
+                    "missing object or joint: {} / {}".format(obj, jnt),
+                )
+            if bind_mode == "parent":
+                cmds.parent(obj, jnt)
+                node = obj
+            elif bind_mode == "point":
+                node = cmds.pointConstraint(jnt, obj, maintainOffset=maintain_offset)[0]
+            else:
+                node = cmds.parentConstraint(jnt, obj, maintainOffset=maintain_offset)[0]
+            bindings.append({"object": obj, "joint": jnt, "binding": node})
+
+        return maya_success(
+            "Bound {} objects using {}".format(len(bindings), bind_mode),
+            prompt="Use keyframe_orbit_animation to animate the joints.",
+            bindings=bindings,
+            bound_count=len(bindings),
+            bind_mode=bind_mode,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return maya_from_exception(exc, message="Failed to bind objects to joints")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`bind_objects_to_joints`."""
+    return bind_objects_to_joints(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/create_playblast.py
+++ b/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/create_playblast.py
@@ -1,0 +1,105 @@
+"""Generate a playblast preview of the current animation (issue #306).
+
+Stage six: capture the active viewport across the playback range to an image
+sequence or movie file so the workflow produces a reviewable artefact.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya.api import maya_error, maya_from_exception, maya_success
+
+_FORMATS = ("qt", "avi", "image")
+
+
+def create_playblast(
+    output_path: str,
+    start_frame: Optional[int] = None,
+    end_frame: Optional[int] = None,
+    width: int = 1280,
+    height: int = 720,
+    fmt: str = "image",
+    show_ornaments: bool = False,
+) -> dict:
+    """Capture a playblast to ``output_path``.
+
+    Args:
+        output_path: Target file path (extension implied by ``fmt``).
+        start_frame: First frame; defaults to the timeline minimum.
+        end_frame: Last frame; defaults to the timeline maximum.
+        width: Output width in pixels.
+        height: Output height in pixels.
+        fmt: ``image`` (frame sequence), ``qt`` (QuickTime), or ``avi``.
+        show_ornaments: Keep HUD/ornaments in the capture.
+
+    Returns:
+        ToolResult dict with ``context.output_path``.
+    """
+    if fmt not in _FORMATS:
+        return maya_error("Invalid fmt", "fmt must be one of {}".format(", ".join(_FORMATS)))
+    if not output_path:
+        return maya_error("Missing output_path", "output_path is required")
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+    except ImportError:
+        return maya_error(
+            "Maya not available",
+            "maya.cmds could not be imported",
+            possible_solutions=["Run inside Maya or mayapy"],
+        )
+
+    try:
+        out_dir = os.path.dirname(output_path)
+        if out_dir and not os.path.isdir(out_dir):
+            os.makedirs(out_dir)
+
+        if start_frame is None:
+            start_frame = int(cmds.playbackOptions(query=True, minTime=True))
+        if end_frame is None:
+            end_frame = int(cmds.playbackOptions(query=True, maxTime=True))
+
+        kwargs = {
+            "filename": output_path,
+            "startTime": start_frame,
+            "endTime": end_frame,
+            "width": width,
+            "height": height,
+            "showOrnaments": show_ornaments,
+            "viewer": False,
+            "forceOverwrite": True,
+            "percent": 100,
+        }
+        if fmt == "image":
+            kwargs["format"] = "image"
+            kwargs["compression"] = "png"
+        else:
+            kwargs["format"] = fmt
+
+        result_path = cmds.playblast(**kwargs)
+        return maya_success(
+            "Captured playblast to {}".format(result_path or output_path),
+            prompt="Use export_scene_artifact to export the geometry alongside the preview.",
+            output_path=result_path or output_path,
+            start_frame=start_frame,
+            end_frame=end_frame,
+            fmt=fmt,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return maya_from_exception(exc, message="Failed to create playblast")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_playblast`."""
+    return create_playblast(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/create_rig_joints.py
+++ b/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/create_rig_joints.py
@@ -1,0 +1,87 @@
+"""Build a simple radial joint hierarchy over a set of objects (issue #306).
+
+Stage three: create a centre root joint plus one child joint snapped to each
+object's world position, giving later stages a skeleton to bind and animate.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya.api import maya_error, maya_from_exception, maya_success
+
+
+def create_rig_joints(
+    objects: List[str],
+    center_position: List[float] = None,
+    joint_prefix: str = "procJnt",
+    root_name: str = "procRoot",
+) -> dict:
+    """Create a root joint and a child joint at each object's position.
+
+    Args:
+        objects: Transform names whose positions seed the child joints.
+        center_position: World position ``[x, y, z]`` for the root joint.
+        joint_prefix: Prefix for child joint names.
+        root_name: Name for the root joint.
+
+    Returns:
+        ToolResult dict with ``context.root_joint`` and ``context.joints``.
+    """
+    if not objects:
+        return maya_error("No objects", "objects must contain at least one name")
+    if center_position is None:
+        center_position = [0.0, 0.0, 0.0]
+    if len(center_position) != 3:
+        return maya_error("Invalid center_position", "center_position must be [x, y, z]")
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+    except ImportError:
+        return maya_error(
+            "Maya not available",
+            "maya.cmds could not be imported",
+            possible_solutions=["Run inside Maya or mayapy"],
+        )
+
+    try:
+        missing = [obj for obj in objects if not cmds.objExists(obj)]
+        if missing:
+            return maya_error(
+                "Objects not found",
+                "missing: {}".format(", ".join(missing)),
+                possible_solutions=["Run create_sphere_layout first and reuse object_names"],
+            )
+
+        cmds.select(clear=True)
+        root = cmds.joint(name=root_name, position=center_position)
+        joints: List[str] = []
+        for i, obj in enumerate(objects):
+            pos = cmds.xform(obj, query=True, worldSpace=True, translation=True)
+            cmds.select(root, replace=True)
+            jnt = cmds.joint(name="{}{}".format(joint_prefix, i + 1), position=pos)
+            joints.append(jnt)
+
+        return maya_success(
+            "Created root joint {} with {} child joints".format(root, len(joints)),
+            prompt="Use bind_objects_to_joints to attach the objects to these joints.",
+            root_joint=root,
+            joints=joints,
+            count=len(joints),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return maya_from_exception(exc, message="Failed to create rig joints")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_rig_joints`."""
+    return create_rig_joints(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/create_sphere_layout.py
+++ b/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/create_sphere_layout.py
@@ -1,0 +1,124 @@
+"""Create a procedural distribution of polygon spheres (issue #306).
+
+Typed, schema-validated alternative to a hand-rolled ``execute_python`` loop
+for the first stage of a procedural rig/animation workflow: place ``count``
+spheres in a deterministic spherical / grid / line layout and return the
+created object names so later stages (materials, joints, animation) can
+consume them.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya.api import maya_error, maya_from_exception, maya_success
+
+_LAYOUTS = ("sphere", "grid", "line")
+
+
+def _sphere_positions(count: int, radius: float) -> List[List[float]]:
+    """Even points on a sphere via the Fibonacci lattice (deterministic)."""
+    if count == 1:
+        return [[0.0, 0.0, 0.0]]
+    points: List[List[float]] = []
+    golden = math.pi * (3.0 - math.sqrt(5.0))
+    for i in range(count):
+        y = 1.0 - (i / float(count - 1)) * 2.0
+        r = math.sqrt(max(0.0, 1.0 - y * y))
+        theta = golden * i
+        points.append([math.cos(theta) * r * radius, y * radius, math.sin(theta) * r * radius])
+    return points
+
+
+def _grid_positions(count: int, spacing: float) -> List[List[float]]:
+    side = int(math.ceil(math.sqrt(count)))
+    offset = (side - 1) * spacing / 2.0
+    out: List[List[float]] = []
+    for i in range(count):
+        row, col = divmod(i, side)
+        out.append([col * spacing - offset, 0.0, row * spacing - offset])
+    return out
+
+
+def _line_positions(count: int, spacing: float) -> List[List[float]]:
+    offset = (count - 1) * spacing / 2.0
+    return [[i * spacing - offset, 0.0, 0.0] for i in range(count)]
+
+
+def create_sphere_layout(
+    count: int = 8,
+    radius: float = 1.0,
+    layout: str = "sphere",
+    spacing: float = 4.0,
+    distribution_radius: float = 10.0,
+    name_prefix: str = "procSphere",
+) -> dict:
+    """Create ``count`` polygon spheres in a procedural layout.
+
+    Args:
+        count: Number of spheres to create (1-500).
+        radius: Per-sphere radius.
+        layout: ``sphere`` (Fibonacci shell), ``grid`` (XZ grid), or ``line``.
+        spacing: Distance between spheres for ``grid`` / ``line`` layouts.
+        distribution_radius: Shell radius for the ``sphere`` layout.
+        name_prefix: Prefix for created transform names.
+
+    Returns:
+        ToolResult dict with ``context.object_names`` and ``context.count``.
+    """
+    if layout not in _LAYOUTS:
+        return maya_error(
+            "Invalid layout",
+            "layout must be one of {}".format(", ".join(_LAYOUTS)),
+        )
+    count = int(count)
+    if count < 1 or count > 500:
+        return maya_error("Invalid count", "count must be between 1 and 500")
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+    except ImportError:
+        return maya_error(
+            "Maya not available",
+            "maya.cmds could not be imported",
+            possible_solutions=["Run inside Maya or mayapy"],
+        )
+
+    try:
+        if layout == "sphere":
+            positions = _sphere_positions(count, distribution_radius)
+        elif layout == "grid":
+            positions = _grid_positions(count, spacing)
+        else:
+            positions = _line_positions(count, spacing)
+
+        object_names: List[str] = []
+        for i, pos in enumerate(positions):
+            transform = cmds.polySphere(radius=radius, name="{}{}".format(name_prefix, i + 1))[0]
+            cmds.move(pos[0], pos[1], pos[2], transform, absolute=True)
+            object_names.append(transform)
+
+        return maya_success(
+            "Created {} spheres in a {} layout".format(len(object_names), layout),
+            prompt="Pass object_names to assign_palette_materials or create_rig_joints next.",
+            object_names=object_names,
+            count=len(object_names),
+            layout=layout,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return maya_from_exception(exc, message="Failed to create sphere layout")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_sphere_layout`."""
+    return create_sphere_layout(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/export_scene_artifact.py
+++ b/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/export_scene_artifact.py
@@ -1,0 +1,107 @@
+"""Export the rigged/animated scene to an interchange file (issue #306).
+
+Final stage: hand the result of the workflow off to other DCCs or a pipeline
+by exporting either the whole scene or a selected subset.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya.api import maya_error, maya_from_exception, maya_success
+
+_FORMATS = {
+    "maya_ascii": ("mayaAscii", ".ma"),
+    "maya_binary": ("mayaBinary", ".mb"),
+    "obj": ("OBJexport", ".obj"),
+    "fbx": ("FBX export", ".fbx"),
+}
+
+
+def export_scene_artifact(
+    output_path: str,
+    fmt: str = "maya_ascii",
+    selection_only: bool = False,
+    objects: Optional[List[str]] = None,
+) -> dict:
+    """Export the scene (or a selection) to ``output_path``.
+
+    Args:
+        output_path: Target file path.
+        fmt: ``maya_ascii``, ``maya_binary``, ``obj``, or ``fbx``.
+        selection_only: Export only the current selection / ``objects``.
+        objects: Explicit nodes to select before a selection-only export.
+
+    Returns:
+        ToolResult dict with ``context.output_path`` and ``context.fmt``.
+    """
+    if fmt not in _FORMATS:
+        return maya_error(
+            "Invalid fmt",
+            "fmt must be one of {}".format(", ".join(sorted(_FORMATS))),
+        )
+    if not output_path:
+        return maya_error("Missing output_path", "output_path is required")
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+    except ImportError:
+        return maya_error(
+            "Maya not available",
+            "maya.cmds could not be imported",
+            possible_solutions=["Run inside Maya or mayapy"],
+        )
+
+    try:
+        out_dir = os.path.dirname(output_path)
+        if out_dir and not os.path.isdir(out_dir):
+            os.makedirs(out_dir)
+
+        type_string, ext = _FORMATS[fmt]
+        if not output_path.lower().endswith(ext):
+            output_path += ext
+
+        export_selected = selection_only or bool(objects)
+        if objects:
+            missing = [obj for obj in objects if not cmds.objExists(obj)]
+            if missing:
+                return maya_error("Objects not found", "missing: {}".format(", ".join(missing)))
+            cmds.select(objects, replace=True)
+
+        if fmt == "fbx":
+            try:
+                cmds.loadPlugin("fbxmaya", quiet=True)
+            except Exception:  # noqa: BLE001
+                pass
+
+        if export_selected:
+            cmds.file(output_path, force=True, options="v=0;", type=type_string, exportSelected=True)
+            exported = len(cmds.ls(selection=True))
+        else:
+            cmds.file(output_path, force=True, options="v=0;", type=type_string, exportAll=True)
+            exported = len(cmds.ls(transforms=True))
+
+        return maya_success(
+            "Exported {} to {}".format(fmt, output_path),
+            output_path=output_path,
+            fmt=fmt,
+            exported_count=exported,
+            selection_only=export_selected,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return maya_from_exception(exc, message="Failed to export scene artifact")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`export_scene_artifact`."""
+    return export_scene_artifact(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/keyframe_orbit_animation.py
+++ b/src/dcc_mcp_maya/skills/maya-procedural-rig/scripts/keyframe_orbit_animation.py
@@ -1,0 +1,114 @@
+"""Keyframe a procedural orbit / bounce / spin animation (issue #306).
+
+Stage five: set deterministic keyframes on a set of nodes (typically the rig
+joints) across a frame range so the playblast stage has motion to capture.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_maya.api import maya_error, maya_from_exception, maya_success
+
+_MODES = ("orbit", "bounce", "spin")
+_AXES = {"x": 0, "y": 1, "z": 2}
+
+
+def keyframe_orbit_animation(
+    nodes: List[str],
+    start_frame: int = 1,
+    end_frame: int = 120,
+    keys: int = 5,
+    amplitude: float = 5.0,
+    axis: str = "y",
+    mode: str = "orbit",
+    seed: int = 0,
+) -> dict:
+    """Set keyframes describing a looping motion on each node.
+
+    Args:
+        nodes: Transform/joint names to animate.
+        start_frame: First keyframe.
+        end_frame: Last keyframe.
+        keys: Number of keyframes per node across the range (>=2).
+        amplitude: Motion magnitude (translate units or degrees for ``spin``).
+        axis: Primary axis ``x`` / ``y`` / ``z``.
+        mode: ``orbit`` (circular translate), ``bounce`` (axis translate),
+            or ``spin`` (axis rotate).
+        seed: Per-node phase offset seed (deterministic).
+
+    Returns:
+        ToolResult dict with ``context.keyed_count`` and frame range.
+    """
+    if mode not in _MODES:
+        return maya_error("Invalid mode", "mode must be one of {}".format(", ".join(_MODES)))
+    if axis not in _AXES:
+        return maya_error("Invalid axis", "axis must be x, y, or z")
+    if not nodes:
+        return maya_error("No nodes", "nodes must contain at least one name")
+    if end_frame <= start_frame:
+        return maya_error("Invalid range", "end_frame must be greater than start_frame")
+    keys = max(2, int(keys))
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+    except ImportError:
+        return maya_error(
+            "Maya not available",
+            "maya.cmds could not be imported",
+            possible_solutions=["Run inside Maya or mayapy"],
+        )
+
+    try:
+        rng = random.Random(seed)
+        span = end_frame - start_frame
+        keyed = 0
+        for node in nodes:
+            if not cmds.objExists(node):
+                return maya_error("Node not found", "missing node: {}".format(node))
+            base = cmds.xform(node, query=True, worldSpace=False, translation=True)
+            phase = rng.random() * math.tau
+            for k in range(keys):
+                t = k / float(keys - 1)
+                frame = start_frame + t * span
+                angle = phase + t * math.tau
+                if mode == "spin":
+                    attr = "r" + axis
+                    cmds.setKeyframe(node, attribute=attr, value=amplitude * 360.0 * t, time=frame)
+                elif mode == "bounce":
+                    attr = "t" + axis
+                    value = base[_AXES[axis]] + amplitude * abs(math.sin(angle))
+                    cmds.setKeyframe(node, attribute=attr, value=value, time=frame)
+                else:  # orbit
+                    cmds.setKeyframe(node, attribute="tx", value=base[0] + amplitude * math.cos(angle), time=frame)
+                    cmds.setKeyframe(node, attribute="tz", value=base[2] + amplitude * math.sin(angle), time=frame)
+                keyed += 1
+
+        cmds.playbackOptions(minTime=start_frame, maxTime=end_frame)
+        return maya_success(
+            "Keyed {} nodes ({}) from frame {} to {}".format(len(nodes), mode, start_frame, end_frame),
+            prompt="Use create_playblast to render a preview of the animation.",
+            keyed_count=keyed,
+            node_count=len(nodes),
+            start_frame=start_frame,
+            end_frame=end_frame,
+            mode=mode,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return maya_from_exception(exc, message="Failed to keyframe animation")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`keyframe_orbit_animation`."""
+    return keyframe_orbit_animation(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-procedural-rig/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-procedural-rig/tools.yaml
@@ -1,0 +1,263 @@
+tools:
+- name: create_sphere_layout
+  description: Create a procedural distribution of polygon spheres (sphere / grid / line).
+  execution: sync
+  affinity: main
+  group: procedural
+  input_schema:
+    type: object
+    properties:
+      count:
+        type: integer
+        minimum: 1
+        maximum: 500
+        default: 8
+        description: Number of spheres to create.
+      radius:
+        type: number
+        minimum: 0.0001
+        default: 1.0
+        description: Per-sphere radius.
+      layout:
+        type: string
+        enum:
+        - sphere
+        - grid
+        - line
+        default: sphere
+        description: Distribution shape.
+      spacing:
+        type: number
+        minimum: 0.0
+        default: 4.0
+        description: Distance between spheres for grid / line layouts.
+      distribution_radius:
+        type: number
+        minimum: 0.0001
+        default: 10.0
+        description: Shell radius for the sphere layout.
+      name_prefix:
+        type: string
+        default: procSphere
+- name: assign_palette_materials
+  description: Create and assign one Lambert material per object from a generated palette.
+  execution: sync
+  affinity: main
+  group: procedural
+  input_schema:
+    type: object
+    required:
+    - objects
+    properties:
+      objects:
+        type: array
+        items:
+          type: string
+        minItems: 1
+        description: Transform names to shade (typically from create_sphere_layout).
+      palette:
+        type: string
+        enum:
+        - rainbow
+        - random
+        - mono
+        default: rainbow
+      seed:
+        type: integer
+        default: 0
+        description: Seed for the random palette (deterministic).
+      base_hue:
+        type: number
+        minimum: 0.0
+        maximum: 1.0
+        default: 0.58
+        description: Anchor hue (0-1) for the mono palette.
+      material_prefix:
+        type: string
+        default: procMat
+- name: create_rig_joints
+  description: Create a root joint plus one child joint snapped to each object's position.
+  execution: sync
+  affinity: main
+  group: procedural
+  input_schema:
+    type: object
+    required:
+    - objects
+    properties:
+      objects:
+        type: array
+        items:
+          type: string
+        minItems: 1
+        description: Transform names whose positions seed the child joints.
+      center_position:
+        type: array
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+        description: World position [x, y, z] for the root joint. Defaults to origin.
+      joint_prefix:
+        type: string
+        default: procJnt
+      root_name:
+        type: string
+        default: procRoot
+- name: bind_objects_to_joints
+  description: Bind objects[i] to joints[i] using a constraint or re-parenting.
+  execution: sync
+  affinity: main
+  group: procedural
+  input_schema:
+    type: object
+    required:
+    - objects
+    - joints
+    properties:
+      objects:
+        type: array
+        items:
+          type: string
+        minItems: 1
+      joints:
+        type: array
+        items:
+          type: string
+        minItems: 1
+      bind_mode:
+        type: string
+        enum:
+        - parentConstraint
+        - parent
+        - point
+        default: parentConstraint
+      maintain_offset:
+        type: boolean
+        default: true
+- name: keyframe_orbit_animation
+  description: Keyframe a procedural orbit / bounce / spin animation across a frame range.
+  execution: async
+  affinity: main
+  timeout_hint_secs: 120
+  group: procedural
+  input_schema:
+    type: object
+    required:
+    - nodes
+    properties:
+      nodes:
+        type: array
+        items:
+          type: string
+        minItems: 1
+        description: Transform / joint names to animate.
+      start_frame:
+        type: integer
+        default: 1
+      end_frame:
+        type: integer
+        default: 120
+      keys:
+        type: integer
+        minimum: 2
+        default: 5
+        description: Number of keyframes per node across the range.
+      amplitude:
+        type: number
+        default: 5.0
+        description: Motion magnitude (units, or rotations for spin).
+      axis:
+        type: string
+        enum:
+        - x
+        - y
+        - z
+        default: y
+      mode:
+        type: string
+        enum:
+        - orbit
+        - bounce
+        - spin
+        default: orbit
+      seed:
+        type: integer
+        default: 0
+- name: create_playblast
+  description: Capture a playblast preview of the current animation to disk.
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
+  group: procedural
+  annotations:
+    idempotent_hint: true
+  input_schema:
+    type: object
+    required:
+    - output_path
+    properties:
+      output_path:
+        type: string
+        description: Target file path (extension implied by fmt).
+      start_frame:
+        type: integer
+        description: First frame; defaults to the timeline minimum.
+      end_frame:
+        type: integer
+        description: Last frame; defaults to the timeline maximum.
+      width:
+        type: integer
+        minimum: 1
+        default: 1280
+      height:
+        type: integer
+        minimum: 1
+        default: 720
+      fmt:
+        type: string
+        enum:
+        - image
+        - qt
+        - avi
+        default: image
+      show_ornaments:
+        type: boolean
+        default: false
+- name: export_scene_artifact
+  description: >-
+    Export the whole scene or just a selection to an interchange file
+    (maya_ascii .ma, maya_binary .mb, obj, or fbx). Pass an absolute output_path;
+    parent folders are created automatically and the correct extension is appended.
+    FBX requires the bundled fbxmaya plugin (loaded on demand); OBJ requires
+    the objExport plugin. Common failures: missing/unloadable plugin, an empty
+    selection when selection_only is true, or names in objects that do not exist.
+  execution: async
+  affinity: main
+  timeout_hint_secs: 300
+  group: procedural
+  annotations:
+    idempotent_hint: true
+  input_schema:
+    type: object
+    required:
+    - output_path
+    properties:
+      output_path:
+        type: string
+      fmt:
+        type: string
+        enum:
+        - maya_ascii
+        - maya_binary
+        - obj
+        - fbx
+        default: maya_ascii
+      selection_only:
+        type: boolean
+        default: false
+      objects:
+        type: array
+        items:
+          type: string
+        description: Explicit nodes to select before a selection-only export.

--- a/tests/test_procedural_rig_skill.py
+++ b/tests/test_procedural_rig_skill.py
@@ -37,9 +37,7 @@ def _load_yaml(name: str) -> Dict:
 
 def _load_script_module(stem: str):
     """Import a workflow script by file path without installing the package."""
-    spec = importlib.util.spec_from_file_location(
-        "procedural_rig_" + stem, SCRIPTS_DIR / (stem + ".py")
-    )
+    spec = importlib.util.spec_from_file_location("procedural_rig_" + stem, SCRIPTS_DIR / (stem + ".py"))
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/tests/test_procedural_rig_skill.py
+++ b/tests/test_procedural_rig_skill.py
@@ -1,0 +1,110 @@
+"""Tests for the maya-procedural-rig workflow skill (issue #306).
+
+These tests are dependency-free: they do not require a running Maya. They
+verify the package wiring (SKILL.md frontmatter, tools.yaml ↔ scripts ↔
+groups.yaml consistency) and that every workflow script degrades to a
+structured ``maya_error`` envelope — never an unhandled exception — when
+``maya.cmds`` is unavailable.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Dict
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILL_DIR = REPO_ROOT / "src" / "dcc_mcp_maya" / "skills" / "maya-procedural-rig"
+SCRIPTS_DIR = SKILL_DIR / "scripts"
+
+EXPECTED_TOOLS = {
+    "create_sphere_layout",
+    "assign_palette_materials",
+    "create_rig_joints",
+    "bind_objects_to_joints",
+    "keyframe_orbit_animation",
+    "create_playblast",
+    "export_scene_artifact",
+}
+
+
+def _load_yaml(name: str) -> Dict:
+    return yaml.safe_load((SKILL_DIR / name).read_text(encoding="utf-8")) or {}
+
+
+def _load_script_module(stem: str):
+    """Import a workflow script by file path without installing the package."""
+    spec = importlib.util.spec_from_file_location(
+        "procedural_rig_" + stem, SCRIPTS_DIR / (stem + ".py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_skill_md_declares_pipeline_stage() -> None:
+    import dcc_mcp_core
+
+    meta = dcc_mcp_core.parse_skill_md(str(SKILL_DIR))
+    assert meta is not None
+    assert getattr(meta, "stage", None) == "pipeline"
+
+
+def test_tools_match_scripts_and_groups() -> None:
+    tools = {t["name"] for t in _load_yaml("tools.yaml")["tools"]}
+    assert tools == EXPECTED_TOOLS
+
+    scripts = {p.stem for p in SCRIPTS_DIR.glob("*.py")}
+    assert EXPECTED_TOOLS <= scripts
+
+    group_tools = set()
+    for group in _load_yaml("groups.yaml")["groups"]:
+        group_tools.update(group["tools"])
+    assert group_tools == EXPECTED_TOOLS
+
+
+def test_async_tools_declare_timeout_hint() -> None:
+    for tool in _load_yaml("tools.yaml")["tools"]:
+        if tool.get("execution") == "async":
+            assert tool.get("timeout_hint_secs"), tool["name"]
+
+
+@pytest.mark.parametrize(
+    ("stem", "kwargs"),
+    [
+        ("create_sphere_layout", {"count": 3}),
+        ("assign_palette_materials", {"objects": ["a", "b"]}),
+        ("create_rig_joints", {"objects": ["a"]}),
+        ("bind_objects_to_joints", {"objects": ["a"], "joints": ["j"]}),
+        ("keyframe_orbit_animation", {"nodes": ["a"]}),
+        ("create_playblast", {"output_path": "/tmp/out"}),
+        ("export_scene_artifact", {"output_path": "/tmp/out"}),
+    ],
+)
+def test_scripts_degrade_gracefully_without_maya(stem: str, kwargs: Dict) -> None:
+    """Without ``maya.cmds`` every script returns a structured envelope."""
+    module = _load_script_module(stem)
+    func = getattr(module, stem)
+    result = func(**kwargs)
+    assert isinstance(result, dict)
+    assert "success" in result
+
+
+@pytest.mark.parametrize(
+    ("stem", "kwargs"),
+    [
+        ("create_sphere_layout", {"layout": "bogus"}),
+        ("assign_palette_materials", {"objects": ["a"], "palette": "bogus"}),
+        ("bind_objects_to_joints", {"objects": ["a"], "joints": ["x", "y"]}),
+        ("keyframe_orbit_animation", {"nodes": ["a"], "mode": "bogus"}),
+    ],
+)
+def test_input_validation_rejects_bad_args(stem: str, kwargs: Dict) -> None:
+    """Validation errors are caught before any maya.cmds import is attempted."""
+    module = _load_script_module(stem)
+    func = getattr(module, stem)
+    result = func(**kwargs)
+    assert result.get("success") is False

--- a/tools/annotate_skill_affinity.py
+++ b/tools/annotate_skill_affinity.py
@@ -68,6 +68,9 @@ SKILL_DEFAULTS: Dict[str, ExecAffinity] = {
     # Scripting: arbitrary user code — sync + main by default; caller chooses
     # async if they know the script is long-running.
     "maya-scripting": ("sync", "main", None),
+    # Procedural rig workflow: most ops are fast scene authoring; the
+    # keyframe / playblast / export verbs are long-running (see overrides).
+    "maya-procedural-rig": ("sync", "main", None),
     # Pure filesystem readers: worker-thread safe
     "maya-dev": ("sync", "main", None),
     "maya-pipeline": ("sync", "main", None),
@@ -205,6 +208,10 @@ TOOL_OVERRIDES: Dict[Tuple[str, str], ExecAffinity] = {
     ("maya-scripting", "introspect_search"): ("sync", "any", None),
     # introspect_eval touches DAG via expression, must stay main-thread
     ("maya-scripting", "introspect_eval"): ("sync", "main", None),
+    # maya-procedural-rig long-running verbs (frame loops, render, file I/O)
+    ("maya-procedural-rig", "keyframe_orbit_animation"): ("async", "main", 120),
+    ("maya-procedural-rig", "create_playblast"): ("async", "main", 600),
+    ("maya-procedural-rig", "export_scene_artifact"): ("async", "main", 300),
 }
 
 


### PR DESCRIPTION
## Summary

Closes #306. Adds a new pipeline-stage skill `maya-procedural-rig` that exposes
a typed, schema-validated procedural workflow as seven composable tools instead
of one large `execute_python` script:

1. `create_sphere_layout` — distribute spheres (sphere / grid / line)
2. `assign_palette_materials` — one Lambert per object from a palette
3. `create_rig_joints` — root + per-object child joints
4. `bind_objects_to_joints` — constraint / parent binding
5. `keyframe_orbit_animation` — orbit / bounce / spin keyframes
6. `create_playblast` — viewport preview to disk
7. `export_scene_artifact` — export scene/selection (ma/mb/obj/fbx)

Each stage returns a structured envelope whose `prompt` points at the next
stage, so the chain is discoverable from any entry point.

## Notes

- All tools declare `affinity: main`; long-running ones declare `async` +
  `timeout_hint_secs`.
- Scripts degrade to a structured `maya_error` (never an unhandled exception)
  when `maya.cmds` is unavailable.
- `SKILLS_INDEX.md` updated (count 25 → 26, pipeline row + task chain).

## Test plan

- [x] `pytest tests/test_procedural_rig_skill.py` (14 passed, dependency-free)
- [x] `pytest tests/test_skill_taxonomy.py tests/test_lint_skills.py` (61 passed)
- [x] `python tools/lint_skills.py --skills-root src/dcc_mcp_maya/skills` (0 errors)
