### PR TITLE
feat(maya): add agent compatibility helpers

### DIFF
--- a/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
@@ -48,7 +48,7 @@ Full rationale: repo root `AGENTS.md` § *Bulk import, export, and naming*; exam
 | Look-dev a hero asset, save material preset | `maya-materials` → `maya-material-library` |
 | Publish an asset version | `maya-pipeline` (uses `maya-geometry` under the hood; declared in `depends`) |
 | Bake AO maps from high-res to low-res | `maya-uv-ops` → `maya-texture-bake` |
-| Create a three-point light rig and tweak intensity | `maya-light-rig` |
+| Create a single light or three-point rig and tweak intensity | `maya-light-rig` (`create_light`, `create_three_point_rig`, `set_light_rig_intensity`) |
 | Render an image, snapshot the viewport, write an MP4 preview, or collect debug evidence | `maya-render` (`render_frame`, `playblast`, `capture_viewport`, `capture_playblast_sequence`, `playblast_to_mp4`, `debug_scene_snapshot`) |
 | Develop and debug a Maya Python tool inside the live session | `maya-dev` (`attach_project` → `run_check`; optional `start_debugpy`) |
 

--- a/src/dcc_mcp_maya/skills/maya-light-rig/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-light-rig/SKILL.md
@@ -2,10 +2,10 @@
 name: maya-light-rig
 description: |-
   Authoring stage — pre-configured lighting templates: three-point rigs,
-  HDRI domes, and rig-level intensity controls. Use when deploying a
-  ready-made lighting setup. Not for individual light creation or final
-  render output — use maya-scripting + cmds.shadingNode for ad-hoc lights,
-  maya-render for output settings.
+  HDRI domes, individual lights, and rig-level intensity controls. Use when
+  deploying a ready-made lighting setup or adding a typed light without falling
+  back to raw Maya commands. Not for final render output — use maya-render for
+  output settings.
 license: MIT
 allowed-tools: Bash Read
 metadata:
@@ -30,10 +30,13 @@ metadata:
 
 Standard lighting rigs (three-point, HDRI dome) and rig-level intensity
 controls. Designed for fast scene illumination without manually wiring
-individual light nodes.
+light nodes. `create_light` always returns both the transform and shape to
+avoid Maya 2022 command return-value traps such as `cmds.directionalLight()`
+returning a shape node.
 
 ## Scripts
 
+- `create_light` — Create one typed light and return transform + shape
 - `create_three_point_rig` — Create a standard key/fill/rim three-point light rig
 - `create_hdri_dome` — Create a skydome/environment light from an HDR image
 - `list_light_rigs` — List all lights grouped under rig transform nodes

--- a/src/dcc_mcp_maya/skills/maya-light-rig/groups.yaml
+++ b/src/dcc_mcp_maya/skills/maya-light-rig/groups.yaml
@@ -3,6 +3,7 @@ groups:
   description: Materials, shading, lighting, and environment tools
   default_active: false
   tools:
+  - create_light
   - create_hdri_dome
   - create_three_point_rig
   - list_light_rigs

