### PR TITLE
PIP-1090: Fix Docker Hub registry timeout flakiness in Multi-Instance Gateway Tests CI

### DIFF
--- a/.github/workflows/multi-instance-tests.yml
+++ b/.github/workflows/multi-instance-tests.yml
@@ -44,8 +44,24 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Pre-pull buildkit image (retry on Docker Hub flakiness)
+        continue-on-error: true
+        timeout-minutes: 10
+        run: |
+          echo "Pre-pulling moby/buildkit:buildx-stable-1 with retry..."
+          for i in 1 2 3; do
+            if docker pull moby/buildkit:buildx-stable-1 2>/dev/null; then
+              echo "✓ Buildkit image pulled successfully"
+              exit 0
+            fi
+            echo "⚠ Attempt $i/3 failed, retrying in 15s..."
+            sleep 15
+          done
+          echo "⚠ All pull attempts failed; continuing without pre-pulled image"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        continue-on-error: true
 
       - name: Verify Docker and pull Maya image
         run: |


### PR DESCRIPTION
## Summary
Fix the moby/buildkit:buildx-stable-1 pull timeout flakiness in the Multi-Instance Gateway Tests workflow.

When Docker Hub is transiently unreachable, `docker/setup-buildx-action@v4` fails with:
`Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded`

This cascades to the Test Gate and breaks CI on `main`.

## Changes
1. **Pre-pull buildkit image with retry** — up to 3 attempts (15s interval) to pull `moby/buildkit:buildx-stable-1` before setup-buildx-action runs. If Docker Hub comes back within ~45s, the image is cached and setup-buildx-action uses it without pulling.
2. **continue-on-error** on setup-buildx-action — the actual test steps (`docker pull`, `docker run` via tests) do **not** require buildx. If builder creation still fails, the job continues instead of aborting.

## Test plan
- [ ] CI run passes on this PR
- [ ] Force CI re-run against main to verify no regression
