### PR TITLE
perf(maya-scene): reduce get_scene_info polling cost

### DIFF
--- a/docs/api/scene.md
+++ b/docs/api/scene.md
@@ -26,16 +26,31 @@ Return high-level Maya session information.
 
 Return a hierarchical DAG description of the scene.
 
+### Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `detail_mode` | enum string | `"full"` | Payload/cost profile: `lightweight`, `standard`, or `full`. `lightweight` omits `node_ref` and transforms for frequent polling; `standard` includes `node_ref`; `full` preserves the historical transform-rich payload. |
+| `include_transforms` | bool | `true` | Include translate/rotate/scale fields in `full` mode. |
+
 ### Return Value
 
 ```typescript
 {
-  name: string
-  children: Array<{
+  nodes: Array<{
     name: string
-    type: string        // Maya node type
-    children: Array<...>
+    long_name: string
+    object_type: string | null
+    parent: string | null
+    visible: boolean
+    children: string[]
+    node_ref?: object
+    translate?: number[]
+    rotate?: number[]
+    scale?: number[]
   }>
+  count: number
+  detail_mode: "lightweight" | "standard" | "full"
 }
 ```
 

--- a/docs/guide/scene.md
+++ b/docs/guide/scene.md
@@ -28,25 +28,25 @@ Get the full DAG hierarchy as a nested structure:
 
 **Tool:** `maya_scene__get_scene_info`
 
+For frequent polling in medium or large scenes, pass
+`{"detail_mode": "lightweight"}`. It returns the DAG skeleton without per-node
+`node_ref` or transform fields. Use `detail_mode="standard"` when stable node
+references are required, and `detail_mode="full"` for the historical
+transform-rich payload.
+
 ```json
 {
-  "name": "root",
-  "children": [
+  "nodes": [
     {
       "name": "pSphere1",
-      "type": "transform",
-      "children": [
-        { "name": "pSphereShape1", "type": "mesh" }
-      ]
-    },
-    {
-      "name": "directionalLight1",
-      "type": "transform",
-      "children": [
-        { "name": "directionalLightShape1", "type": "directionalLight" }
-      ]
+      "long_name": "|pSphere1",
+      "object_type": "transform",
+      "parent": null,
+      "children": ["|pSphere1|pSphereShape1"]
     }
-  ]
+  ],
+  "count": 1,
+  "detail_mode": "lightweight"
 }
 ```
 

--- a/src/dcc_mcp_maya/api.py
+++ b/src/dcc_mcp_maya/api.py
@@ -887,7 +887,17 @@ def _current_scene_path(cmds: Any) -> Optional[str]:
     return str(path) if path else None
 
 
