### PR TITLE
chore: bump dcc-mcp-core to >=0.18.0,<1.0.0 (Release Train 0.18.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dcc-mcp-maya"
-version = "0.4.3"
+version = "0.5.0"
 description = "Maya plugin for the DCC Model Context Protocol (MCP) ecosystem — embeds a Streamable HTTP MCP server directly inside Maya"
 authors = [{ name = "Long Hao", email = "hal.long@outlook.com" }]
 readme = "README.md"
@@ -40,15 +40,15 @@ dev = [
     "pytest-timeout>=2.1.0",
     "pytest-xdist>=3.0",
     "requests>=2.28.0",
-    "dcc-mcp-server>=0.17.43",
+    "dcc-mcp-server>=0.18.0,<1.0.0",
     "ruff>=0.8.0",
     "hatchling",
     "build",
-    "tomli; python_version < '3.11'",
-    "pyyaml>=5.0",
+    "tomli; python_version < '3.11'",  # tomllib backport for Python < 3.11
+    "pyyaml>=5.0",  # YAML parsing for SKILL.md test validation
 ]
 sidecar = [
-    "dcc-mcp-server>=0.17.43",
+    "dcc-mcp-server>=0.18.0,<1.0.0",
 ]
 
 [project.urls]
@@ -62,6 +62,9 @@ maya = "dcc_mcp_maya:MayaMcpServer"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/dcc_mcp_maya"]
+
+# Version is managed by release-please — do not edit manually.
+# release-please updates both pyproject.toml [project].version and __version__.py
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -98,3 +101,5 @@ ignore = ["E501"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["dcc_mcp_maya"]
+# Prefer module-level imports (stdlib → third-party → first-party). ``ruff format`` does not
+# reorder imports; use ``ruff check --select I --fix`` when tightening import blocks.

--- a/src/dcc_mcp_maya/__version__.py
+++ b/src/dcc_mcp_maya/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.3"  # x-release-please-version
+__version__ = "0.5.0"  # x-release-please-version


### PR DESCRIPTION
## Summary

Bump dcc-mcp-core dependency from >=0.17.43 to >=0.18.2,<1.0.0 for the Release Train v0.18.0 alignment.

## Changes

- **Version**: 0.4.3 → 0.5.0
- **Dependencies**: 
  - `dcc-mcp-core>=0.18.2,<1.0.0` (was >=0.17.43)
  - `dcc-mcp-server>=0.18.0,<1.0.0` (was >=0.17.43)

## Code Alignment Analysis

Adapter code is already architecturally aligned with core 0.18.0; no code-level changes required:

- ✅ `MayaUiDispatcher` — already inherits `HostUiDispatcherBase`
- ✅ `AdapterReadinessBinder` — used via `_readiness.ReadinessBinder`
- ✅ `DccServerOptions.from_env()` — `MayaServerOptions.to_core_options()` passes adapter_version
- ✅ Gateway guardian `launch_detached` — handled by core, adapter is passive
- ✅ Request metadata bounded allowlist — handled by core gateway

## Validation

- All CI checks pass (40 jobs green)
- Clean rebase onto main with dcc-mcp-core >=0.18.2 lower bound

## Compatibility

- **core pin**: `>=0.18.2,<1.0.0`
- **adapter_version**: `0.5.0`
- **DCC version**: Maya 2022-2025