### PR TITLE
feat(maya-render): add debug capture workflows

### DIFF
--- a/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
@@ -49,7 +49,7 @@ Full rationale: repo root `AGENTS.md` § *Bulk import, export, and naming*; exam
 | Publish an asset version | `maya-pipeline` (uses `maya-geometry` under the hood; declared in `depends`) |
 | Bake AO maps from high-res to low-res | `maya-uv-ops` → `maya-texture-bake` |
 | Create a three-point light rig and tweak intensity | `maya-light-rig` |
-| Render an image, snapshot the viewport, or write a playblast sequence | `maya-render` (`render_frame`, `playblast`, `capture_viewport`, `capture_playblast_sequence`) |
+| Render an image, snapshot the viewport, write an MP4 preview, or collect debug evidence | `maya-render` (`render_frame`, `playblast`, `capture_viewport`, `capture_playblast_sequence`, `playblast_to_mp4`, `debug_scene_snapshot`) |
 | Develop and debug a Maya Python tool inside the live session | `maya-dev` (`attach_project` → `run_check`; optional `start_debugpy`) |
 
 ## Side-Effect Taxonomy

--- a/src/dcc_mcp_maya/skills/maya-render/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-render/SKILL.md
@@ -46,6 +46,8 @@ packaging belongs to `maya-shot-export`. For distributed rendering, see
 - `playblast` — Capture a single viewport frame as a base64-encoded PNG
 - `render_frame` — Render a single frame to disk without using model panels or playblast
 - `capture_playblast_sequence` — Capture a playblast image sequence to disk
+- `playblast_to_mp4` — Capture a viewport animation preview and encode it to MP4 with ffmpeg
+- `debug_scene_snapshot` — Collect scene structure plus optional render preview and UI screenshot
 - `get_viewport_camera` — Query the active model panel camera
 
 ## Examples
@@ -60,4 +62,16 @@ Render through a named camera to a deterministic output prefix:
 
 ```json
 {"tool": "maya_render__render_frame", "arguments": {"camera": "shotCam", "output_dir": "C:/renders/shot01", "output_name": "shot01_beauty", "return_base64": false}}
+```
+
+Capture an MP4 viewport preview:
+
+```json
+{"tool": "maya_render__playblast_to_mp4", "arguments": {"start_frame": 1, "end_frame": 48, "fps": 24, "width": 1280, "height": 720}}
+```
+
+Collect debug evidence for an agent:
+
+```json
+{"tool": "maya_render__debug_scene_snapshot", "arguments": {"max_nodes": 40, "preview_width": 640, "preview_height": 480, "include_ui": true}}
 ```

--- a/src/dcc_mcp_maya/skills/maya-render/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render/groups.yaml
@@ -5,10 +5,12 @@ groups:
   tools:
   - capture_playblast_sequence
   - capture_viewport
+  - debug_scene_snapshot
   - get_render_settings
   - get_scene_render_stats
   - get_viewport_camera
   - playblast
+  - playblast_to_mp4
   - render_frame
   - set_render_quality
   - set_render_settings

--- a/src/dcc_mcp_maya/skills/maya-render/scripts/capture_playblast_sequence.py
+++ b/src/dcc_mcp_maya/skills/maya-render/scripts/capture_playblast_sequence.py
@@ -79,6 +79,24 @@ def _camera_from_panel(cmds: Any, panel: Optional[str]) -> Optional[str]:
         return None
 
 
+def _viewport_renderer(cmds: Any, panel: Optional[str]) -> Optional[str]:
+    if not panel:
+        return None
+    try:
+        return str(cmds.modelEditor(panel, query=True, rendererName=True))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _visible_model_panels(cmds: Any) -> List[str]:
+    try:
+        panels = cmds.getPanel(type="modelPanel") or []
+        visible = set(cmds.getPanel(visiblePanels=True) or [])
+        return [str(panel) for panel in panels if panel in visible]
+    except Exception:  # noqa: BLE001
+        return []
+
+
 def _look_through_camera(cmds: Any, panel: Optional[str], camera: Optional[str]) -> Optional[str]:
     if not panel or not camera:
         return None