-def node_ref_from_name(cmds: Any, node_name: str) -> Dict[str, Any]:
+_UNSET = object()
+
+
+def node_ref_from_name(
+    cmds: Any,
+    node_name: str,
+    *,
+    scene_path: Any = _UNSET,
+    node_type: Optional[str] = None,
+    exists: Optional[bool] = None,
+) -> Dict[str, Any]:
     """Build a stable JSON NodeRef for a Maya node.
 
     The payload is intentionally plain JSON and PyMEL-free.  UUID is preferred
@@ -898,18 +908,19 @@ def node_ref_from_name(cmds: Any, node_name: str) -> Dict[str, Any]:
     long_name = node_long_name(cmds, node_name)
     short_name = long_name.rsplit("|", 1)[-1] if "|" in long_name else str(node_name)
     uuid_value = node_uuid(cmds, long_name)
-    exists = _node_exists(cmds, long_name)
-    node_type = _node_type(cmds, long_name)
+    node_exists = _node_exists(cmds, long_name) if exists is None else bool(exists)
+    resolved_scene_path = _current_scene_path(cmds) if scene_path is _UNSET else scene_path
+    resolved_node_type = _node_type(cmds, long_name) if node_type is None else node_type
     return {
         "kind": "maya_node",
         "id": uuid_value or long_name,
         "uuid": uuid_value,
         "long_name": long_name,
         "short_name": short_name,
-        "type": node_type,
-        "exists": exists,
-        "stale": not exists,
-        "metadata": build_context_dict(scene_path=_current_scene_path(cmds)),
+        "type": resolved_node_type,
+        "exists": node_exists,
+        "stale": not node_exists,
+        "metadata": build_context_dict(scene_path=resolved_scene_path),
     }
 
 

--- a/src/dcc_mcp_maya/skills/maya-scene/scripts/get_scene_info.py
+++ b/src/dcc_mcp_maya/skills/maya-scene/scripts/get_scene_info.py
@@ -6,10 +6,53 @@ from __future__ import annotations
 # Import local modules
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
-from dcc_mcp_maya.api import node_ref_from_name, object_transform_from_node, scene_object_from_node
+from dcc_mcp_maya.api import node_ref_from_name, object_transform_from_node
+
+_DETAIL_MODES = ("lightweight", "standard", "full")
 
 
-def get_scene_info(include_transforms: bool = True) -> dict:
+def _short_name(long_name: str) -> str:
+    return long_name.rsplit("|", 1)[-1] if "|" in long_name else long_name
+
+
+def _safe_parent(cmds, node_name: str):
+    try:
+        parents = cmds.listRelatives(node_name, parent=True, fullPath=True) or []
+    except Exception:
+        return None
+    return parents[0] if parents else None
+
+
+def _safe_children(cmds, node_name: str):
+    try:
+        return cmds.listRelatives(node_name, children=True, fullPath=True) or []
+    except Exception:
+        return []
+
+
+def _safe_visible(cmds, node_name: str) -> bool:
+    try:
+        return bool(cmds.getAttr(node_name + ".visibility"))
+    except Exception:
+        return True
+
+
+def _safe_object_type(cmds, node_name: str):
+    try:
+        return cmds.objectType(node_name)
+    except Exception:
+        return None
+
+
+def _current_scene_path(cmds):
+    try:
+        scene_path = cmds.file(query=True, sceneName=True)
+    except Exception:
+        return None
+    return scene_path or None
+
+
+def get_scene_info(include_transforms: bool = True, detail_mode: str = "full") -> dict:
     """Return a hierarchical DAG description of the current scene.
 
     For each DAG transform node the result includes the node's name, type,
@@ -25,6 +68,10 @@ def get_scene_info(include_transforms: bool = True) -> dict:
         include_transforms: If True (default), each node entry also carries its
             world-space translate/rotate/scale values via ``ObjectTransform``
             schema.
+        detail_mode: Payload/cost profile. ``lightweight`` returns only the DAG
+            skeleton and basic node fields, ``standard`` also includes
+            ``node_ref``, and ``full`` keeps the historical payload including
+            transforms unless ``include_transforms`` is False.
 
     Returns:
         ToolResult dict with ``context.nodes`` (list of dicts) and
@@ -33,13 +80,35 @@ def get_scene_info(include_transforms: bool = True) -> dict:
     try:
         import maya.cmds as cmds  # noqa: PLC0415
 
+        if detail_mode not in _DETAIL_MODES:
+            return skill_error(
+                "Invalid detail_mode",
+                "detail_mode must be one of: {}".format(", ".join(_DETAIL_MODES)),
+            )
+
         transforms = cmds.ls(type="transform", long=True) or []
+        scene_path = _current_scene_path(cmds) if detail_mode in ("standard", "full") else None
         nodes = []
         for long_name in transforms:
-            node = scene_object_from_node(cmds, long_name)
-            node["node_ref"] = node_ref_from_name(cmds, long_name)
-            node["children"] = cmds.listRelatives(long_name, children=True, fullPath=True) or []
-            if include_transforms:
+            object_type = _safe_object_type(cmds, long_name)
+            node = {
+                "name": _short_name(long_name),
+                "long_name": long_name,
+                "object_type": object_type,
+                "parent": _safe_parent(cmds, long_name),
+                "visible": _safe_visible(cmds, long_name),
+                "metadata": {},
+                "children": _safe_children(cmds, long_name),
+            }
+            if detail_mode in ("standard", "full"):
+                node["node_ref"] = node_ref_from_name(
+                    cmds,
+                    long_name,
+                    scene_path=scene_path,
+                    node_type=object_type,
+                    exists=True,
+                )
+            if detail_mode == "full" and include_transforms:
                 try:
                     xform = object_transform_from_node(cmds, long_name)
                     node["translate"] = xform["translate"]
