### PR TITLE
fix(ci): add fetch-depth: 0 to test-mayapy-py37 checkout step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Verify mayapy (Python 3.7)
         run: |

--- a/tests/test_agent_instruction_files.py
+++ b/tests/test_agent_instruction_files.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import subprocess
-
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 AGENT_ENTRYPOINTS = (


### PR DESCRIPTION
## Summary

The `test-mayapy-py37` job runs inside a Docker container where the default shallow clone (`fetch-depth: 1`) causes `git ls-files` to fail with exit code 128.

This breaks two tests in `tests/test_agent_instruction_files.py`:
- `test_agent_entrypoints_do_not_include_multica_runtime_context`
- `test_multica_runtime_artifacts_are_not_tracked`

## Fix

Add `fetch-depth: 0` to the `actions/checkout@v6` step in the `test-mayapy-py37` job (ci.yml:63), matching the pattern already used in docs.yml.

## Verification

- The same `fetch-depth: 0` pattern is already used in `docs.yml` without issues.
- With a full clone, `git ls-files` works correctly inside the Docker container.