### PR TITLE
feat(schema): add input_schema to maya-rigging, maya-scene, maya-render tools.yaml

### DIFF
--- a/src/dcc_mcp_maya/skills/maya-render/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render/tools.yaml
@@ -147,29 +147,39 @@ tools:
         type: string
         description: Optional Qt objectName/windowTitle for the UI capture.
 - name: get_render_settings
-  description: Query current render settings
+  description: Query current render settings (resolution, renderer, frame range, format, output path).
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  input_schema:
+    type: object
+    properties: {}
 - name: get_scene_render_stats
-  description: Get scene render statistics without modifying the Maya scene.
+  description: Get scene render statistics including quality attributes without modifying the Maya scene.
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  input_schema:
+    type: object
+    properties: {}
 - name: get_viewport_camera
-  description: Query the active model panel camera with scene-camera fallback.
+  description: Query the active model panel camera with scene-camera fallback, returning
+    camera transform, shape, focal length, and film aperture.
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
     idempotent_hint: true
   group: rendering
+  input_schema:
+    type: object
+    properties: {}
 - name: playblast
   description: Capture a viewport screenshot as a base64-encoded PNG via playblast (off-screen).
     Frame is passed as a proper Maya time range; width and height are clamped to reduce
@@ -307,16 +317,52 @@ tools:
         default: true
         description: Include base64 image bytes in context.image_base64.
 - name: set_render_quality
-  description: Set render quality settings in the current Maya scene.
+  description: Apply a render quality preset (low/medium/high) to the Maya defaultRenderQuality node.
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
+  input_schema:
+    type: object
+    properties:
+      preset:
+        type: string
+        enum:
+        - low
+        - medium
+        - high
+        default: medium
 - name: set_render_settings
-  description: Set render parameters (resolution, frame range, renderer, image format)
+  description: Set render parameters (resolution, frame range, renderer, image format, output path).
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rendering
+  input_schema:
+    type: object
+    properties:
+      width:
+        type: integer
+        minimum: 1
+        description: Render width in pixels.
+      height:
+        type: integer
+        minimum: 1
+        description: Render height in pixels.
+      start_frame:
+        type: number
+        description: Animation start frame.
+      end_frame:
+        type: number
+        description: Animation end frame.
+      renderer:
+        type: string
+        description: Render engine name (e.g. mayaSoftware, arnold, vray).
+      image_format:
+        type: string
+        description: Image format (e.g. png, exr, jpg, tiff).
+      output_path:
+        type: string
+        description: Output directory path for rendered images.

--- a/src/dcc_mcp_maya/skills/maya-rigging/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-rigging/tools.yaml
@@ -1,21 +1,78 @@
 tools:
 - name: assign_deformer
-  description: Assign a deformer in the current Maya scene.
+  description: Apply a deformer (cluster, blendShape, lattice, wrap, bend, twist, flare, sine, squash, wave) to an object.
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  input_schema:
+    type: object
+    required:
+    - object_name
+    properties:
+      object_name:
+        type: string
+      deformer_type:
+        type: string
+        enum:
+        - cluster
+        - blendShape
+        - lattice
+        - wrap
+        - bend
+        - twist
+        - flare
+        - sine
+        - squash
+        - wave
+        default: cluster
 - name: blend_shape_add_target
-  description: Blend shape add target in the current Maya scene.
+  description: Add a target mesh to an existing blend shape deformer.
   execution: sync
   affinity: main
   group: rigging
+  input_schema:
+    type: object
+    required:
+    - blend_shape
+    - target_mesh
+    properties:
+      blend_shape:
+        type: string
+      target_mesh:
+        type: string
+      weight:
+        type: number
+        minimum: 0.0
+        maximum: 1.0
+        default: 0.0
+      index:
+        type: integer
 - name: create_blend_shape
-  description: Create a blend shape in the current Maya scene.
+  description: Create a blend shape deformer on a base mesh with optional target meshes.
   execution: sync
   affinity: main
   group: rigging