@@ -53,6 +122,7 @@ def get_scene_info(include_transforms: bool = True) -> dict:
             "Scene info: {} transform node(s)".format(len(nodes)),
             nodes=nodes,
             count=len(nodes),
+            detail_mode=detail_mode,
             prompt="Use set_transform or assign_material to modify listed objects.",
         )
     except ImportError:

--- a/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
@@ -77,13 +77,31 @@ tools:
   group: scene-management
   description: Get an object bounding box without modifying the Maya scene.
 - name: get_scene_info
-  description: Return a hierarchical DAG description of the current scene
+  description: Return a hierarchical DAG description of the current scene. Use
+    detail_mode=lightweight for high-frequency polling, standard when stable
+    node refs are needed, and full for the historical transform-rich payload.
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: core
+  input_schema:
+    type: object
+    properties:
+      include_transforms:
+        type: boolean
+        default: true
+        description: Include translate/rotate/scale fields in full detail mode.
+      detail_mode:
+        type: string
+        enum:
+        - lightweight
+        - standard
+        - full
+        default: full
+        description: Payload/cost profile. lightweight omits node_ref and transform
+          fields; standard includes node_ref; full preserves the historical payload.
 - name: find_by_pattern
   description: Find nodes by Maya wildcard pattern, defaulting to transform nodes
     so object searches exclude shapes and animation curves.

--- a/tests/test_maya_scene_skill.py
+++ b/tests/test_maya_scene_skill.py
@@ -86,6 +86,59 @@ def test_get_scene_info_includes_node_refs():
     assert node["node_ref"]["metadata"]["scene_path"] == "C:/show/scene.ma"
 
 
+def test_get_scene_info_reads_scene_path_once_for_many_node_refs():
+    cmds = MagicMock()
+
+    def _ls(*args, **kwargs):
+        if kwargs.get("type") == "transform" and kwargs.get("long"):
+            return ["|pCube1", "|pCube2", "|pCube3"]
+        if kwargs.get("uuid"):
+            return ["uuid-" + str(args[0]).rsplit("|", 1)[-1]]
+        if kwargs.get("long"):
+            return [str(args[0])]
+        return [str(args[0])] if args else []
+
+    cmds.ls.side_effect = _ls
+    cmds.nodeType.return_value = "transform"
+    cmds.objectType.return_value = "transform"
+    cmds.objExists.return_value = True
+    cmds.file.return_value = "C:/show/scene.ma"
+    cmds.getAttr.return_value = True
+    cmds.listRelatives.return_value = []
+
+    result = load_and_call("maya-scene/scripts/get_scene_info.py", cmds, "main", detail_mode="standard")
+
+    assert result["success"] is True
+    assert result["context"]["count"] == 3
+    cmds.file.assert_called_once_with(query=True, sceneName=True)
+
+
+def test_get_scene_info_lightweight_omits_node_refs_and_transforms():
+    cmds = MagicMock()
+    cmds.ls.return_value = ["|pCube1"]
+    cmds.objectType.return_value = "transform"
+    cmds.getAttr.return_value = True
+    cmds.listRelatives.return_value = []
+
+    result = load_and_call("maya-scene/scripts/get_scene_info.py", cmds, "main", detail_mode="lightweight")
+
+    assert result["success"] is True
+    node = result["context"]["nodes"][0]
+    assert result["context"]["detail_mode"] == "lightweight"
+    assert "node_ref" not in node
+    assert "translate" not in node
+    cmds.file.assert_not_called()
+
+
+def test_get_scene_info_rejects_invalid_detail_mode():
+    cmds = MagicMock()
+
+    result = load_and_call("maya-scene/scripts/get_scene_info.py", cmds, "main", detail_mode="verbose")
+
+    assert result["success"] is False
+    assert "detail_mode" in result["message"]
+
+
 def test_create_camera_sets_transform_shape_attrs_and_optional_aim():
     cmds = MagicMock()
     cmds.camera.return_value = ["camera1", "cameraShape1"]