--- a/src/dcc_mcp_maya/skills/maya-light-rig/scripts/create_light.py
+++ b/src/dcc_mcp_maya/skills/maya-light-rig/scripts/create_light.py
@@ -1,0 +1,118 @@
+"""Create a single Maya light and return both transform and shape names."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SUPPORTED_LIGHT_TYPES = {
+    "ambientLight",
+    "areaLight",
+    "directionalLight",
+    "pointLight",
+    "spotLight",
+    "volumeLight",
+    "aiSkyDomeLight",
+}
+
+
+def _as_float3(value, fallback):
+    if value is None:
+        value = fallback
+    try:
+        values = [float(item) for item in value[:3]]
+    except Exception:
+        values = [float(item) for item in fallback[:3]]
+    while len(values) < 3:
+        values.append(0.0)
+    return values[:3]
+
+
+def _safe_set_attr(cmds, plug: str, value) -> bool:
+    try:
+        cmds.setAttr(plug, value)
+        return True
+    except Exception:
+        return False
+
+
+def create_light(
+    name: str = "mcpLight",
+    light_type: str = "directionalLight",
+    intensity: float = 1.0,
+    color: Optional[list] = None,
+    position: Optional[list] = None,
+    rotation: Optional[list] = None,
+    parent: Optional[str] = None,
+    cone_angle: Optional[float] = None,
+    penumbra_angle: Optional[float] = None,
+) -> dict:
+    """Create one light with a transform parent.
+
+    This avoids the Maya 2022 ``cmds.directionalLight()`` trap where the
+    command returns the shape node, not the transform.  The returned envelope
+    always includes both names so agents can move the transform safely.
+    """
+
+    try:
+        import maya.cmds as cmds  # noqa: PLC0415
+
+        if light_type not in _SUPPORTED_LIGHT_TYPES:
+            return skill_error(
+                "Unsupported light_type",
+                "light_type must be one of: {}".format(", ".join(sorted(_SUPPORTED_LIGHT_TYPES))),
+                light_type=light_type,
+            )
+        if parent and not cmds.objExists(parent):
+            return skill_error("Parent node not found", "The supplied parent transform does not exist.", parent=parent)
+
+        transform = cmds.createNode("transform", name=name, parent=parent) if parent else cmds.createNode("transform", name=name)
+        shape = cmds.createNode(light_type, name="{}Shape".format(transform), parent=transform)
+
+        rgb = _as_float3(color, [1.0, 1.0, 1.0])
+        position_values = _as_float3(position, [0.0, 0.0, 0.0])
+        rotation_values = _as_float3(rotation, [0.0, 0.0, 0.0])
+
+        cmds.setAttr("{}.translate".format(transform), *position_values, type="double3")
+        cmds.setAttr("{}.rotate".format(transform), *rotation_values, type="double3")
+        _safe_set_attr(cmds, "{}.intensity".format(shape), float(intensity))
+        try:
+            cmds.setAttr("{}.color".format(shape), *rgb, type="double3")
+        except Exception:
+            for channel, channel_value in zip(("R", "G", "B"), rgb):
+                _safe_set_attr(cmds, "{}.color{}".format(shape, channel), channel_value)
+
+        if light_type == "spotLight":
+            if cone_angle is not None:
+                _safe_set_attr(cmds, "{}.coneAngle".format(shape), float(cone_angle))
+            if penumbra_angle is not None:
+                _safe_set_attr(cmds, "{}.penumbraAngle".format(shape), float(penumbra_angle))
+
+        return skill_success(
+            "Created {} light '{}'".format(light_type, transform),
+            transform=transform,
+            shape=shape,
+            light_type=light_type,
+            intensity=float(intensity),
+            color=rgb,
+            position=position_values,
+            rotation=rotation_values,
+            parent=parent,
+            prompt="Move or rotate context.transform; light command return values can be shape nodes in Maya 2022.",
+        )
+    except ImportError:
+        return skill_error("Maya not available", "maya.cmds could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create light '{}'".format(name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_light(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_maya/skills/maya-light-rig/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-light-rig/tools.yaml
@@ -1,4 +1,47 @@
 tools:
+- name: create_light
+  execution: sync
+  affinity: main
+  group: shading-lighting
+  description: Create a single Maya light and return both transform and shape names.
+  input_schema:
+    type: object
+    properties:
+      name:
+        type: string
+        default: mcpLight
+      light_type:
+        type: string
+        enum:
+        - ambientLight
+        - areaLight
+        - directionalLight
+        - pointLight
+        - spotLight
+        - volumeLight
+        - aiSkyDomeLight
+        default: directionalLight
+      intensity:
+        type: number
+        default: 1.0
+      color:
+        type: array
+        items:
+          type: number
+      position:
+        type: array
+        items:
+          type: number
+      rotation:
+        type: array
+        items:
+          type: number
+      parent:
+        type: string
+      cone_angle:
+        type: number
+      penumbra_angle:
+        type: number
 - name: create_hdri_dome
   execution: sync
   affinity: main

--- a/src/dcc_mcp_maya/skills/maya-materials/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-materials/SKILL.md
@@ -32,5 +32,9 @@ Build and assign basic shader networks. Eight scripts cover the typical
 "create a Lambert and assign it" loop while keeping `inputSchema`
 validation in place.
 
+`set_material_attribute` includes Maya 2022 / MtoA compatibility aliases for
+Arnold `aiStandardSurface`, such as accepting `metallic` and writing
+`metalness` when that is the available attribute.
+
 For sharing material presets across assets / shots, use
 `maya-material-library`.

--- a/src/dcc_mcp_maya/skills/maya-materials/scripts/set_material_attribute.py
+++ b/src/dcc_mcp_maya/skills/maya-materials/scripts/set_material_attribute.py
@@ -12,6 +12,47 @@ from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_
 from dcc_mcp_maya.api import validate_node_exists
 
 _SUPPORTED_SHADERS = ("lambert", "blinn", "phong", "phongE", "aiStandardSurface")
+_ARNOLD_ATTRIBUTE_ALIASES = {
+    "metallic": ("metalness",),
+    "specular_roughness": ("specularRoughness",),
+    "base_color": ("baseColor", "baseColorR"),
+    "baseColor": ("baseColor", "color"),
+}
+
+
+def _attribute_exists(cmds, material_name: str, attribute: str) -> bool:
+    try:
+        return bool(cmds.objExists("{}.{}".format(material_name, attribute)))
+    except Exception:
+        return False
+
+
+def _node_type(cmds, node: str) -> str:
+    try:
+        return str(cmds.nodeType(node))
+    except Exception:
+        return ""
+
+
+def _resolve_attribute(cmds, material_name: str, attribute: str):
+    node_type = _node_type(cmds, material_name)
+    if node_type != "aiStandardSurface":
+        return attribute, False, node_type, None
+    if _attribute_exists(cmds, material_name, attribute):
+        return attribute, False, node_type, None
+    for candidate in _ARNOLD_ATTRIBUTE_ALIASES.get(attribute, ()):
+        if _attribute_exists(cmds, material_name, candidate):
+            return candidate, True, node_type, attribute
+    return attribute, False, node_type, None
+
+
+def _mtoa_version(cmds):
+    try:
+        if cmds.pluginInfo("mtoa", q=True, loaded=True):
+            return cmds.pluginInfo("mtoa", q=True, version=True)
+    except Exception:
+        return None
+    return None
 
 
 def set_material_attribute(
@@ -36,16 +77,23 @@ def set_material_attribute(
         if err:
             return err
 
-        attr_path = "{}.{}".format(material_name, attribute)
+        resolved_attribute, alias_applied, material_type, requested_attribute = _resolve_attribute(
+            cmds, material_name, attribute
+        )
+        attr_path = "{}.{}".format(material_name, resolved_attribute)
         if isinstance(value, (list, tuple)):
             cmds.setAttr(attr_path, *value, type="double3" if len(value) == 3 else "double4")
         else:
             cmds.setAttr(attr_path, value)
 
         return skill_success(
-            "Set {}.{} = {}".format(material_name, attribute, value),
+            "Set {}.{} = {}".format(material_name, resolved_attribute, value),
             material_name=material_name,
-            attribute=attribute,
+            attribute=resolved_attribute,
+            requested_attribute=requested_attribute or attribute,
+            attribute_alias_applied=alias_applied,
+            material_type=material_type,
+            mtoa_version=_mtoa_version(cmds) if material_type == "aiStandardSurface" else None,
             value=value,
             prompt="Use get_material_connections to verify or render_frame to preview.",
         )

--- a/src/dcc_mcp_maya/skills/maya-scene/scripts/get_session_info.py
+++ b/src/dcc_mcp_maya/skills/maya-scene/scripts/get_session_info.py
@@ -10,6 +10,27 @@ import sys
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _safe_get_attr(cmds, attr: str):
+    try:
+        return cmds.getAttr(attr)
+    except Exception:
+        return None
+
+
+def _plugin_loaded(cmds, plugin_name: str) -> bool:
+    try:
+        return bool(cmds.pluginInfo(plugin_name, q=True, loaded=True))
+    except Exception:
+        return False
+
+
+def _plugin_version(cmds, plugin_name: str):
+    try:
+        return cmds.pluginInfo(plugin_name, q=True, version=True)
+    except Exception:
+        return None
+
+
 def get_session_info() -> dict:
     """Return Maya version, scene path, and basic stats.
 
