### PR TITLE
fix: re-assert gateway_port on _config after __init__ in test helper

### DIFF
--- a/tests/test_gateway_integration.py
+++ b/tests/test_gateway_integration.py
@@ -145,6 +145,7 @@ class TestGatewayProperties:
         mock_handle = MagicMock()
         mock_handle.is_gateway = is_gateway_val
         server._handle = mock_handle
+        server._config.gateway_port = gateway_port  # Re-assert after __init__ may reset it
         return server
 
     def test_is_gateway_true_when_handle_is_gateway(self):


### PR DESCRIPTION
## Summary
- Fixes `test_gateway_url_returns_url_when_is_gateway` that fails across all platforms in CI (1636 passed, 1 failed)
- Root cause: `_init_job_persistence` called during `MayaMcpServer.__init__` resets `_config.gateway_port` to 0 on the MagicMock, causing `gateway_url` to return `None` instead of `"http://127.0.0.1:9765/mcp"`
- This bug exists on `main` branch — not introduced by any release PR

## Test plan
- [x] `python -m pytest tests/test_gateway_integration.py::TestGatewayProperties -xvs` — all 6 passed