### PR TITLE
feat(sidecar): use core launch lifecycle contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Maya plugin starts a Rust `dcc-mcp-server` sidecar by default, so HTTP and g
 [![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-maya?label=Python)](https://pypi.org/project/dcc-mcp-maya/)
 [![Maya](https://img.shields.io/badge/Maya-2020%2B-37A5CC)](https://www.autodesk.com/products/maya/overview)
 [![MCP](https://img.shields.io/badge/MCP-Streamable%20HTTP-6f42c1)](https://modelcontextprotocol.io/)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.36-blue)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.43-blue)](https://github.com/loonghao/dcc-mcp-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ## Why Use It
@@ -175,7 +175,7 @@ mode. On clean machines, install or provide the sidecar runtime before loading
 the plugin:
 
 ```bash
-mayapy -m pip install "dcc-mcp-server>=0.17.36"
+mayapy -m pip install "dcc-mcp-server>=0.17.43"
 mayapy -c "from dcc_mcp_maya.sidecar import resolve_sidecar_binary; print(resolve_sidecar_binary())"
 ```
 
@@ -372,8 +372,8 @@ Windows symlinks require Developer Mode or an elevated shell. If symlinks are un
 
 - Autodesk Maya 2020+
 - Python 3.7+
-- `dcc-mcp-core>=0.17.36,<1.0.0`
-- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.17.36`
+- `dcc-mcp-core>=0.17.43,<1.0.0`
+- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.17.43`
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "pyyaml>=5.0",  # YAML parsing for SKILL.md test validation
 ]
 sidecar = [
-    "dcc-mcp-server>=0.17.36",
+    "dcc-mcp-server>=0.17.43",
 ]
 
 [project.urls]

--- a/src/dcc_mcp_maya/sidecar/__init__.py
+++ b/src/dcc_mcp_maya/sidecar/__init__.py
@@ -24,9 +24,10 @@ The plug-in flow:
 2. The Qt server receives a ``dispatch`` method handler that forwards to
    :mod:`dcc_mcp_maya.sidecar._dispatcher.dispatch_payload` —
    same action-lookup contract as the in-process path.
-3. The supervisor spawns ``dcc-mcp-server sidecar --host-rpc
-   qtserver://127.0.0.1:<port>`` and the sidecar binary connects back
-   to Maya over the JSON-line wire.
+3. The supervisor asks :mod:`dcc_mcp_core.install_lifecycle` for the
+   canonical ``dcc-mcp-server sidecar`` launch contract, spawns that
+   command, and the sidecar binary connects back to Maya over the
+   JSON-line wire.
 
 No ``commandPort`` is opened on the Maya side.
 
@@ -49,7 +50,7 @@ spawns the supervisor automatically unless disabled.
 * :func:`is_sidecar_mode_enabled` — read the env-var gate.
 * :class:`SidecarHandle` — lifetime handle exposing ``proc``,
   ``qt_port``, ``qt_binding``, ``host_rpc_uri``, ``binary_path``,
-  ``maya_pid``.
+  ``maya_pid``, ``command``, and ``launch_contract``.
 * :class:`SidecarSpawnError` — raised on resolver / Qt-start /
   spawn failure.
 * :func:`dispatch_payload` — Maya-side wire-frame handler used by the

--- a/src/dcc_mcp_maya/sidecar/_supervisor.py
+++ b/src/dcc_mcp_maya/sidecar/_supervisor.py
@@ -19,7 +19,8 @@ main thread is idle, and :func:`stop_sidecar` from
    becomes the transport, but the action-lookup contract stays
    identical to the in-process path.
 
-3. Spawns the ``dcc-mcp-server sidecar`` subprocess with
+3. Asks :mod:`dcc_mcp_core.install_lifecycle` for the canonical
+   ``dcc-mcp-server sidecar`` launch contract and spawns it with
    ``--host-rpc qtserver://...`` so the binary connects back to the
    Maya-hosted Qt server. The binary runs alongside Maya, supervised
    by its PPID-watch, and survives non-cooperative Maya shutdowns so
@@ -121,6 +122,8 @@ class SidecarHandle:
     host_rpc_uri: str
     binary_path: Path
     maya_pid: int
+    command: list = field(default_factory=list)
+    launch_contract: dict = field(default_factory=dict)
     extra_env: dict = field(default_factory=dict)
 
     @property
@@ -192,6 +195,19 @@ def resolve_gateway_remote_options(env: Optional[dict] = None) -> tuple[str, int
     if port < 0:
         port = DEFAULT_GATEWAY_REMOTE_PORT
     return host, port
+
+
+def _resolve_gateway_port(env: dict) -> int:
+    """Resolve the local gateway port option passed to core's launch helper."""
+
+    raw = str(env.get("DCC_MCP_GATEWAY_PORT", "9765")).strip()
+    try:
+        port = int(raw)
+    except ValueError:
+        return 9765
+    if port < 0 or port > 65535:
+        return 9765
+    return port
 
 
 def start_sidecar(
@@ -277,42 +293,43 @@ def start_sidecar(
 
     host_rpc_uri = build_qtserver_uri(qt_port, host=qt_host)
 
-    cmd = [
-        str(binary),
-        "sidecar",
-        "--dcc",
-        dcc_name,
-        "--host-rpc",
-        host_rpc_uri,
-        "--watch-pid",
-        str(maya_pid),
-    ]
-    if registry_dir is not None:
-        cmd.extend(["--registry-dir", str(registry_dir)])
-    if instance_id is not None:
-        cmd.extend(["--instance-id", str(instance_id)])
-    if display_name is not None:
-        cmd.extend(["--display-name", display_name])
-    if adapter_version is not None:
-        cmd.extend(["--adapter-version", adapter_version])
-    if gateway_name is not None:
-        cmd.extend(["--gateway-name", gateway_name])
-
     spawn_env = os.environ.copy()
     if extra_env:
         spawn_env.update(extra_env)
 
-    gateway_port_str = str(spawn_env.get("DCC_MCP_GATEWAY_PORT", "9765")).strip()
     try:
-        gateway_port = int(gateway_port_str)
-    except ValueError:
-        gateway_port = 9765
-    if gateway_port > 0:
-        cmd.extend(["--gateway-port", str(gateway_port)])
-    if extra_args:
-        cmd.extend(extra_args)
+        from dcc_mcp_core.install_lifecycle import build_sidecar_command  # noqa: PLC0415
+    except Exception as exc:  # noqa: BLE001
+        _stop_qt_server(stop_qt_server_fn)
+        raise SidecarSpawnError(
+            "dcc_mcp_core.install_lifecycle.build_sidecar_command is unavailable: {0}".format(exc)
+        ) from exc
 
     gateway_remote_host, gateway_remote_port = resolve_gateway_remote_options(spawn_env)
+    launch_contract = build_sidecar_command(
+        dcc_type=dcc_name,
+        host_rpc=host_rpc_uri,
+        watch_pid=maya_pid,
+        registry_dir=registry_dir,
+        server_bin=str(binary),
+        instance_id=instance_id,
+        display_name=display_name,
+        adapter_version=adapter_version,
+        gateway_port=_resolve_gateway_port(spawn_env),
+        gateway_name=gateway_name,
+        gateway_remote_host=gateway_remote_host,
+        gateway_remote_port=gateway_remote_port,
+        extra_args=extra_args,
+        env=spawn_env,
+    )
+    if not launch_contract.get("success"):
+        _stop_qt_server(stop_qt_server_fn)
+        reason = launch_contract.get("reason") or "invalid_sidecar_launch"
+        message = launch_contract.get("message") or "unknown launch-contract failure"
+        raise SidecarSpawnError("failed to build sidecar launch command ({0}): {1}".format(reason, message))
+
+    cmd = list(launch_contract["command"])
+    spawn_env.update(dict(launch_contract.get("environment", {}).get("set", {})))
     spawn_env[ENV_GATEWAY_REMOTE_HOST] = gateway_remote_host
     spawn_env[ENV_GATEWAY_REMOTE_PORT] = str(gateway_remote_port)
 
@@ -344,6 +361,8 @@ def start_sidecar(
         host_rpc_uri=host_rpc_uri,
         binary_path=binary,
         maya_pid=maya_pid,
+        command=cmd,
+        launch_contract=dict(launch_contract),
         extra_env=dict(extra_env or {}),
     )
 

--- a/tests/test_sidecar_supervisor.py
+++ b/tests/test_sidecar_supervisor.py
@@ -16,6 +16,11 @@ class _FakeProc:
         return None
 
 
+def _flag_value(cmd, flag):
+    index = cmd.index(flag)
+    return cmd[index + 1]
+
+
 def test_start_sidecar_forwards_identity_flags(monkeypatch):
     captured = {}
 
@@ -43,26 +48,25 @@ def test_start_sidecar_forwards_identity_flags(monkeypatch):
     )
 
     assert handle.host_rpc_uri == "qtserver://127.0.0.1:45555"
-    assert captured["cmd"] == [
-        "dcc-mcp-server",
-        "sidecar",
-        "--dcc",
-        "maya",
-        "--host-rpc",
-        "qtserver://127.0.0.1:45555",
-        "--watch-pid",
-        "1234",
-        "--instance-id",
-        "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
-        "--display-name",
-        "Maya 2025 pid 1234",
-        "--adapter-version",
-        "0.0.0-test",
-        "--gateway-name",
-        "dcc-mcp-gateway@workstation-01",
-        "--gateway-port",
-        "9765",
-    ]
+    assert captured["cmd"] == handle.command
+    assert captured["cmd"][:2] == ["dcc-mcp-server", "sidecar"]
+    assert _flag_value(captured["cmd"], "--dcc") == "maya"
+    assert _flag_value(captured["cmd"], "--host-rpc") == "qtserver://127.0.0.1:45555"
+    assert _flag_value(captured["cmd"], "--watch-pid") == "1234"
+    assert _flag_value(captured["cmd"], "--instance-id") == "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+    assert _flag_value(captured["cmd"], "--display-name") == "Maya 2025 pid 1234"
+    assert _flag_value(captured["cmd"], "--adapter-version") == "0.0.0-test"
+    assert _flag_value(captured["cmd"], "--gateway-name") == "dcc-mcp-gateway@workstation-01"
+    assert _flag_value(captured["cmd"], "--gateway-port") == "9765"
+    assert _flag_value(captured["cmd"], "--gateway-remote-host") == "0.0.0.0"
+    assert _flag_value(captured["cmd"], "--gateway-remote-port") == "59765"
+    assert _flag_value(captured["cmd"], "--registry-dir")
+    assert captured["kwargs"]["env"]["DCC_MCP_REGISTRY_DIR"] == _flag_value(captured["cmd"], "--registry-dir")
+    assert captured["kwargs"]["env"]["DCC_MCP_GATEWAY_PORT"] == "9765"
+    assert captured["kwargs"]["env"]["DCC_MCP_GATEWAY_REMOTE_HOST"] == "0.0.0.0"
+    assert captured["kwargs"]["env"]["DCC_MCP_GATEWAY_REMOTE_PORT"] == "59765"
+    assert handle.launch_contract["role"] == "per-dcc-sidecar"
+    assert handle.launch_contract["recommended_next_action"]
 
 
 def test_start_sidecar_honors_extra_env_gateway_port_zero(monkeypatch):
@@ -88,7 +92,7 @@ def test_start_sidecar_honors_extra_env_gateway_port_zero(monkeypatch):
         extra_env={"DCC_MCP_GATEWAY_PORT": "0"},
     )
 
-    assert "--gateway-port" not in captured["cmd"]
+    assert _flag_value(captured["cmd"], "--gateway-port") == "0"
     assert captured["kwargs"]["env"]["DCC_MCP_GATEWAY_PORT"] == "0"
 
 


### PR DESCRIPTION
## Summary
- build Maya sidecar argv/env through dcc_mcp_core.install_lifecycle
- keep Qt dispatcher supervision in the plugin while exposing the launch contract on SidecarHandle
- align sidecar runtime docs and optional dependency floor with the current core contract

## Validation
- vx uv run --extra dev pytest tests/test_sidecar_supervisor.py tests/test_plugin_env_vars.py -q
- vx uv run --extra dev ruff check src/dcc_mcp_maya/sidecar/_supervisor.py src/dcc_mcp_maya/sidecar/__init__.py tests/test_sidecar_supervisor.py
- vx git diff --check