+  input_schema:
+    type: object
+    required:
+    - base_mesh
+    properties:
+      base_mesh:
+        type: string
+      target_meshes:
+        type: array
+        items:
+          type: string
+      name:
+        type: string
+      origin:
+        type: string
+        enum:
+        - local
+        - world
+        default: local
 - name: copy_skin_weights
   description: Copy or mirror skin weights between skinned meshes.
   execution: sync
@@ -113,20 +170,71 @@ tools:
         minItems: 3
         maxItems: 3
 - name: create_curve
-  description: Create a curve in the current Maya scene.
+  description: Create a NURBS curve from a list of control points.
   execution: sync
   affinity: main
   group: rigging
+  input_schema:
+    type: object
+    properties:
+      points:
+        type: array
+        items:
+          type: array
+          items:
+            type: number
+          minItems: 3
+          maxItems: 3
+      name:
+        type: string
+      degree:
+        type: integer
+        minimum: 1
+        default: 3
+      periodic:
+        type: boolean
+        default: false
 - name: create_ik_handle
-  description: Create an IK handle in the current Maya scene.
+  description: Create an IK handle between two joints with configurable solver.
   execution: sync
   affinity: main
   group: rigging
+  input_schema:
+    type: object
+    required:
+    - start_joint
+    - end_joint
+    properties:
+      start_joint:
+        type: string
+      end_joint:
+        type: string
+      solver:
+        type: string
+        enum:
+        - ikRPsolver
+        - ikSCsolver
+        default: ikRPsolver
+      name:
+        type: string
 - name: create_joint
-  description: Create a joint in the current Maya scene.
+  description: Create a Maya joint node with optional parent and position.
   execution: sync
   affinity: main
   group: rigging
+  input_schema:
+    type: object
+    properties:
+      name:
+        type: string
+      position:
+        type: array
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      parent:
+        type: string
 - name: create_rig_control
   description: Create a rig control curve with optional offset groups and constraints.
   execution: sync
@@ -201,10 +309,33 @@ tools:
         type: boolean
         default: false
 - name: mirror_joints
-  description: Mirror joints in the current Maya scene.
+  description: Mirror a joint chain across an axis plane with optional search/replace renaming.
   execution: sync
   affinity: main
   group: rigging
+  input_schema:
+    type: object
+    required:
+    - joint_name
+    properties:
+      joint_name:
+        type: string
+      mirror_behavior:
+        type: boolean
+        default: true
+      search_replace:
+        type: array
+        items:
+          type: string
+        minItems: 2
+        maxItems: 2
+      mirror_axis:
+        type: string
+        enum:
+        - YZ
+        - XY
+        - XZ
+        default: YZ
 - name: query_skin_cluster
   description: Query skinCluster influences, geometry, and common settings.
   execution: sync
@@ -221,35 +352,146 @@ tools:
       node:
         type: string
 - name: set_driven_key
-  description: Set a driven key in the current Maya scene.
+  description: Create a set-driven key relationship between a driver attribute and driven attributes.
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  input_schema:
+    type: object
+    required:
+    - driver_attr
+    - driven_attrs
+    - driver_values
+    - driven_values
+    properties:
+      driver_attr:
+        type: string
+      driven_attrs:
+        type: array
+        items:
+          type: string
+      driver_values:
+        type: array
+        items:
+          type: number
+      driven_values:
+        type: array
+        items:
+          type: array
+          items:
+            type: number
+      tangent_type:
+        type: string
+        enum:
+        - linear
+        - smooth
+        - flat
+        - step
+        default: linear
 - name: set_ik_fk_blend
-  description: Set IK/FK blend values in the current Maya scene.
+  description: Set the IK/FK blend weight on an IK handle (0 = full FK, 1 = full IK).
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  input_schema:
+    type: object
+    required:
+    - ik_handle
+    properties:
+      ik_handle:
+        type: string
+      blend:
+        type: number
+        minimum: 0.0
+        maximum: 1.0
+        default: 1.0
+      attribute:
+        type: string
+        default: ikBlend
 - name: set_joint_limit
