### PR TITLE
chore(skills): enrich recall metadata for bundled Maya skills (#308)

### DIFF
--- a/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-animation/SKILL.md
@@ -22,7 +22,8 @@ metadata:
     - bake
     search-hint: |-
       animate motion, keyframe, set key, timeline range, animation curve,
-      curve tangent, bake constraint, bake simulation, anim file import export
+      curve tangent, bake constraint, bake simulation, anim file import export,
+      animate a rig, make an animated rig, animate joints, motion for playblast
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-primitives/SKILL.md
@@ -24,7 +24,8 @@ metadata:
     search-hint: |-
       create sphere cube cylinder plane, set transform, get transform, rename,
       delete object, primitive geometry, basic shape, polySphere polyCube,
-      batch primitives, random transforms, many cubes procedural
+      batch primitives, random transforms, many cubes procedural,
+      populate a scene with shapes, build a scene, create geometry to animate
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-render/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-render/SKILL.md
@@ -24,7 +24,9 @@ metadata:
     - viewport
     search-hint: |-
       final output, preview render, playblast, viewport capture, render globals,
-      set render settings, image format, frame range render
+      set render settings, image format, frame range render, make a playblast,
+      playblast the animation, preview movie, turntable, capture animation,
+      record viewport, animated rig playblast, review video
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/src/dcc_mcp_maya/skills/maya-rigging/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-rigging/SKILL.md
@@ -27,7 +27,8 @@ metadata:
     search-hint: |-
       build character rig, skeleton setup, IK chain, rig control, constraint,
       skin bind, skin weight copy, blendshape, control curve, mgear,
-      advanced skeleton, deformer, joint hierarchy, weight paint
+      advanced skeleton, deformer, joint hierarchy, weight paint,
+      animated rig, rig for animation, make a rig, set up joints to animate
     tools: tools.yaml
     groups: groups.yaml
 ---

--- a/tests/test_skill_recall_metadata.py
+++ b/tests/test_skill_recall_metadata.py
@@ -87,11 +87,7 @@ def test_every_skill_declares_layer_and_stage() -> None:
 
 
 def test_arbitrary_execution_tools_live_in_thin_harness_bootstrap() -> None:
-    owners = {
-        skill
-        for skill, tool in _bundled_tools()
-        if tool.get("name") in {"execute_python", "execute_mel"}
-    }
+    owners = {skill for skill, tool in _bundled_tools() if tool.get("name") in {"execute_python", "execute_mel"}}
     assert owners, "execute_python / execute_mel must exist as the escape hatch"
     for owner in owners:
         meta = _frontmatter(SKILLS_DIR / owner)

--- a/tests/test_skill_recall_metadata.py
+++ b/tests/test_skill_recall_metadata.py
@@ -1,0 +1,146 @@
+"""Recall-metadata regression tests for bundled Maya skills (issue #308).
+
+These pin the structured metadata the gateway / core retrieval layer relies on
+to pick the right skill *without* depending only on generated script names:
+
+1. Every bundled skill declares both an intent ``layer`` and a workflow
+   ``stage`` in its ``SKILL.md`` frontmatter.
+2. The arbitrary-execution escape hatch (``execute_python`` / ``execute_mel``)
+   lives in a ``thin-harness`` / ``bootstrap`` skill so core's layer ranking
+   keeps it *below* typed domain skills for normal workflows.
+3. Common natural-language queries resolve to the right typed skill through
+   ``search-hint`` aliases + ``tags`` (not just exact tool names).
+4. Destructive tools carry a ``destructive_hint`` side-effect annotation.
+
+All checks read the bundled files directly and need no running Maya.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, List, Set
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "src" / "dcc_mcp_maya" / "skills"
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+
+
+def _skill_dirs() -> List[Path]:
+    return sorted(p.parent for p in SKILLS_DIR.glob("*/SKILL.md"))
+
+
+def _frontmatter(skill_dir: Path) -> Dict:
+    text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    match = _FRONTMATTER_RE.match(text)
+    assert match, "{} missing frontmatter".format(skill_dir)
+    data = yaml.safe_load(match.group(1)) or {}
+    return data.get("metadata", {}).get("dcc-mcp", {})
+
+
+def _searchable_text(skill_dir: Path) -> str:
+    meta = _frontmatter(skill_dir)
+    parts = [skill_dir.name]
+    parts.extend(str(t) for t in meta.get("tags", []) or [])
+    parts.append(str(meta.get("search-hint", "")))
+    return " ".join(parts).lower()
+
+
+def _skills_matching(tokens: List[str], exclude_bootstrap: bool = True) -> Set[str]:
+    """Return skills whose searchable text contains *all* tokens."""
+    out: Set[str] = set()
+    for skill_dir in _skill_dirs():
+        meta = _frontmatter(skill_dir)
+        if exclude_bootstrap and meta.get("stage") == "bootstrap":
+            continue
+        text = _searchable_text(skill_dir)
+        if all(tok in text for tok in tokens):
+            out.add(skill_dir.name)
+    return out
+
+
+def _bundled_tools():
+    for tools_yaml in sorted(SKILLS_DIR.glob("*/tools.yaml")):
+        data = yaml.safe_load(tools_yaml.read_text(encoding="utf-8")) or {}
+        for tool in data.get("tools", []):
+            yield tools_yaml.parent.name, tool
+
+
+# ---------------------------------------------------------------------------
+# Intent + stage metadata completeness
+# ---------------------------------------------------------------------------
+
+
+def test_every_skill_declares_layer_and_stage() -> None:
+    for skill_dir in _skill_dirs():
+        meta = _frontmatter(skill_dir)
+        assert meta.get("layer"), "{} missing metadata.dcc-mcp.layer".format(skill_dir.name)
+        assert meta.get("stage"), "{} missing metadata.dcc-mcp.stage".format(skill_dir.name)
+
+
+# ---------------------------------------------------------------------------
+# Escape-hatch ranking (acceptance: execute-python ranks after typed skills)
+# ---------------------------------------------------------------------------
+
+
+def test_arbitrary_execution_tools_live_in_thin_harness_bootstrap() -> None:
+    owners = {
+        skill
+        for skill, tool in _bundled_tools()
+        if tool.get("name") in {"execute_python", "execute_mel"}
+    }
+    assert owners, "execute_python / execute_mel must exist as the escape hatch"
+    for owner in owners:
+        meta = _frontmatter(SKILLS_DIR / owner)
+        assert meta.get("layer") == "thin-harness", (
+            "{} owns execute_python/mel but is not layer 'thin-harness' — core "
+            "ranking would let the escape hatch outrank typed skills".format(owner)
+        )
+        assert meta.get("stage") == "bootstrap", owner
+
+
+# ---------------------------------------------------------------------------
+# Natural-language recall via search-hint aliases + tags
+# ---------------------------------------------------------------------------
+
+
+def test_recall_phrases_resolve_to_typed_skills() -> None:
+    # "make an animated rig and playblast"
+    assert "maya-render" in _skills_matching(["rig", "playblast"])
+    assert "maya-render" in _skills_matching(["playblast"])
+    assert _skills_matching(["animat", "rig"])  # animation/animated + rig
+
+    # "export geometry to FBX"
+    assert "maya-geometry" in _skills_matching(["export", "fbx"])
+
+    # "create some spheres"
+    assert "maya-primitives" in _skills_matching(["create", "sphere"])
+
+    # "build a character rig"
+    assert "maya-rigging" in _skills_matching(["character", "rig"])
+
+
+def test_recall_phrases_do_not_collapse_to_bootstrap_only() -> None:
+    """No priority phrase should be served *only* by the escape hatch."""
+    for tokens in (["rig", "playblast"], ["export", "fbx"], ["create", "sphere"]):
+        typed = _skills_matching(tokens, exclude_bootstrap=True)
+        assert typed, "phrase {} has no typed skill match".format(tokens)
+
+
+# ---------------------------------------------------------------------------
+# Side-effect signalling
+# ---------------------------------------------------------------------------
+
+
+def test_destructive_tools_declare_destructive_hint() -> None:
+    offenders = []
+    for skill, tool in _bundled_tools():
+        name = str(tool.get("name", ""))
+        if name.startswith("delete"):
+            annotations = tool.get("annotations") or {}
+            if not annotations.get("destructive_hint"):
+                offenders.append("{}:{}".format(skill, name))
+    assert offenders == [], "destructive tools missing destructive_hint: {}".format(offenders)


### PR DESCRIPTION
## Summary

Closes #308. Strengthens the structured recall metadata the gateway / core
retrieval layer uses to pick the right Maya skill without relying only on tool
names or generated scripts.

- Enriches `search-hint` aliases on priority skill families (`maya-render`,
  `maya-rigging`, `maya-animation`, `maya-primitives`) with common
  natural-language phrasings ("make a playblast", "animated rig",
  "populate a scene with shapes", "preview movie", "turntable", …).
- Adds `tests/test_skill_recall_metadata.py` pinning the recall invariants:
  - every bundled skill declares both `layer` (intent) and `stage` (workflow);
  - the `execute_python` / `execute_mel` escape hatch stays in a
    `thin-harness` / `bootstrap` skill so core ranking keeps it **below**
    typed domain skills for normal workflows;
  - priority phrases ("animated rig + playblast", "export fbx",
    "create sphere", "character rig") resolve to typed skills via aliases;
  - destructive tools carry a `destructive_hint` side-effect annotation.

## Notes

- No unknown `metadata.dcc-mcp.*` keys are introduced — only the gateway/core
  accepted `search-hint` / `tags` / `layer` / `stage` fields are used, so
  existing skill loading and validation are unaffected.
- USD interchange and the Qt UI inspector recall paths are tracked separately
  (the latter is delivered programmatically via #307); this PR scopes to the
  bundled SKILL.md families that own real typed tools.

## Test plan

- [x] `pytest tests/test_skill_recall_metadata.py` (5 passed)
- [x] `pytest tests/test_skill_taxonomy.py tests/test_lint_skills.py` (61 passed)
- [x] `python tools/lint_skills.py --skills-root src/dcc_mcp_maya/skills` (0 errors)