@@ -26,6 +47,7 @@ def get_session_info() -> dict:
         # ``TypeError: … boolean parameter``.  ``type=`` filters are safe
         # off-thread; transform count is a stable proxy for scene size.
         transforms = cmds.ls(type="transform") or []
+        mtoa_loaded = _plugin_loaded(cmds, "mtoa")
         info = {
             "maya_version": cmds.about(version=True),
             "api_version": cmds.about(apiVersion=True),
@@ -35,6 +57,9 @@ def get_session_info() -> dict:
             "fps": cmds.currentUnit(query=True, time=True),
             "up_axis": cmds.upAxis(query=True, axis=True),
             "object_count": len(transforms),
+            "current_renderer": _safe_get_attr(cmds, "defaultRenderGlobals.currentRenderer"),
+            "mtoa_loaded": mtoa_loaded,
+            "mtoa_version": _plugin_version(cmds, "mtoa") if mtoa_loaded else None,
         }
         return skill_success(
             "Maya session info", **info, prompt="Check the result with list_scene or use related actions to continue."

--- a/tests/test_maya_light_rig_skill.py
+++ b/tests/test_maya_light_rig_skill.py
@@ -1,0 +1,55 @@
+"""Unit tests for maya-light-rig skill scripts."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from conftest import load_and_call
+
+
+def test_create_light_returns_transform_and_shape_without_directional_command():
+    cmds = MagicMock()
+
+    def _create_node(node_type, **kwargs):
+        if node_type == "transform":
+            return kwargs["name"]
+        return kwargs["name"]
+
+    cmds.createNode.side_effect = _create_node
+
+    result = load_and_call(
+        "maya-light-rig/scripts/create_light.py",
+        cmds,
+        "main",
+        name="key_light",
+        light_type="directionalLight",
+        intensity=2.0,
+        color=[1.0, 0.9, 0.8],
+        position=[1, 2, 3],
+        rotation=[10, 20, 30],
+    )
+
+    assert result["success"] is True, result
+    assert result["context"]["transform"] == "key_light"
+    assert result["context"]["shape"] == "key_lightShape"
+    cmds.createNode.assert_any_call("transform", name="key_light")
+    cmds.createNode.assert_any_call("directionalLight", name="key_lightShape", parent="key_light")
+    cmds.setAttr.assert_any_call("key_light.translate", 1.0, 2.0, 3.0, type="double3")
+    cmds.setAttr.assert_any_call("key_light.rotate", 10.0, 20.0, 30.0, type="double3")
+    assert not cmds.directionalLight.called
+
+
+def test_create_light_rejects_unsupported_light_type():
+    cmds = MagicMock()
+
+    result = load_and_call(
+        "maya-light-rig/scripts/create_light.py",
+        cmds,
+        "main",
+        name="badLight",
+        light_type="unsupportedLight",
+    )
+
+    assert result["success"] is False
+    assert "Unsupported" in result["message"]
+    cmds.createNode.assert_not_called()

--- a/tests/test_maya_materials_skill.py
+++ b/tests/test_maya_materials_skill.py
@@ -1,0 +1,58 @@
+"""Unit tests for maya-materials skill scripts."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from conftest import load_and_call
+
+
+def test_set_material_attribute_maps_arnold_metallic_to_metalness():
+    cmds = MagicMock()
+    cmds.objExists.side_effect = lambda plug: plug in {"carPaint", "carPaint.metalness"}
+    cmds.nodeType.return_value = "aiStandardSurface"
+
+    def _plugin_info(_plugin, **kwargs):
+        if kwargs.get("loaded"):
+            return True
+        if kwargs.get("version"):
+            return "5.0.0.3"
+        return None
+
+    cmds.pluginInfo.side_effect = _plugin_info
+
+    result = load_and_call(
+        "maya-materials/scripts/set_material_attribute.py",
+        cmds,
+        "main",
+        material_name="carPaint",
+        attribute="metallic",
+        value=0.7,
+    )
+
+    assert result["success"] is True, result
+    assert result["context"]["requested_attribute"] == "metallic"
+    assert result["context"]["attribute"] == "metalness"
+    assert result["context"]["attribute_alias_applied"] is True
+    assert result["context"]["mtoa_version"] == "5.0.0.3"
+    cmds.setAttr.assert_called_once_with("carPaint.metalness", 0.7)
+
+
+def test_set_material_attribute_keeps_existing_attribute():
+    cmds = MagicMock()
+    cmds.objExists.side_effect = lambda plug: plug in {"lambert1", "lambert1.color"}
+    cmds.nodeType.return_value = "lambert"
+
+    result = load_and_call(
+        "maya-materials/scripts/set_material_attribute.py",
+        cmds,
+        "main",
+        material_name="lambert1",
+        attribute="color",
+        value=[1.0, 0.0, 0.0],
+    )
+
+    assert result["success"] is True, result
+    assert result["context"]["attribute"] == "color"
+    assert result["context"]["attribute_alias_applied"] is False
+    cmds.setAttr.assert_called_once_with("lambert1.color", 1.0, 0.0, 0.0, type="double3")

--- a/tests/test_maya_scene_skill.py
+++ b/tests/test_maya_scene_skill.py
@@ -139,6 +139,32 @@ def test_get_scene_info_rejects_invalid_detail_mode():
     assert "detail_mode" in result["message"]
 
 
+def test_get_session_info_includes_renderer_and_mtoa_version():
+    cmds = MagicMock()
+    cmds.ls.return_value = ["persp", "pCube1"]
+    cmds.about.side_effect = lambda **kwargs: "2022" if kwargs.get("version") else 20220501
+    cmds.file.side_effect = lambda **kwargs: "C:/show/scene.ma" if kwargs.get("sceneName") else False
+    cmds.currentUnit.return_value = "film"
+    cmds.upAxis.return_value = "y"
+    cmds.getAttr.return_value = "arnold"
+
+    def _plugin_info(_plugin, **kwargs):
+        if kwargs.get("loaded"):
+            return True
+        if kwargs.get("version"):
+            return "5.0.0.3"
+        return None
+
+    cmds.pluginInfo.side_effect = _plugin_info
+
+    result = load_and_call("maya-scene/scripts/get_session_info.py", cmds, "main")
+
+    assert result["success"] is True, result
+    assert result["context"]["current_renderer"] == "arnold"
+    assert result["context"]["mtoa_loaded"] is True
+    assert result["context"]["mtoa_version"] == "5.0.0.3"
+
+
 def test_create_camera_sets_transform_shape_attrs_and_optional_aim():
     cmds = MagicMock()
     cmds.camera.return_value = ["camera1", "cameraShape1"]


### PR DESCRIPTION
## Summary
- add maya_light_rig__create_light so agents can create single lights and receive both transform + shape names
- map Arnold aiStandardSurface attribute aliases such as metallic -> metalness in set_material_attribute
- expose current_renderer, mtoa_loaded, and mtoa_version from maya_scene__get_session_info

## Stack
- Depends on #333, which promotes #331's debug capture workflows to main.

## Tests
- python -m pytest tests/test_maya_light_rig_skill.py tests/test_maya_materials_skill.py tests/test_maya_scene_skill.py tests/test_skill_affinity.py tests/test_capability_manifest.py tests/test_lint_skills.py -q