-  description: Set joint limits in the current Maya scene.
+  description: Set rotation limits on a joint axis (x, y, or z) with min/max angles.
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  input_schema:
+    type: object
+    required:
+    - joint_name
+    - axis
+    properties:
+      joint_name:
+        type: string
+      axis:
+        type: string
+        enum:
+        - x
+        - y
+        - z
+      min_angle:
+        type: number
+      max_angle:
+        type: number
+      enable:
+        type: boolean
+        default: true
 - name: set_joint_orient
-  description: Set joint orientation in the current Maya scene.
+  description: Set the joint orientation (local rotation axes) on a Maya joint.
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: rigging
+  input_schema:
+    type: object
+    required:
+    - joint_name
+    properties:
+      joint_name:
+        type: string
+      orient:
+        type: array
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      zero_scale_orient:
+        type: boolean
+        default: false
 - name: skin_cluster_bind
-  description: Skin cluster bind in the current Maya scene.
+  description: Bind a mesh to a set of joints using a skin cluster.
   execution: sync
   affinity: main
   group: rigging
+  input_schema:
+    type: object
+    required:
+    - joints
+    - mesh
+    properties:
+      joints:
+        type: array
+        items:
+          type: string
+        minItems: 1
+      mesh:
+        type: string
+      max_influences:
+        type: integer
+        minimum: 1
+        default: 4
+      bind_method:
+        type: integer
+        enum:
+        - 0
+        - 1
+        - 2
+        - 3
+        default: 0
+      name:
+        type: string

--- a/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene/tools.yaml
@@ -3,12 +3,30 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
-  description: Center pivot in the current Maya scene.
+  description: Center the pivot point of an object to its bounding box center.
+  input_schema:
+    type: object
+    required:
+    - object_name
+    properties:
+      object_name:
+        type: string
 - name: create_locator
   execution: sync
   affinity: main
   group: scene-management
-  description: Create a locator in the current Maya scene.
+  description: Create a Maya locator node at an optional world-space position.
+  input_schema:
+    type: object
+    properties:
+      name:
+        type: string
+      position:
+        type: array
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
 - name: create_camera
   description: Create a camera transform and shape with common camera attributes.
   execution: sync
@@ -62,12 +80,31 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
-  description: Duplicate an object in the current Maya scene.
+  description: Duplicate an object in the Maya scene, optionally as an instance.
+  input_schema:
+    type: object
+    required:
+    - object_name
+    properties:
+      object_name:
+        type: string
+      new_name:
+        type: string
+      instance:
+        type: boolean
+        default: false
 - name: freeze_transforms
   execution: sync
   affinity: main
   group: scene-management
-  description: Freeze transforms in the current Maya scene.
+  description: Freeze (apply) the transforms of an object, zeroing out translate/rotate and resetting scale to 1.
+  input_schema:
+    type: object
+    required:
+    - object_name
+    properties:
+      object_name:
+        type: string
 - name: get_bounding_box
   execution: sync
   affinity: main
@@ -75,7 +112,14 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
-  description: Get an object bounding box without modifying the Maya scene.
+  description: Query the world-space bounding box of an object, returning min, max, center, and size.
+  input_schema:
+    type: object
+    required:
+    - object_name
+    properties:
+      object_name:
+        type: string
 - name: get_scene_info
   description: Return a hierarchical DAG description of the current scene. Use
     detail_mode=lightweight for high-frequency polling, standard when stable
@@ -134,6 +178,9 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: core
+  input_schema:
+    type: object
+    properties: {}
 - name: get_session_info
   description: Return Maya version, scene path, and basic session statistics
   execution: sync
@@ -142,6 +189,9 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: core
+  input_schema:
+    type: object
+    properties: {}
 - name: group_objects
   description: Group a list of objects under a new transform node.
   execution: sync
@@ -171,7 +221,14 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
-  description: List cameras without modifying the Maya scene.
+  description: List all cameras in the scene with focal length, clip planes, and renderable status.
+  input_schema:
+    type: object
+    properties:
+      include_default:
+        type: boolean
+        default: true
+        description: Include Maya built-in cameras (persp, top, front, side).
 - name: look_through_camera
   description: Switch a model panel to look through a camera.
   execution: sync