--- a/tools/benchmark_get_scene_info.py
+++ b/tools/benchmark_get_scene_info.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _percentile(sorted_values: Sequence[float], q: float) -> float:
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return float(sorted_values[0])
+    idx = (len(sorted_values) - 1) * q
+    lo = int(idx)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = idx - lo
+    return float(sorted_values[lo] * (1.0 - frac) + sorted_values[hi] * frac)
+
+
+def _summary(values_ms: Sequence[float]) -> Dict[str, float]:
+    if not values_ms:
+        return {"avg_ms": 0.0, "p50_ms": 0.0, "p95_ms": 0.0, "p99_ms": 0.0, "max_ms": 0.0}
+    ordered = sorted(values_ms)
+    return {
+        "avg_ms": float(statistics.fmean(values_ms)),
+        "p50_ms": _percentile(ordered, 0.50),
+        "p95_ms": _percentile(ordered, 0.95),
+        "p99_ms": _percentile(ordered, 0.99),
+        "max_ms": float(ordered[-1]),
+    }
+
+
+@dataclass
+class GatewayClient:
+    base_url: str
+    timeout_secs: int = 120
+
+    def _post(self, route: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        url = self.base_url.rstrip("/") + route
+        raw = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=raw,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout_secs) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            payload = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"HTTP {exc.code} {url}: {payload[:500]}") from exc
+
+    def search(self, query: str, *, loaded_only: bool = False, limit: int = 25) -> Dict[str, Any]:
+        return self._post("/v1/search", {"query": query, "loaded_only": loaded_only, "limit": limit})
+
+    def describe(self, tool_slug: str) -> Dict[str, Any]:
+        return self._post("/v1/describe", {"tool_slug": tool_slug, "include_schema": True})
+
+    def call(self, tool_slug: str, arguments: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        return self._post("/v1/call", {"tool_slug": tool_slug, "arguments": arguments or {}})
+
+
+def _slug(hit: Dict[str, Any]) -> str:
+    return str(hit.get("tool_slug") or hit.get("slug") or hit.get("name") or "")
+
+
+def _action(hit: Dict[str, Any]) -> str:
+    return str(hit.get("backend_tool") or hit.get("action") or hit.get("name") or "")
+
+
+def _resolve_action(client: GatewayClient, action_name: str) -> str:
+    result = client.search(action_name, loaded_only=False, limit=20)
+    for hit in result.get("hits") or []:
+        if _action(hit) == action_name:
+            slug = _slug(hit)
+            if slug:
+                client.describe(slug)
+                return slug
+    for hit in result.get("hits") or []:
+        slug = _slug(hit)
+        if action_name in slug:
+            client.describe(slug)
+            return slug
+    raise RuntimeError(f"Could not resolve action {action_name!r}: {result!r}")
+
+
+def _ensure_success(resp: Dict[str, Any], op: str) -> Dict[str, Any]:
+    output = resp.get("output")
+    if isinstance(output, dict) and output.get("success") is True:
+        return output
+    raise RuntimeError(f"{op} failed: {json.dumps(resp, ensure_ascii=False)[:1000]}")
+
+
+def _load_skill(client: GatewayClient, skill_name: str) -> None:
+    load_skill = _resolve_action(client, "load_skill")
+    _ensure_success(client.call(load_skill, {"skill_name": skill_name}), f"load_skill({skill_name})")
+
+
+def _prepare_scene(client: GatewayClient, object_count: int) -> None:
+    _load_skill(client, "maya-scene")
+    _load_skill(client, "maya-primitives")
+    new_scene = _resolve_action(client, "maya_scene__new_scene")
+    create_sphere = _resolve_action(client, "maya_primitives__create_sphere")
+    set_transform = _resolve_action(client, "maya_primitives__set_transform")
+    _ensure_success(client.call(new_scene, {"force": True}), "new_scene")
+    for idx in range(object_count):
+        name = f"scene_info_bench_{idx + 1:03d}"
+        _ensure_success(client.call(create_sphere, {"radius": 0.25, "name": name}), "create_sphere")
+        _ensure_success(
+            client.call(
+                set_transform,
+                {"object_name": name, "translate": [float(idx % 15) * 2.0, float(idx // 15), 0.0]},
+            ),
+            "set_transform",
+        )
+
+
+def _measure_mode(client: GatewayClient, tool_slug: str, mode: str, iterations: int) -> Dict[str, Any]:
+    latencies: List[float] = []
+    payload_sizes: List[int] = []
+    failures: List[str] = []
+    args = {"detail_mode": mode}
+    for _ in range(iterations):
+        started = time.perf_counter()
+        try:
+            resp = client.call(tool_slug, args)
+            payload_sizes.append(len(json.dumps(resp, ensure_ascii=False).encode("utf-8")))
+            _ensure_success(resp, f"get_scene_info({mode})")
+        except Exception as exc:  # noqa: BLE001
+            failures.append(str(exc))
+        finally:
+            latencies.append((time.perf_counter() - started) * 1000.0)
+    summary = _summary(latencies)
+    summary.update(
+        {
+            "iterations": iterations,
+            "payload_bytes_avg": int(statistics.fmean(payload_sizes)) if payload_sizes else 0,
+            "payload_bytes_max": max(payload_sizes) if payload_sizes else 0,
+            "failure_count": len(failures),
+            "failures": failures[:10],
+        }
+    )
+    return summary
+
+
+def _base_url(cli_value: Optional[str]) -> str:
+    if cli_value:
+        return cli_value.rstrip("/")
+    return os.environ.get("DCC_MCP_GATEWAY_BASE_URL", "http://127.0.0.1:9765").rstrip("/")
+
+
+def run(args: argparse.Namespace) -> Dict[str, Any]:
+    client = GatewayClient(_base_url(args.base_url), timeout_secs=args.timeout_secs)
+    if args.prepare_scene:
+        _prepare_scene(client, args.object_count)
+    _load_skill(client, "maya-scene")
+    get_scene_info = _resolve_action(client, "maya_scene__get_scene_info")
+    modes = ["lightweight", "standard", "full"]
+    return {
+        "issue": "PIP-479",
+        "suite": "benchmark_get_scene_info",
+        "started_at": _utc_now(),
+        "gateway_base_url": client.base_url,
+        "config": {
+            "iterations": args.iterations,
+            "object_count": args.object_count if args.prepare_scene else "existing_scene",
+            "prepared_scene": bool(args.prepare_scene),
+        },
+        "modes": {mode: _measure_mode(client, get_scene_info, mode, args.iterations) for mode in modes},
+        "finished_at": _utc_now(),
+    }
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark maya_scene__get_scene_info detail modes through gateway REST")
+    parser.add_argument("--base-url", default=None, help="Gateway REST base URL")
+    parser.add_argument("--iterations", type=int, default=100, help="Calls per detail mode")
+    parser.add_argument("--object-count", type=int, default=150, help="Object count when --prepare-scene is set")
+    parser.add_argument("--prepare-scene", action="store_true", help="Create a deterministic benchmark scene first")
+    parser.add_argument("--output-dir", default="artifacts/perf", help="Directory for JSON report")
+    parser.add_argument("--report", default="", help="Optional explicit report path")
+    parser.add_argument("--timeout-secs", type=int, default=120, help="HTTP timeout per request")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str]) -> int:
+    args = parse_args(argv)
+    report = run(args)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    report_path = Path(args.report) if args.report else out_dir / ("get_scene_info_benchmark_" + datetime.now().strftime("%Y%m%d_%H%M%S") + ".json")
+    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    print(f"REPORT_PATH={report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

- Adds `detail_mode` to `maya_scene__get_scene_info`: `lightweight`, `standard`, and backward-compatible `full`.
- Avoids per-node `cmds.file()` / duplicate node metadata lookups by allowing `node_ref_from_name` callers to pass cached scene path, node type, and existence state.
- Documents the cheaper polling path and adds `tools/benchmark_get_scene_info.py` to report payload size plus avg/P50/P95/P99/max latency across modes.

## Validation

- `python -m ruff check src\dcc_mcp_maya\api.py src\dcc_mcp_maya\skills\maya-scene\scripts\get_scene_info.py tests\test_maya_scene_skill.py tools\benchmark_get_scene_info.py`
- `python -m pytest tests/test_maya_scene_skill.py tests/test_skills_round39.py::TestGetSceneInfoCrossModel tests/test_api.py::test_node_ref_from_name_returns_plain_json_reference`
- `python -m py_compile tools\benchmark_get_scene_info.py src\dcc_mcp_maya\skills\maya-scene\scripts\get_scene_info.py`

## Notes

Live Maya gateway numbers still need to be captured with `python tools/benchmark_get_scene_info.py --prepare-scene --iterations 100` on a running Maya instance.