### PR TITLE
PIP-873: Update maya-render/SKILL.md with intent routing, VP2 fallback, and SKILLS_INDEX.md cross-refs

### DIFF
--- a/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_maya/skills/SKILLS_INDEX.md
@@ -49,7 +49,7 @@ Full rationale: repo root `AGENTS.md` § *Bulk import, export, and naming*; exam
 | Publish an asset version | `maya-pipeline` (uses `maya-geometry` under the hood; declared in `depends`) |
 | Bake AO maps from high-res to low-res | `maya-uv-ops` → `maya-texture-bake` |
 | Create a single light or three-point rig and tweak intensity | `maya-light-rig` (`create_light`, `create_three_point_rig`, `set_light_rig_intensity`) |
-| Render an image, snapshot the viewport, write an MP4 preview, or collect debug evidence | `maya-render` (`render_frame`, `playblast`, `capture_viewport`, `capture_playblast_sequence`, `playblast_to_mp4`, `debug_scene_snapshot`) |
+| Render an image, snapshot the viewport, write an MP4 preview, or collect debug evidence | **Intent-driven:** `maya-render` (`render_frame` for final-frame output, `debug_scene_snapshot` for diagnostics, `playblast_to_mp4` for animation preview). See `maya-render/SKILL.md` § *Render intents → tool routing* and § *VP2 fallback flow* for error recovery when viewport is unavailable. |
 | Develop and debug a Maya Python tool inside the live session | `maya-dev` (`attach_project` → `run_check`; optional `start_debugpy`) |
 
 ## Side-Effect Taxonomy

--- a/src/dcc_mcp_maya/skills/maya-render/SKILL.md
+++ b/src/dcc_mcp_maya/skills/maya-render/SKILL.md
@@ -13,7 +13,7 @@ metadata:
     dcc: maya
     layer: domain
     stage: pipeline
-    version: 1.1.0
+    version: 1.2.0
     tags:
     - maya
     - render
@@ -22,11 +22,16 @@ metadata:
     - capture
     - settings
     - viewport
+    - debug
+    - snapshot
     search-hint: |-
       final output, preview render, playblast, viewport capture, render globals,
-      set render settings, image format, frame range render
+      set render settings, image format, frame range render, debug snapshot,
+      MP4 preview, render intent, VP2 fallback
     tools: tools.yaml
     groups: groups.yaml
+    resources:
+    - docs://maya-render
 ---
 # maya-render (Pipeline stage)
 
@@ -36,6 +41,64 @@ scene or geometry file import/export belongs to `maya-geometry`; shot
 packaging belongs to `maya-shot-export`. For distributed rendering, see
 `maya-render-farm`.
 
+## Render intents → tool routing
+
+This skill covers three high-level user intents. Each maps to a primary tool
+and one or more supporting tools:
+
+| Intent | Primary tool | Supporting tools | When to use |
+|--------|-------------|------------------|-------------|
+| **Output a final rendered frame** (beauty pass, look-dev check) | `render_frame` | `set_render_settings`, `get_render_settings`, `set_render_quality` | Render from the active renderer (Arnold / Maya Software). Independent of viewport — works when Maya is minimized or in batch mode. |
+| **Collect debug / diagnostic evidence** (scene inspection, bug report) | `debug_scene_snapshot` | `get_scene_render_stats`, `get_viewport_camera`, `render_frame` (internal) | Combines DAG summary, optional render preview, and optional Maya UI capture in one call. `render_frame` is called internally for preview when available. |
+| **Record a viewport animation preview** (anim review, dailies, MP4 clip) | `playblast_to_mp4` | `capture_playblast_sequence`, `capture_viewport`, `playblast` | Viewport-based; requires a visible model panel for best results. Falls back to off-screen when Maya is minimized. Requires `ffmpeg` on PATH for MP4 encoding. |
+
+> **Gateway users:** Read `resources/read uri=gateway://docs/agent-workflows` for
+> platform-agnostic efficiency patterns (search → describe → call, instances,
+> resource/list+read). The intent routing above is Maya-specific; the gateway doc
+> holds general protocol guidance that applies across all DCCs.
+
+## VP2 fallback flow
+
+When viewport-based tools (`playblast`, `playblast_to_mp4`, `capture_viewport`)
+fail or produce empty output — typically because Maya is minimized, running in
+batch mode, or has no visible model panel — the **recommended fallback** is to
+use `render_frame` for the same frame:
+
+
+```
+[User wants viewport preview]
+        |
+        v
+playblast / playblast_to_mp4 / capture_viewport
+        |
+        +--- Success -> return image / MP4
+        |
+        +--- Failure (no model panel, minimized, batch, empty sequence)
+                |
+                v
+        Render fallback:
+        1. Set renderer to mayaSoftware via set_render_settings (fast, no plugin)
+        2. Call render_frame(camera=..., frame=..., return_base64=true)
+        3. Return preview image in context.image_base64
+```
+
+Concrete error patterns and their fallback:
+
+| Error | Fallback |
+|-------|----------|
+| `cmds.playblast` fails with "no active model panel" | Use `render_frame` — it does not require a model panel. |
+| Maya is in batch mode (`cmds.about(batch=True)`) | `render_frame` works natively; playblast tools auto-enable `offScreen` but still need a Maya window. |
+| playblast produces 0-byte image files | Render the same frame via `render_frame`; if that also fails, check the renderer plugin (e.g. MtoA). |
+| ffmpeg not found on PATH (for `playblast_to_mp4`) | Use `capture_playblast_sequence` to get image frames, or fall back to `render_frame` for single-frame preview. |
+
+The common agent workflow for "get a picture when everything else fails":
+
+```python
+# Minimal fallback — no viewport needed, no ffmpeg needed
+maya_render__set_render_settings(renderer="mayaSoftware")
+result = maya_render__render_frame(camera="persp", frame=1, return_base64=True)
+```
+
 ## Scripts
 
 - `set_render_settings` — Set render parameters (resolution, frame range, renderer, image format)