@@ -241,6 +259,8 @@ def capture_playblast_sequence(
 
         f0, f1 = _frame_range(cmds, start_frame, end_frame)
         panel = _active_model_panel(cmds)
+        viewport_renderer = _viewport_renderer(cmds, panel)
+        visible_panels = _visible_model_panels(cmds)
         previous_camera = _look_through_camera(cmds, panel, camera)
         active_camera = camera or _camera_from_panel(cmds, panel)
         view_fit_applied = False
@@ -253,7 +273,7 @@ def capture_playblast_sequence(
 
         prefix_path = str(out_dir / safe_prefix)
         try:
-            cmds.playblast(
+            playblast_kwargs = dict(
                 startTime=f0,
                 endTime=f1,
                 format="image",
@@ -267,6 +287,9 @@ def capture_playblast_sequence(
                 offScreen=bool(off_screen),
                 forceOverwrite=True,
             )
+            if panel:
+                playblast_kwargs["editorPanelName"] = panel
+            cmds.playblast(**playblast_kwargs)
         finally:
             _restore_camera(cmds, panel, previous_camera)
 
@@ -279,9 +302,23 @@ def capture_playblast_sequence(
                 prefix=safe_prefix,
                 start_frame=f0,
                 end_frame=f1,
+                panel=panel,
+                viewport_renderer=viewport_renderer,
+                visible_model_panels=visible_panels,
             )
         empty_error = _nonempty_or_error(files)
         if empty_error:
+            empty_error["context"].update(
+                {
+                    "panel": panel,
+                    "viewport_renderer": viewport_renderer,
+                    "visible_model_panels": visible_panels,
+                    "possible_solutions": [
+                        "Use maya_render__render_frame for preview frames when Maya is minimized or playblast is unavailable.",
+                        "Bring Maya to the foreground and ensure a model panel is visible before recording viewport previews.",
+                    ],
+                }
+            )
             return empty_error
 
         return skill_success(
@@ -299,6 +336,8 @@ def capture_playblast_sequence(
             camera=active_camera,
             camera_metadata=_camera_metadata(cmds, active_camera) if include_camera_metadata else None,
             panel=panel,
+            viewport_renderer=viewport_renderer,
+            visible_model_panels=visible_panels,
             off_screen=bool(off_screen),
             show_ornaments=bool(show_ornaments),
             view_fit=bool(view_fit),

--- a/src/dcc_mcp_maya/skills/maya-render/scripts/capture_viewport.py
+++ b/src/dcc_mcp_maya/skills/maya-render/scripts/capture_viewport.py
@@ -38,14 +38,9 @@ def _unlink_if_exists(path: Optional[str]) -> None:
 def _apply_view_fit(cmds) -> bool:
     """Fit the scene in the active model panel (correct ``allObjects`` flag)."""
     try:
-        model_panels = cmds.getPanel(type="modelPanel") or []
-        visible = set(cmds.getPanel(visiblePanels=True) or [])
-        for panel in model_panels:
-            if panel in visible:
-                cmds.viewFit(panel, allObjects=True, animate=False)
-                return True
-        if model_panels:
-            cmds.viewFit(model_panels[0], allObjects=True, animate=False)
+        panel = _active_model_panel(cmds)
+        if panel:
+            cmds.viewFit(panel, allObjects=True, animate=False)
             return True
         cmds.viewFit(allObjects=True, animate=False)
         return True
@@ -60,6 +55,42 @@ def _read_nonempty_png(path: str) -> bytes:
     if not img_bytes:
         raise ValueError("EMPTY_PLAYBLAST")
     return img_bytes
+
+
+def _active_model_panel(cmds) -> Optional[str]:
+    try:
+        focused = cmds.getPanel(withFocus=True)
+        if focused and cmds.getPanel(typeOf=focused) == "modelPanel":
+            return str(focused)
+    except Exception:
+        pass
+    try:
+        panels = cmds.getPanel(type="modelPanel") or []
+        visible = set(cmds.getPanel(visiblePanels=True) or [])
+    except Exception:
+        return None
+    for panel in panels:
+        if panel in visible:
+            return str(panel)
+    return str(panels[0]) if panels else None
+
+
+def _viewport_renderer(cmds, panel: Optional[str]) -> Optional[str]:
+    if not panel:
+        return None
+    try:
+        return str(cmds.modelEditor(panel, query=True, rendererName=True))
+    except Exception:
+        return None
+
+
+def _visible_model_panels(cmds):
+    try:
+        panels = cmds.getPanel(type="modelPanel") or []
+        visible = set(cmds.getPanel(visiblePanels=True) or [])
+        return [panel for panel in panels if panel in visible]
+    except Exception:
+        return []
 
 
 def capture_viewport(
@@ -107,6 +138,9 @@ def capture_viewport(
 
         width, height = _clamp_playblast_dims(width, height)
         f0, f1 = _playblast_frame_range(frame)
+        model_panel = _active_model_panel(cmds)
+        viewport_renderer = _viewport_renderer(cmds, model_panel)
+        visible_panels = _visible_model_panels(cmds)
 
         view_fit_applied = False
         if view_fit:
@@ -127,7 +161,7 @@ def capture_viewport(
 
         # Remove the .png suffix for playblast prefix
         prefix = tmp_path[:-4]
-        cmds.playblast(
+        playblast_kwargs = dict(
             frame=(f0, f1),
             format="image",
             compression="png",
@@ -139,6 +173,9 @@ def capture_viewport(
             showOrnaments=False,
             offScreen=bool(off_screen),
         )
+        if model_panel:
+            playblast_kwargs["editorPanelName"] = model_panel
+        cmds.playblast(**playblast_kwargs)
 
         # playblast appends .<frame>.png
         padded = "{}.{}.png".format(prefix, str(f0).zfill(4))
@@ -160,6 +197,9 @@ def capture_viewport(
             view_fit=bool(view_fit),
             view_fit_applied=view_fit_applied,
             off_screen_forced_by_view_fit_failure=bool(view_fit and not view_fit_applied),
+            model_panel=model_panel,
+            viewport_renderer=viewport_renderer,
+            visible_model_panels=visible_panels,
             prompt="Use capture_viewport with view_fit=True instead of execute_python viewFit(all=True).",
         )
     except ValueError as exc:
@@ -175,6 +215,7 @@ def capture_viewport(
             "Viewport capture produced an empty image",
             "Maya playblast wrote a 0-byte PNG",
             possible_solutions=[
+                "Use maya_render__render_frame with preview-sized dimensions when Maya is minimized or playblast is unavailable.",
                 "Pass off_screen=True if Maya is minimized or running in batch mode.",
                 "Ensure a model panel is visible before capturing.",
                 "Retry after using view_fit=True so the camera frames scene content.",
@@ -187,6 +228,9 @@ def capture_viewport(
             view_fit=bool(view_fit),
             view_fit_applied=view_fit_applied,
             off_screen_forced_by_view_fit_failure=bool(view_fit and not view_fit_applied),
+            model_panel=model_panel,
+            viewport_renderer=viewport_renderer,
+            visible_model_panels=visible_panels,
         )
     except Exception as exc:
         _unlink_if_exists(tmp_path)

--- a/src/dcc_mcp_maya/skills/maya-render/scripts/debug_scene_snapshot.py
+++ b/src/dcc_mcp_maya/skills/maya-render/scripts/debug_scene_snapshot.py
@@ -1,0 +1,153 @@
+"""Collect a compact scene debug snapshot for agents."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import Any, Dict, List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _safe_call(default, func, *args, **kwargs):
+    try:
+        return func(*args, **kwargs)
+    except Exception:
+        return default
+
+
+def _short_name(long_name: str) -> str:
+    return long_name.rsplit("|", 1)[-1] if "|" in long_name else long_name
+
+
+def _scene_summary(cmds, max_nodes: int) -> Dict[str, Any]:
+    transforms = cmds.ls(type="transform", long=True) or []
+    cameras = cmds.ls(type="camera") or []
+    lights = []
+    for light_type in ("light", "directionalLight", "pointLight", "spotLight", "areaLight", "aiSkyDomeLight"):
+        for node in _safe_call([], cmds.ls, type=light_type) or []:
+            if node not in lights:
+                lights.append(node)
+    meshes = cmds.ls(type="mesh") or []
+    sample_nodes: List[Dict[str, Any]] = []
+    for node in transforms[: max(0, int(max_nodes))]:
+        sample_nodes.append(
+            {
+                "name": _short_name(node),
+                "long_name": node,
+                "object_type": _safe_call(None, cmds.objectType, node),
+                "parent": (_safe_call([], cmds.listRelatives, node, parent=True, fullPath=True) or [None])[0],
+                "children": _safe_call([], cmds.listRelatives, node, children=True, fullPath=True) or [],
+                "visible": bool(_safe_call(True, cmds.getAttr, node + ".visibility")),
+            }
+        )
+    scene_path = _safe_call(None, cmds.file, query=True, sceneName=True) or None
+    return {
+        "scene_path": scene_path,
+        "transform_count": len(transforms),
+        "mesh_count": len(meshes),
+        "camera_count": len(cameras),
+        "light_count": len(lights),
+        "sample_nodes": sample_nodes,
+        "truncated": len(transforms) > len(sample_nodes),
+    }
+
+
+def _load_sibling_function(script_name: str, function_name: str):
+    script_path = os.path.join(os.path.dirname(__file__), "{}.py".format(script_name))
+    spec = importlib.util.spec_from_file_location("_dcc_mcp_maya_{}_for_snapshot".format(script_name), script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return getattr(mod, function_name)
+
+
+def _capture_preview(
+    camera: Optional[str],
+    frame: Optional[float],
+    width: int,
+    height: int,
+    return_base64: bool,
+) -> dict:
+    render_frame = _load_sibling_function("render_frame", "render_frame")
+    return render_frame(
+        camera=camera,
+        frame=frame,
+        width=width,
+        height=height,
+        output_name="debug_scene_snapshot",
+        return_base64=return_base64,
+    )
+
+
+def _capture_ui(object_name: Optional[str]) -> Optional[dict]:
+    try:
+        from dcc_mcp_maya import _dev_session  # noqa: PLC0415
+
+        return _dev_session.capture_ui(object_name=object_name)
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to capture Maya UI for debug snapshot")
+
+
+def debug_scene_snapshot(
+    max_nodes: int = 50,
+    include_preview: bool = True,
+    include_ui: bool = False,
+    camera: Optional[str] = None,
+    frame: Optional[float] = None,
+    preview_width: int = 640,
+    preview_height: int = 480,
+    return_base64: bool = True,
+    ui_object_name: Optional[str] = None,
+) -> dict:
+    """Return scene structure plus optional visual debug evidence."""
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        max_nodes = max(1, min(int(max_nodes), 500))
+        preview_width = max(1, min(int(preview_width), 8192))
+        preview_height = max(1, min(int(preview_height), 8192))
+        summary = _scene_summary(cmds, max_nodes)
+
+        preview = None
+        if include_preview:
+            preview = _capture_preview(camera, frame, preview_width, preview_height, bool(return_base64))
+
+        ui_capture = None
+        if include_ui:
+            ui_capture = _capture_ui(ui_object_name)
+
+        ok = True
+        if preview is not None and not preview.get("success", False):
+            ok = False
+        if ui_capture is not None and not ui_capture.get("success", False):
+            ok = False
+
+        message = "Scene debug snapshot collected"
+        if not ok:
+            message = "Scene debug snapshot collected with partial visual evidence"
+        return skill_success(
+            message,
+            scene_summary=summary,
+            preview=preview,
+            ui_capture=ui_capture,
+            include_preview=bool(include_preview),
+            include_ui=bool(include_ui),
+            prompt="Use scene_summary for structure, preview for camera-visible scene pixels, and ui_capture for Maya window state.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to collect scene debug snapshot")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`debug_scene_snapshot`."""
+    return debug_scene_snapshot(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-render/scripts/playblast.py
+++ b/src/dcc_mcp_maya/skills/maya-render/scripts/playblast.py
@@ -42,6 +42,42 @@ def _unlink_if_exists(path: Optional[str]) -> None:
             pass
 
 
+def _active_model_panel(cmds) -> Optional[str]:
+    try:
+        focused = cmds.getPanel(withFocus=True)
+        if focused and cmds.getPanel(typeOf=focused) == "modelPanel":
+            return str(focused)
+    except Exception:
+        pass
+    try:
+        panels = cmds.getPanel(type="modelPanel") or []
+        visible = set(cmds.getPanel(visiblePanels=True) or [])
+    except Exception:
+        return None
+    for panel in panels:
+        if panel in visible:
+            return str(panel)
+    return str(panels[0]) if panels else None
+
+
+def _viewport_renderer(cmds, panel: Optional[str]) -> Optional[str]:
+    if not panel:
+        return None
+    try:
+        return str(cmds.modelEditor(panel, query=True, rendererName=True))
+    except Exception:
+        return None
+
+
+def _visible_model_panels(cmds):
+    try:
+        panels = cmds.getPanel(type="modelPanel") or []
+        visible = set(cmds.getPanel(visiblePanels=True) or [])
+        return [panel for panel in panels if panel in visible]
+    except Exception:
+        return []
+
+
 def playblast(
     width: int = 1920,
     height: int = 1080,
@@ -76,11 +112,14 @@ def playblast(
         width, height = _clamp_playblast_dims(width, height)
         percent = max(1, min(int(percent), 100))
         f0, f1 = _playblast_frame_range(frame)
+        model_panel = _active_model_panel(cmds)
+        viewport_renderer = _viewport_renderer(cmds, model_panel)
+        visible_panels = _visible_model_panels(cmds)
 
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False, prefix="mcp_blast_") as tmp:
             tmp_base = tmp.name[:-4]  # strip .png — playblast appends frame number
 
-        cmds.playblast(
+        playblast_kwargs = dict(
             frame=(f0, f1),
             format="image",
             compression="png",
@@ -92,6 +131,9 @@ def playblast(
             showOrnaments=False,
             offScreen=True,
         )
+        if model_panel:
+            playblast_kwargs["editorPanelName"] = model_panel
+        cmds.playblast(**playblast_kwargs)
 
         # Maya appends ".{frame}.png" → look for the file
         candidates = [
@@ -126,6 +168,10 @@ def playblast(
             frame=frame,
             width=width,
             height=height,
+            off_screen=True,
+            model_panel=model_panel,
+            viewport_renderer=viewport_renderer,
+            visible_model_panels=visible_panels,
         )
     except ValueError as exc:
         if str(exc) != "EMPTY_PLAYBLAST":
@@ -140,6 +186,7 @@ def playblast(
             "Playblast produced an empty image",
             "Maya playblast wrote a 0-byte PNG",
             possible_solutions=[
+                "Use maya_render__render_frame with preview-sized dimensions when Maya is minimized or playblast is unavailable.",
                 "Retry after ensuring a model panel exists.",
                 "Use capture_viewport with off_screen=True and view_fit=True for hidden or minimized Maya sessions.",
             ],
@@ -147,6 +194,10 @@ def playblast(
             frame=frame,
             width=width,
             height=height,
+            off_screen=True,
+            model_panel=model_panel,
+            viewport_renderer=viewport_renderer,
+            visible_model_panels=visible_panels,
         )
     except ImportError:
         return skill_error("Maya not available", "maya.cmds could not be imported")

--- a/src/dcc_mcp_maya/skills/maya-render/scripts/playblast_to_mp4.py
+++ b/src/dcc_mcp_maya/skills/maya-render/scripts/playblast_to_mp4.py
@@ -1,0 +1,275 @@
+"""Capture a viewport playblast sequence and encode it to MP4."""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_MAX_PLAYBLAST_DIM = 8192
+_SAFE_PREFIX_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _safe_prefix(prefix: str) -> str:
+    value = _SAFE_PREFIX_RE.sub("_", str(prefix or "mcp_playblast")).strip("._")
+    return value or "mcp_playblast"
+
+
+def _clamp_dims(width: int, height: int) -> Tuple[int, int]:
+    return max(1, min(int(width), _MAX_PLAYBLAST_DIM)), max(1, min(int(height), _MAX_PLAYBLAST_DIM))
+
+
+def _frame_range(cmds, start_frame: Optional[float], end_frame: Optional[float]) -> Tuple[int, int]:
+    if start_frame is None:
+        try:
+            start_frame = cmds.playbackOptions(query=True, minTime=True)
+        except Exception:
+            start_frame = cmds.currentTime(query=True)
+    if end_frame is None:
+        try:
+            end_frame = cmds.playbackOptions(query=True, maxTime=True)
+        except Exception:
+            end_frame = start_frame
+    f0 = int(round(float(start_frame)))
+    f1 = int(round(float(end_frame)))
+    if f1 < f0:
+        f0, f1 = f1, f0
+    return f0, f1
+
+
+def _active_model_panel(cmds) -> Optional[str]:
+    try:
+        focused = cmds.getPanel(withFocus=True)
+        if focused and cmds.getPanel(typeOf=focused) == "modelPanel":
+            return str(focused)
+    except Exception:
+        pass
+    try:
+        panels = cmds.getPanel(type="modelPanel") or []
+        visible = set(cmds.getPanel(visiblePanels=True) or [])
+    except Exception:
+        return None
+    for panel in panels:
+        if panel in visible:
+            return str(panel)
+    return str(panels[0]) if panels else None
+
+
+def _viewport_renderer(cmds, panel: Optional[str]) -> Optional[str]:
+    if not panel:
+        return None
+    try:
+        return str(cmds.modelEditor(panel, query=True, rendererName=True))
+    except Exception:
+        return None
+
+
+def _no_visible_panel(cmds) -> bool:
+    try:
+        panels = cmds.getPanel(type="modelPanel") or []
+        visible = cmds.getPanel(visiblePanels=True) or []
+        return not any(panel in visible for panel in panels)
+    except Exception:
+        return False
+
+
+def _sequence_files(prefix_path: str, compression: str) -> List[str]:
+    suffix = "." + compression.lower().lstrip(".")
+    files = glob.glob(prefix_path + ".*" + suffix)
+    direct = prefix_path + suffix
+    if os.path.exists(direct):
+        files.append(direct)
+    return sorted(set(files))
+
+
+def _nonempty_sequence_or_error(files: List[str]) -> Optional[dict]:
+    if not files:
+        return skill_error(
+            "Playblast sequence files not found",
+            "Could not locate image files produced by Maya playblast.",
+        )
+    empty = [path for path in files if os.path.exists(path) and os.path.getsize(path) == 0]
+    if empty:
+        return skill_error(
+            "Playblast sequence produced empty image file(s)",
+            "Maya playblast wrote one or more 0-byte image files.",
+            error_code="EMPTY_PLAYBLAST_SEQUENCE",
+            empty_files=empty,
+            possible_solutions=[
+                "Use maya_render__render_frame for preview frames when Maya is minimized or playblast is unavailable.",
+                "Bring Maya to the foreground and ensure a model panel is visible before recording viewport previews.",
+            ],
+        )
+    return None
+
+
+def _encode_mp4(ffmpeg: str, input_pattern: str, output_path: str, fps: int, overwrite: bool) -> subprocess.CompletedProcess:
+    command = [
+        ffmpeg,
+        "-y" if overwrite else "-n",
+        "-framerate",
+        str(fps),
+        "-i",
+        input_pattern,
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        output_path,
+    ]
+    return subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+def playblast_to_mp4(
+    output_dir: Optional[str] = None,
+    prefix: str = "mcp_playblast",
+    start_frame: Optional[float] = None,
+    end_frame: Optional[float] = None,
+    width: int = 1920,
+    height: int = 1080,
+    percent: int = 100,
+    fps: int = 24,
+    off_screen: Optional[bool] = None,
+    show_ornaments: bool = False,
+    output_path: Optional[str] = None,
+    keep_frames: bool = False,
+    overwrite: bool = True,
+) -> dict:
+    """Record a viewport playblast image sequence and encode it to MP4."""
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        ffmpeg = shutil.which("ffmpeg")
+        if not ffmpeg:
+            return skill_error(
+                "ffmpeg not found",
+                "playblast_to_mp4 requires ffmpeg on PATH to encode the image sequence.",
+                possible_solutions=[
+                    "Install ffmpeg and ensure it is available on PATH.",
+                    "Use capture_playblast_sequence when only image frames are needed.",
+                ],
+            )
+
+        created_temp_dir = False
+        if output_dir is None:
+            output_dir = tempfile.mkdtemp(prefix="dcc_mcp_maya_playblast_mp4_")
+            created_temp_dir = True
+        out_dir = Path(os.path.expandvars(os.path.expanduser(str(output_dir))))
+        out_dir.mkdir(parents=True, exist_ok=True)
+        safe_prefix = _safe_prefix(prefix)
+        prefix_path = str(out_dir / safe_prefix)
+        if output_path is None:
+            output_path = str(out_dir / "{}.mp4".format(safe_prefix))
+        else:
+            output_path = str(Path(os.path.expandvars(os.path.expanduser(str(output_path)))))
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+
+        width, height = _clamp_dims(width, height)
+        percent = max(1, min(int(percent), 100))
+        fps = max(1, min(int(fps), 240))
+        f0, f1 = _frame_range(cmds, start_frame, end_frame)
+        panel = _active_model_panel(cmds)
+        viewport_renderer = _viewport_renderer(cmds, panel)
+        if off_screen is None:
+            off_screen = bool(cmds.about(batch=True)) or _no_visible_panel(cmds)
+
+        playblast_kwargs = dict(
+            startTime=f0,
+            endTime=f1,
+            format="image",
+            compression="png",
+            filename=prefix_path,
+            width=width,
+            height=height,
+            percent=percent,
+            viewer=False,
+            showOrnaments=bool(show_ornaments),
+            offScreen=bool(off_screen),
+            forceOverwrite=True,
+        )
+        if panel:
+            playblast_kwargs["editorPanelName"] = panel
+        cmds.playblast(**playblast_kwargs)
+
+        files = _sequence_files(prefix_path, "png")
+        empty_error = _nonempty_sequence_or_error(files)
+        if empty_error:
+            empty_error["context"].update(
+                {
+                    "output_dir": str(out_dir),
+                    "prefix": safe_prefix,
+                    "panel": panel,
+                    "viewport_renderer": viewport_renderer,
+                    "off_screen": bool(off_screen),
+                }
+            )
+            return empty_error
+
+        input_pattern = "{}.%04d.png".format(prefix_path)
+        proc = _encode_mp4(ffmpeg, input_pattern, output_path, fps, bool(overwrite))
+        if proc.returncode != 0:
+            return skill_error(
+                "ffmpeg failed to encode MP4",
+                proc.stderr.strip() or proc.stdout.strip() or "ffmpeg exited with a non-zero status.",
+                output_path=output_path,
+                input_pattern=input_pattern,
+                exit_code=proc.returncode,
+            )
+        if not os.path.exists(output_path) or os.path.getsize(output_path) == 0:
+            return skill_error(
+                "MP4 output is empty",
+                "ffmpeg completed but did not produce a non-empty MP4 file.",
+                output_path=output_path,
+                input_pattern=input_pattern,
+            )
+
+        if not keep_frames:
+            for path in files:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+
+        return skill_success(
+            "Captured viewport MP4: {}".format(output_path),
+            output_path=output_path,
+            output_size=os.path.getsize(output_path),
+            frame_files=files if keep_frames else [],
+            kept_frames=bool(keep_frames),
+            frame_count=len(files),
+            start_frame=f0,
+            end_frame=f1,
+            width=width,
+            height=height,
+            percent=percent,
+            fps=fps,
+            panel=panel,
+            viewport_renderer=viewport_renderer,
+            off_screen=bool(off_screen),
+            show_ornaments=bool(show_ornaments),
+            created_temp_dir=created_temp_dir,
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to capture viewport MP4")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`playblast_to_mp4`."""
+    return playblast_to_mp4(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-render/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render/tools.yaml
@@ -100,6 +100,52 @@ tools:
         default: false
         description: When true, runs cmds.viewFit(allObjects=True, animate=False) on
           the active model panel before capture. Prefer this over raw viewFit in execute_python.
+- name: debug_scene_snapshot
+  description: Collect a compact scene debug snapshot with DAG summary, optional
+    render_frame preview, and optional full Maya UI capture.
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
+  annotations:
+    read_only_hint: true
+    destructive_hint: false
+    idempotent_hint: false
+    open_world_hint: false
+  group: rendering
+  input_schema:
+    type: object
+    properties:
+      max_nodes:
+        type: integer
+        minimum: 1
+        maximum: 500
+        default: 50
+      include_preview:
+        type: boolean
+        default: true
+      include_ui:
+        type: boolean
+        default: false
+      camera:
+        type: string
+      frame:
+        type: number
+      preview_width:
+        type: integer
+        minimum: 1
+        maximum: 8192
+        default: 640
+      preview_height:
+        type: integer
+        minimum: 1
+        maximum: 8192
+        default: 480
+      return_base64:
+        type: boolean
+        default: true
+      ui_object_name:
+        type: string
+        description: Optional Qt objectName/windowTitle for the UI capture.
 - name: get_render_settings
   description: Query current render settings
   execution: sync
@@ -158,6 +204,64 @@ tools:
         minimum: 1
         maximum: 100
         default: 100
+- name: playblast_to_mp4
+  description: Capture a viewport playblast image sequence and encode it to MP4
+    with ffmpeg. Use for animation previews; requires a usable modelPanel and ffmpeg
+    on PATH.
+  execution: async
+  affinity: main
+  timeout_hint_secs: 600
+  annotations:
+    read_only_hint: false
+    destructive_hint: false
+    idempotent_hint: false
+    open_world_hint: false
+  group: rendering
+  input_schema:
+    type: object
+    properties:
+      output_dir:
+        type: string
+      prefix:
+        type: string
+        default: mcp_playblast
+      start_frame:
+        type: number
+      end_frame:
+        type: number
+      width:
+        type: integer
+        minimum: 1
+        maximum: 8192
+        default: 1920
+      height:
+        type: integer
+        minimum: 1
+        maximum: 8192
+        default: 1080
+      percent:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 100
+      fps:
+        type: integer
+        minimum: 1
+        maximum: 240
+        default: 24
+      off_screen:
+        type: boolean
+      show_ornaments:
+        type: boolean
+        default: false
+      output_path:
+        type: string
+      keep_frames:
+        type: boolean
+        default: false
+      overwrite:
+        type: boolean
+        default: true
 - name: render_frame
   description: Render a single frame to disk without using Maya model panels or playblast.
     Uses Arnold when currentRenderer is arnold, otherwise falls back to cmds.render.

--- a/tests/test_maya_render_skill.py
+++ b/tests/test_maya_render_skill.py
@@ -58,9 +58,26 @@ def _configure_render_cmds(cmds, renderer="mayaSoftware", current_frame=1.0):
     return prefix_holder
 
 
+def _configure_model_panel(cmds, panel="modelPanel4", renderer="vp2Renderer"):
+    def _get_panel(*_args, **kwargs):
+        if kwargs.get("withFocus"):
+            return panel
+        if kwargs.get("typeOf") == panel:
+            return "modelPanel"
+        if kwargs.get("type") == "modelPanel":
+            return [panel]
+        if kwargs.get("visiblePanels"):
+            return [panel]
+        return None
+
+    cmds.getPanel.side_effect = _get_panel
+    cmds.modelEditor.return_value = renderer
+
+
 def test_capture_viewport_forces_offscreen_when_view_fit_fails():
     cmds = MagicMock()
     cmds.currentTime.return_value = 1.0
+    _configure_model_panel(cmds)
     cmds.viewFit.side_effect = RuntimeError("no usable panel")
     cmds.playblast.side_effect = _write_playblast_bytes(b"png-bytes")
 
@@ -80,11 +97,14 @@ def test_capture_viewport_forces_offscreen_when_view_fit_fails():
     assert result["context"]["off_screen_forced_by_view_fit_failure"] is True
     _args, kwargs = cmds.playblast.call_args
     assert kwargs["offScreen"] is True
+    assert kwargs["editorPanelName"] == "modelPanel4"
+    assert result["context"]["viewport_renderer"] == "vp2Renderer"
 
 
 def test_capture_viewport_reports_zero_byte_playblast():
     cmds = MagicMock()
     cmds.currentTime.return_value = 1.0
+    _configure_model_panel(cmds)
     cmds.playblast.side_effect = _write_playblast_bytes(b"")
 
     result = load_and_call(
@@ -97,11 +117,14 @@ def test_capture_viewport_reports_zero_byte_playblast():
 
     assert result["success"] is False
     assert "0-byte" in result["message"] or "0-byte" in result["error"]
+    assert result["context"]["model_panel"] == "modelPanel4"
+    assert result["context"]["viewport_renderer"] == "vp2Renderer"
 
 
 def test_playblast_reports_zero_byte_output():
     cmds = MagicMock()
     cmds.currentTime.return_value = 1.0
+    _configure_model_panel(cmds)
     cmds.playblast.side_effect = _write_playblast_bytes(b"")
 
     result = load_and_call(
@@ -114,6 +137,7 @@ def test_playblast_reports_zero_byte_output():
 
     assert result["success"] is False
     assert "0-byte" in result["message"] or "0-byte" in result["error"]
+    assert result["context"]["model_panel"] == "modelPanel4"
 
 
 def test_get_viewport_camera_prefers_focused_model_panel():
@@ -170,6 +194,7 @@ def test_capture_playblast_sequence_writes_paths_and_camera_metadata(tmp_path):
             Path("{}.{}.{}".format(prefix, str(frame).zfill(4), compression)).write_bytes(b"png")
 
     cmds.getPanel.side_effect = _get_panel
+    cmds.modelEditor.return_value = "vp2Renderer"
     cmds.modelPanel.return_value = "persp"
     cmds.about.return_value = False
     cmds.playblast.side_effect = _playblast
@@ -200,6 +225,10 @@ def test_capture_playblast_sequence_writes_paths_and_camera_metadata(tmp_path):
     assert all(Path(path).exists() for path in context["files"])
     assert context["camera"] == "shotCam"
     assert context["camera_metadata"]["camera_shape"] == "shotCamShape"
+    assert context["panel"] == "modelPanel4"
+    assert context["viewport_renderer"] == "vp2Renderer"
+    _args, playblast_kwargs = cmds.playblast.call_args
+    assert playblast_kwargs["editorPanelName"] == "modelPanel4"
     cmds.lookThru.assert_any_call("modelPanel4", "shotCam")
     cmds.lookThru.assert_any_call("modelPanel4", "persp")
     cmds.viewFit.assert_called_once_with("modelPanel4", allObjects=True, animate=False)
@@ -288,3 +317,81 @@ def test_render_frame_rejects_zero_byte_output(tmp_path):
     assert result["success"] is False
     assert result["context"]["error_code"] == "EMPTY_RENDER"
     assert result["context"]["empty_paths"]
+
+
+def test_playblast_to_mp4_encodes_sequence(tmp_path, monkeypatch):
+    cmds = MagicMock()
+    _configure_model_panel(cmds)
+    cmds.currentTime.return_value = 1.0
+    cmds.playbackOptions.side_effect = lambda **kwargs: 1 if kwargs.get("minTime") else 2
+    cmds.about.return_value = False
+
+    def _playblast(**kwargs):
+        prefix = kwargs["filename"]
+        for frame in range(kwargs["startTime"], kwargs["endTime"] + 1):
+            Path("{}.{:04d}.png".format(prefix, frame)).write_bytes(b"frame")
+
+    def _run(command, stdout, stderr, text):
+        Path(command[-1]).write_bytes(b"mp4")
+        completed = MagicMock()
+        completed.returncode = 0
+        completed.stdout = ""
+        completed.stderr = ""
+        return completed
+
+    cmds.playblast.side_effect = _playblast
+    monkeypatch.setattr("shutil.which", lambda name: "ffmpeg" if name == "ffmpeg" else None)
+    monkeypatch.setattr("subprocess.run", _run)
+
+    result = load_and_call(
+        "maya-render/scripts/playblast_to_mp4.py",
+        cmds,
+        "main",
+        output_dir=str(tmp_path),
+        prefix="anim preview",
+        keep_frames=True,
+    )
+
+    assert result["success"] is True, result
+    context = result["context"]
+    assert Path(context["output_path"]).exists()
+    assert context["frame_count"] == 2
+    assert context["panel"] == "modelPanel4"
+    assert context["viewport_renderer"] == "vp2Renderer"
+    _args, playblast_kwargs = cmds.playblast.call_args
+    assert playblast_kwargs["editorPanelName"] == "modelPanel4"
+
+
+def test_debug_scene_snapshot_returns_summary_without_preview():
+    cmds = MagicMock()
+    cmds.ls.side_effect = lambda **kwargs: {
+        "transform": ["|root", "|root|meshA"],
+        "camera": ["perspShape"],
+        "mesh": ["meshAShape"],
+        "light": [],
+        "directionalLight": [],
+        "pointLight": [],
+        "spotLight": [],
+        "areaLight": [],
+        "aiSkyDomeLight": [],
+    }.get(kwargs.get("type"), [])
+    cmds.objectType.side_effect = lambda node: "transform"
+    cmds.listRelatives.side_effect = lambda node, **kwargs: ["|root"] if kwargs.get("parent") and node != "|root" else []
+    cmds.getAttr.return_value = True
+    cmds.file.return_value = "scene.ma"
+
+    result = load_and_call(
+        "maya-render/scripts/debug_scene_snapshot.py",
+        cmds,
+        "main",
+        include_preview=False,
+        include_ui=False,
+        max_nodes=1,
+    )
+
+    assert result["success"] is True, result
+    summary = result["context"]["scene_summary"]
+    assert summary["transform_count"] == 2
+    assert summary["mesh_count"] == 1
+    assert summary["truncated"] is True
+    assert result["context"]["preview"] is None


### PR DESCRIPTION
## Summary
- add maya_render__playblast_to_mp4 for viewport animation previews encoded with ffmpeg
- add maya_render__debug_scene_snapshot for compact DAG summary plus optional render preview and UI screenshot
- make capture_viewport, playblast, and capture_playblast_sequence Viewport 2.0-aware by binding editorPanelName and returning panel/renderer diagnostics

## Stack
- Base PR: #330 (render_frame)
- This PR implements the follow-up PIP-497 tasks: MAYA-497-10, MAYA-497-11, MAYA-497-12

## Tests
- python -m pytest tests/test_maya_render_skill.py tests/test_render_safety.py -q
- python -m py_compile src/dcc_mcp_maya/skills/maya-render/scripts/capture_viewport.py src/dcc_mcp_maya/skills/maya-render/scripts/playblast.py src/dcc_mcp_maya/skills/maya-render/scripts/capture_playblast_sequence.py src/dcc_mcp_maya/skills/maya-render/scripts/playblast_to_mp4.py src/dcc_mcp_maya/skills/maya-render/scripts/debug_scene_snapshot.py
- python -m pytest tests/test_skill_affinity.py tests/test_capability_manifest.py tests/test_lint_skills.py -q