### PR TITLE
chore(deps): bump dcc-mcp-core to >=0.18.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ classifiers = [
 ]
 
 dependencies = [
-    # Release Train anchor: dcc-mcp-core v0.18.2 (PIP-552).
+    # Release Train anchor: dcc-mcp-core v0.18.9 (PIP-908).
     # Provides abi3 (cp38+) on 3.8+; separate cp37 wheels on Python 3.7 (Maya 2022).
-    "dcc-mcp-core>=0.18.2,<1.0.0",
+    "dcc-mcp-core>=0.18.9,<1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump `dcc-mcp-core` dependency from `>=0.18.2,<1.0.0` to `>=0.18.9,<1.0.0`
- Release Train v0.18.0..v0.18.9: marketplace shared crate, gateway election disabled for probe server, ADR-010 dual-protocol migration docs

## Related
- Core release: https://github.com/dcc-mcp/dcc-mcp-core/releases/tag/v0.18.9