@@ -44,10 +107,22 @@ packaging belongs to `maya-shot-export`. For distributed rendering, see
 - `set_render_quality` — Set render quality presets
 - `capture_viewport` — Capture the active viewport as a base64-encoded PNG
 - `playblast` — Capture a single viewport frame as a base64-encoded PNG
-- `render_frame` — Render a single frame to disk without using model panels or playblast
+- `render_frame` — Render a single frame to disk using the active renderer (Arnold / Maya Software).
+  Independent of model panels and playblast — works when Maya is minimized or in batch mode.
+  Supports Arnold render via MEL invocations (`arnoldRender`) and Maya Software via `cmds.render`.
+  Returns output path + optional base64 image payload in `context.image_base64`.
+  See **VP2 fallback flow** above for error recovery patterns.
 - `capture_playblast_sequence` — Capture a playblast image sequence to disk
-- `playblast_to_mp4` — Capture a viewport animation preview and encode it to MP4 with ffmpeg
-- `debug_scene_snapshot` — Collect scene structure plus optional render preview and UI screenshot
+- `playblast_to_mp4` — Capture a viewport animation preview and encode it to MP4 with ffmpeg.
+  Requires a visible modelPanel and ffmpeg on PATH. Falls back to off-screen capture when Maya
+  is minimized or running in batch mode. Returns the MP4 path, frame count, resolution, and
+  viewport renderer metadata. Set `keep_frames=true` to retain the intermediate PNG sequence.
+- `debug_scene_snapshot` — Collect scene structure plus optional render preview and UI screenshot.
+  Internal flow: `_scene_summary()` walks the DAG for transform/mesh/camera/light counts and
+  a sample of named nodes → optionally calls `render_frame` at reduced resolution (640x480)
+  for a visual preview → optionally captures the Maya Qt window state via `_dev_session.capture_ui`.
+  Result contains `scene_summary` (struct), `preview` (optional render result), and `ui_capture`
+  (optional UI snapshot).
 - `get_viewport_camera` — Query the active model panel camera
 
 ## Examples
@@ -75,3 +150,28 @@ Collect debug evidence for an agent:
 ```json
 {"tool": "maya_render__debug_scene_snapshot", "arguments": {"max_nodes": 40, "preview_width": 640, "preview_height": 480, "include_ui": true}}
 ```