@@ -201,11 +258,31 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: scene-management
+  input_schema:
+    type: object
+    properties:
+      object_type:
+        type: string
+        description: Optional Maya node type filter (e.g. mesh, transform, joint).
+      dag:
+        type: boolean
+        default: true
+        description: Return only DAG nodes.
 - name: lock_object
   execution: sync
   affinity: main
   group: scene-management
-  description: Lock an object in the current Maya scene.
+  description: Lock or unlock the translate/rotate/scale attributes of an object.
+  input_schema:
+    type: object
+    required:
+    - object_name
+    properties:
+      object_name:
+        type: string
+      lock:
+        type: boolean
+        default: true
 - name: new_scene
   description: Create a new empty Maya scene
   execution: async
@@ -255,7 +332,19 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
-  description: Parent an object in the current Maya scene.
+  description: Set or clear the parent of an object.
+  input_schema:
+    type: object
+    required:
+    - child
+    properties:
+      child:
+        type: string
+      parent:
+        type: string
+      world:
+        type: boolean
+        default: false
 - name: save_scene
   description: >-
     Canonical native Maya scene save. Saves the current scene in place, or first
@@ -282,14 +371,41 @@ tools:
   execution: sync
   affinity: main
   group: scene-management
-  description: Select by type in the current Maya scene.
+  description: Select all objects of a given Maya type (e.g. mesh, transform, joint, camera).
+  input_schema:
+    type: object
+    required:
+    - object_type
+    properties:
+      object_type:
+        type: string
 - name: set_frame_rate
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
-  description: Set the frame rate in the current Maya scene.
+  description: Change the scene playback frame rate.
+  input_schema:
+    type: object
+    properties:
+      fps:
+        type: string
+        enum:
+        - game
+        - film
+        - pal
+        - ntsc
+        - show
+        - palf
+        - ntscf
+        - 23.976fps
+        - 29.97fps
+        - 47.952fps
+        - 59.94fps
+        - 44100fps
+        - 48000fps
+        default: film
 - name: set_camera
   description: Edit camera transform and common shape attributes.
   execution: sync
@@ -341,10 +457,30 @@ tools:
   annotations:
     idempotent_hint: true
   group: scene-management
+  input_schema:
+    type: object
+    required:
+    - objects
+    properties:
+      objects:
+        type: array
+        items:
+          type: string
+        minItems: 1
 - name: set_visibility
   execution: sync
   affinity: main
   annotations:
     idempotent_hint: true
   group: scene-management
-  description: Set object visibility in the current Maya scene.
+  description: Show or hide an object in the viewport.
+  input_schema:
+    type: object
+    required:
+    - object_name
+    - visible
+    properties:
+      object_name:
+        type: string
+      visible:
+        type: boolean


### PR DESCRIPTION
## Summary

Adds `input_schema` to all 32 previously-missing tools across three high-frequency Maya skills:

### maya-rigging (12 tools)
`assign_deformer`, `blend_shape_add_target`, `create_blend_shape`, `create_curve`, `create_ik_handle`, `create_joint`, `mirror_joints`, `set_driven_key`, `set_ik_fk_blend`, `set_joint_limit`, `set_joint_orient`, `skin_cluster_bind`

### maya-scene (15 tools)
`center_pivot`, `create_locator`, `duplicate_object`, `freeze_transforms`, `get_bounding_box`, `get_selection`, `get_session_info`, `list_cameras`, `list_objects`, `lock_object`, `parent_object`, `select_by_type`, `set_frame_rate`, `set_selection`, `set_visibility`

### maya-render (5 tools)
`get_render_settings`, `get_scene_render_stats`, `get_viewport_camera`, `set_render_quality`, `set_render_settings`

## Verification

- All tools now return `has_schema: true` with complete `properties`
- Schema parameters are derived from the actual Python function signatures
- All existing tests pass: `test_skill_rest_mcp_parity`, `test_lint_skills`, `test_skill_affinity`, `test_capability_manifest`
- Schemas respect the 1.5 KB budget per tool
- No `inputSchema` (camelCase) usage — all use core's `input_schema` convention

## Context

Core 0.18.7 already fixed the schema propagation path; this is the YAML layer fill for skills that were missing schema definitions, causing `has_schema: false` in live gateway testing.