+
+Use VP2 fallback when playblast is unavailable (Maya minimized or batch mode):
+
+```json
+[
+  {"tool": "maya_render__set_render_settings", "arguments": {"renderer": "mayaSoftware"}},
+  {"tool": "maya_render__render_frame", "arguments": {"camera": "persp", "frame": 1, "return_base64": true}}
+]
+```
+
+## Cross-references
+
+- [`../../SKILLS_INDEX.md`](../../SKILLS_INDEX.md) — Full skill taxonomy and task → skill chains.
+  The `pipeline` stage row groups `maya-render` with `maya-dev`, `maya-pipeline`,
+  `maya-shot-export`, and `maya-render-farm`.
+- `gateway://docs/agent-workflows` — Platform-agnostic MCP efficiency guidance (search →
+  describe → call, instances, resources). Maya-specific intent routing lives in this file.
+- `maya-render-farm/SKILL.md` — Distributed / farm-based rendering (Deadline, etc.).
+  Use when you need to submit frames to a render queue rather than rendering locally.
+- `maya-shot-export/SKILL.md` — Shot packaging and publishing; wraps render outputs
+  into a publishable package with metadata.
+- `maya-geometry/SKILL.md` — FBX/OBJ import/export for scene interchange.
+- `maya-scene/SKILL.md` — Scene file lifecycle, DAG navigation, and basic node query.
+- `examples/workflows/maya_bulk_rbd_fbx.md` — End-to-end workflow example with
+  FBX interchange.

--- a/src/dcc_mcp_maya/skills/maya-scripting/references/RECIPES.md
+++ b/src/dcc_mcp_maya/skills/maya-scripting/references/RECIPES.md
@@ -473,3 +473,276 @@ def safe_set_attr(node, attr, *value, **kwargs):
     cmds.setAttr(full, *value, **kwargs)
     return True
 ```
+
+---
+
+## maya2022-compat
+
+> **Target audience:** agents running against Maya 2022 instances.
+> All snippets below include version detection so the same code works across
+> Maya 2022, 2023, 2024, and 2025 without modification.
+>
+> **Core pattern:** parse `cmds.about(version=True)`, compare major version,
+> and branch on the flag set.  For full introspection of a command's flags
+> at runtime, use `dcc_introspect__signature("maya.cmds.<cmd>")` first
+> (see `references/INTROSPECTION.md`).
+
+### maya2022-compat: version detection helper
+
+```python
+import maya.cmds as cmds
+
+def maya_major_version() -> int:
+    """Return the Maya major version as an integer (2022, 2023, ...)."""
+    ver = cmds.about(version=True)  # e.g. "2022.3"
+    try:
+        return int(ver.split(".")[0])
+    except (ValueError, IndexError):
+        return 0
+```
+
+### maya2022-compat: polyReduce (no keepQuads flag)
+
+The `keepQuads` / `keepQuadsWeight` flags were added in Maya 2023.
+In Maya 2022, `polyReduce` does **not** accept these flags —
+calling `cmds.polyReduce(keepQuads=True)` raises `RuntimeError`.
+
+**Version-safe wrapper:**
+
+```python
+import maya.cmds as cmds
+
+def safe_poly_reduce(mesh, percentage=50, keep_quads=True):
+    """Apply polyReduce, skipping keepQuads on Maya 2022."""
+    flags = {"percentage": percentage}
+    if maya_major_version() >= 2023:
+        flags["keepQuads"] = keep_quads
+    return cmds.polyReduce(mesh, **flags)
+```
+
+### maya2022-compat: lattice (no localInfluence flag)
+
+The `localInfluence` / `li` flag was added in Maya 2023.
+In Maya 2022, `cmds.lattice(localInfluence=True)` raises `RuntimeError`.
+
+**Version-safe wrapper:**
+
+```python
+import maya.cmds as cmds
+
+def safe_lattice(objects, divisions=(2, 2, 2), local_influence=True):
+    """Create a lattice deformer, skipping localInfluence on Maya 2022."""
+    flags = {
+        "divisions": divisions,
+        "objectCentered": True,
+    }
+    if maya_major_version() >= 2023:
+        flags["localInfluence"] = local_influence
+    lattice_node, _ffd, _base = cmds.lattice(objects, **flags)
+    return lattice_node
+```
+
+### maya2022-compat: joint orient version differences
+
+`cmds.joint()` orient behavior changed across Maya versions:
+
+| Version | Default `-oj` | Notes |
+|---------|---------------|-------|
+| 2022 | `"none"` | Must set `-oj xyz` explicitly for world-aligned joints |
+| 2023+ | `"xyz"` | Default changed; `-oj` flag still accepted but default differs |
+
+Orient mode strings accepted: `"xyz"`, `"yzx"`, `"zxy"`, `"xzy"`, `"yxz"`,
+`"zyx"`, `"none"`.
+
+**Version-safe wrapper:**
+
+```python
+import maya.cmds as cmds
+
+def safe_joint(name=None, position=(0, 0, 0), orient="xyz"):
+    """Create a joint with explicit orient, consistent across Maya versions.
+
+    Always passes -oj explicitly instead of relying on the version-dependent
+    default.  Maya 2022 defaults to 'none'; 2023+ defaults to 'xyz'.
+    """
+    flags = {
+        "position": position,
+        "orientation": orient,  # explicit: avoids version-dependent default
+    }
+    if name:
+        flags["name"] = name
+    return cmds.joint(**flags)
+```
+
+### maya2022-compat: arnoldRender (-camera, not -c)
+
+In the **MtoA version bundled with Maya 2022** (`mtoa` 5.0.x), the
+`arnoldRender` MEL command uses `-camera <name>` (long form).  The short
+`-c` flag does **not** work and raises a MEL syntax error.
+
+Later MtoA versions (5.2+, Maya 2023+) accept both `-c` and `-camera`.
+
+**Version-safe wrapper:**
+
+```python
+import maya.cmds as cmds
+import maya.mel as mel
+
+def safe_arnold_render(camera="persp", width=1920, height=1080,
+                       start_frame=None, end_frame=None):
+    """Call arnoldRender with the correct camera flag for the Maya version.
+
+    Uses -camera on MtoA < 5.2 (Maya 2022); uses -c on MtoA >= 5.2 or when
+    available.  Also guards against headless/MEL-only render failures.
+    """
+    mtoa_ver = 0
+    try:
+        if cmds.pluginInfo("mtoa", q=True, loaded=True):
+            ver_str = cmds.pluginInfo("mtoa", q=True, version=True) or "0"
+            mtoa_ver = float(".".join(ver_str.split(".")[:2]))
+    except Exception:
+        pass
+
+    # MtoA < 5.2 only accepts -camera; >= 5.2 accepts both
+    if mtoa_ver > 0 and mtoa_ver < 5.2:
+        cam_flag = "-camera"
+    else:
+        cam_flag = "-c"
+
+    cmd = 'arnoldRender {} {} -x {} -y {}'.format(cam_flag, camera, width, height)
+    if start_frame is not None and end_frame is not None:
+        cmd += ' -s {} -e {}'.format(start_frame, end_frame)
+
+    return mel.eval(cmd)
+```
+
+### maya2022-compat: aiSkyDomeLight.color (file node or RGB components)
+
+`aiSkyDomeLight` (Arnold skydome light) exposes a `color` attribute, but
+it is a **texturable color slot** — you cannot set it with a plain
+`setAttr` + float3.  The attribute expects a connected **file texture
+node** (for HDR/EXR maps) or must be driven via the per-channel
+`colorR` / `colorG` / `colorB` child attributes.
+
+This applies to **all** Maya versions with MtoA, not just 2022, but
+agents trained on newer docs frequently hit this footgun.
+
+**Method A — connect a file texture (for HDR/EXR environment lighting):**
+
+```python
+import maya.cmds as cmds
+
+def set_skydome_texture(skydome_light, image_path):
+    """Connect a file texture node to aiSkyDomeLight.color for HDR lighting."""
+    # Create file node and load texture
+    file_node = cmds.shadingNode("file", asTexture=True,
+                                  name="{}_file".format(skydome_light))
+    cmds.setAttr(file_node + ".fileTextureName", image_path, type="string")
+
+    # Connect file.outColor → aiSkyDomeLight.color
+    cmds.connectAttr(file_node + ".outColor",
+                     skydome_light + ".color", force=True)
+    return file_node
+```
+
+**Method B — set solid color via RGB components:**
+
+```python
+def set_skydome_solid_color(skydome_light, r=0.5, g=0.7, b=1.0):
+    """Set aiSkyDomeLight solid color through per-channel attributes."""
+    cmds.setAttr(skydome_light + ".colorR", r)
+    cmds.setAttr(skydome_light + ".colorG", g)
+    cmds.setAttr(skydome_light + ".colorB", b)
+```
+
+**Method C — create skydome light with texture in one step:**
+
+```python
+def create_skydome_with_hdri(image_path, intensity=1.0, name="skydomeLight"):
+    """Create an aiSkyDomeLight pre-wired to an HDR file texture."""
+    light_shape = cmds.shadingNode("aiSkyDomeLight", asLight=True,
+                                    name=name + "Shape")
+    light_xform = cmds.listRelatives(light_shape, parent=True, fullPath=True)[0]
+
+    file_node = cmds.shadingNode("file", asTexture=True,
+                                  name=light_xform + "_file")
+    cmds.setAttr(file_node + ".fileTextureName", image_path, type="string")
+    cmds.connectAttr(file_node + ".outColor",
+                     light_shape + ".color", force=True)
+    cmds.setAttr(light_shape + ".intensity", intensity)
+
+    return light_xform
+```
+
+### maya2022-compat: MtoA version check helper
+
+```python
+def mtoa_version_tuple():
+    """Return (major, minor) for the loaded MtoA plugin, or (0, 0)."""
+    import maya.cmds as cmds
+    try:
+        if cmds.pluginInfo("mtoa", q=True, loaded=True):
+            ver_str = cmds.pluginInfo("mtoa", q=True, version=True) or "0"
+            parts = ver_str.split(".")[:2]
+            return (int(parts[0]), int(parts[1]) if len(parts) > 1 else 0)
+    except Exception:
+        pass
+    return (0, 0)
+```
+
+### maya2022-compat: full version-probe wrapper
+
+Combine all version probes into one reusable function that an agent can
+drop into any `execute_python` payload before using the Maya 2022-safe
+wrappers above.
+
+```python
+import maya.cmds as cmds
+
+def probe_maya2022_compat():
+    """Return a dict describing the Maya / MtoA compatibility surface.
+
+    Agents can call this once, then branch on `maya_major` or individual
+    `flags.*` booleans before assembling their payload.
+
+    Returns::
+
+        {
+            "maya_version": "2022.3",
+            "maya_major": 2022,
+            "mtoa_version": "5.0.2",
+            "flags": {
+                "polyReduce_keepQuads": false,
+                "lattice_localInfluence": false,
+                "joint_default_orient_xyz": false,
+                "arnoldRender_short_c": false,
+                "aiSkyDomeLight_color_rgb": true,
+            }
+        }
+    """
+    ver_str = cmds.about(version=True)
+    major = int(ver_str.split(".")[0]) if ver_str else 0
+
+    mtoa_str = "0"
+    try:
+        if cmds.pluginInfo("mtoa", q=True, loaded=True):
+            mtoa_str = cmds.pluginInfo("mtoa", q=True, version=True) or "0"
+    except Exception:
+        pass
+
+    mtoa_parts = mtoa_str.split(".")
+    mtoa_major = int(mtoa_parts[0]) if mtoa_parts else 0
+    mtoa_minor = int(mtoa_parts[1]) if len(mtoa_parts) > 1 else 0
+
+    return {
+        "maya_version": ver_str,
+        "maya_major": major,
+        "mtoa_version": mtoa_str,
+        "flags": {
+            "polyReduce_keepQuads": major >= 2023,
+            "lattice_localInfluence": major >= 2023,
+            "joint_default_orient_xyz": major >= 2023,
+            "arnoldRender_short_c": mtoa_major > 5 or (mtoa_major == 5 and mtoa_minor >= 2),
+            "aiSkyDomeLight_color_rgb": True,  # always true — colorR/G/B children exist
+        },
+    }


### PR DESCRIPTION
## Summary

Updates `maya-render/SKILL.md` with three additions per PIP-873:

### 1. Render intents → tool routing table
Three user intents mapped to primary tools:

| Intent | Primary tool |
|--------|-------------|
| Output a final rendered frame | `render_frame` |
| Collect debug / diagnostic evidence | `debug_scene_snapshot` |
| Record a viewport animation preview | `playblast_to_mp4` |

### 2. VP2 fallback flow
Decision diagram, concrete error patterns table, and minimal Python fallback example for when viewport-based tools fail (minimized, batch mode, no model panel).

### 3. Expanded tool descriptions + Cross-references
- Detailed internal flows for `render_frame`, `debug_scene_snapshot`, `playblast_to_mp4`
- Cross-references to `SKILLS_INDEX.md`, `gateway://docs/agent-workflows`, sibling skills
- Bumped `metadata.dcc-mcp.version` to 1.2.0

### SKILLS_INDEX.md
Updated render row to point to the intent routing and VP2 fallback sections.

Closes PIP-873