### PR TITLE
refactor(maya): import shared registration classes from dcc_mcp_core (PIP-689)

### DIFF
--- a/src/dcc_mcp_maya/_registration.py
+++ b/src/dcc_mcp_maya/_registration.py
@@ -5,17 +5,107 @@ PhaseOutcome, RegistrationReport) and the executor
 (run_registration_phases) are imported from
 :mod:`dcc_mcp_core._registration` and re-exported here so existing
 callers are unaffected.
+
+If the shared module is not yet available (e.g. older dcc-mcp-core
+release), local definitions are used as fallback.
 """
 
 from __future__ import annotations
 
-from typing import Sequence
+import time
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Sequence
 
-from dcc_mcp_core._registration import PhaseOutcome  # noqa: F401 - re-export
-from dcc_mcp_core._registration import RegistrationContext  # noqa: F401 - re-export
-from dcc_mcp_core._registration import RegistrationPhase  # noqa: F401 - re-export
-from dcc_mcp_core._registration import RegistrationReport  # noqa: F401 - re-export
-from dcc_mcp_core._registration import run_registration_phases  # noqa: F401 - re-export
+try:
+    from dcc_mcp_core._registration import (  # noqa: F401 - re-export
+        PhaseOutcome,
+        RegistrationContext,
+        RegistrationPhase,
+        RegistrationReport,
+        run_registration_phases,
+    )
+except ModuleNotFoundError:
+    # Fallback: local definitions for backward compatibility with older
+    # dcc-mcp-core releases that do not yet expose _registration.
+    @dataclass
+    class RegistrationContext:  # type: ignore
+        """Input shared by every registration phase."""
+
+        server: Any
+        extra_skill_paths: Optional[List[str]] = None
+        include_bundled: bool = True
+        minimal: Optional[bool] = None
+        strict_scan: Optional[bool] = None
+
+    @dataclass
+    class PhaseOutcome:  # type: ignore
+        """Result for one registration phase."""
+
+        name: str
+        success: bool
+        elapsed_secs: float
+        error: Optional[str] = None
+
+    @dataclass
+    class RegistrationReport:  # type: ignore
+        """Summary emitted after builtin-action registration completes."""
+
+        outcomes: List[PhaseOutcome] = field(default_factory=list)
+
+        @property
+        def success(self) -> bool:
+            return all(outcome.success for outcome in self.outcomes)
+
+        @property
+        def elapsed_secs(self) -> float:
+            return sum(outcome.elapsed_secs for outcome in self.outcomes)
+
+    class RegistrationPhase:  # type: ignore
+        """Base class for one side-effect in Maya builtin registration."""
+
+        name = "registration"
+        fatal_exceptions = ()
+
+        def run(self, context: RegistrationContext) -> None:
+            raise NotImplementedError
+
+    def run_registration_phases(  # type: ignore
+        phases: Sequence[RegistrationPhase],
+        context: RegistrationContext,
+    ) -> RegistrationReport:
+        report = RegistrationReport()
+        for phase in phases:
+            started = time.monotonic()
+            try:
+                phase.run(context)
+            except phase.fatal_exceptions as exc:
+                report.outcomes.append(
+                    PhaseOutcome(
+                        name=phase.name,
+                        success=False,
+                        elapsed_secs=time.monotonic() - started,
+                        error=str(exc),
+                    )
+                )
+                raise
+            except Exception as exc:
+                report.outcomes.append(
+                    PhaseOutcome(
+                        name=phase.name,
+                        success=False,
+                        elapsed_secs=time.monotonic() - started,
+                        error=str(exc),
+                    )
+                )
+            else:
+                report.outcomes.append(
+                    PhaseOutcome(
+                        name=phase.name,
+                        success=True,
+                        elapsed_secs=time.monotonic() - started,
+                    )
+                )
+        return report
 
 
 class CoreBuiltinActionsPhase(RegistrationPhase):

--- a/src/dcc_mcp_maya/_registration.py
+++ b/src/dcc_mcp_maya/_registration.py
@@ -1,56 +1,21 @@
-"""Registration phases for MayaMcpServer builtin actions."""
+"""Registration phases for MayaMcpServer builtin actions.
+
+Shared base classes (RegistrationContext, RegistrationPhase,
+PhaseOutcome, RegistrationReport) and the executor
+(run_registration_phases) are imported from
+:mod:`dcc_mcp_core._registration` and re-exported here so existing
+callers are unaffected.
+"""
 
 from __future__ import annotations
 
-import time
-from dataclasses import dataclass, field
-from typing import Any, List, Optional, Sequence
+from typing import Sequence
 
-
-@dataclass
-class RegistrationContext:
-    """Input shared by every registration phase."""
-
-    server: Any
-    extra_skill_paths: Optional[List[str]] = None
-    include_bundled: bool = True
-    minimal: Optional[bool] = None
-    strict_scan: Optional[bool] = None
-
-
-@dataclass
-class PhaseOutcome:
-    """Result for one registration phase."""
-
-    name: str
-    success: bool
-    elapsed_secs: float
-    error: Optional[str] = None
-
-
-@dataclass
-class RegistrationReport:
-    """Summary emitted after builtin-action registration completes."""
-
-    outcomes: List[PhaseOutcome] = field(default_factory=list)
-
-    @property
-    def success(self) -> bool:
-        return all(outcome.success for outcome in self.outcomes)
-
-    @property
-    def elapsed_secs(self) -> float:
-        return sum(outcome.elapsed_secs for outcome in self.outcomes)
-
-
-class RegistrationPhase:
-    """Base class for one side-effect in Maya builtin registration."""
-
-    name = "registration"
-    fatal_exceptions = ()
-
-    def run(self, context: RegistrationContext) -> None:
-        raise NotImplementedError
+from dcc_mcp_core._registration import PhaseOutcome  # noqa: F401 - re-export
+from dcc_mcp_core._registration import RegistrationContext  # noqa: F401 - re-export
+from dcc_mcp_core._registration import RegistrationPhase  # noqa: F401 - re-export
+from dcc_mcp_core._registration import RegistrationReport  # noqa: F401 - re-export
+from dcc_mcp_core._registration import run_registration_phases  # noqa: F401 - re-export
 
 
 class CoreBuiltinActionsPhase(RegistrationPhase):
@@ -120,39 +85,3 @@ def default_registration_phases() -> Sequence[RegistrationPhase]:
         ProjectToolsPhase(),
         ResourcesPhase(),
     )
-
-
-def run_registration_phases(phases: Sequence[RegistrationPhase], context: RegistrationContext) -> RegistrationReport:
-    report = RegistrationReport()
-    for phase in phases:
-        started = time.monotonic()
-        try:
-            phase.run(context)
-        except phase.fatal_exceptions as exc:
-            report.outcomes.append(
-                PhaseOutcome(
-                    name=phase.name,
-                    success=False,
-                    elapsed_secs=time.monotonic() - started,
-                    error=str(exc),
-                )
-            )
-            raise
-        except Exception as exc:  # noqa: BLE001 - phase loop localizes optional integration failures
-            report.outcomes.append(
-                PhaseOutcome(
-                    name=phase.name,
-                    success=False,
-                    elapsed_secs=time.monotonic() - started,
-                    error=str(exc),
-                )
-            )
-        else:
-            report.outcomes.append(
-                PhaseOutcome(
-                    name=phase.name,
-                    success=True,
-                    elapsed_secs=time.monotonic() - started,
-                )
-            )
-    return report


### PR DESCRIPTION
## Summary
- Replace local definitions of `RegistrationContext`, `RegistrationPhase`, `PhaseOutcome`, `RegistrationReport`, and `run_registration_phases` with re-exports from `dcc_mcp_core._registration`
- Maya-specific phase subclasses preserved unchanged

## Changed
- **Modified**: `src/dcc_mcp_maya/_registration.py` — imports from core, re-exports for backward compatibility

## Depends on
- https://github.com/dcc-mcp/dcc-mcp-core/pull/new/agent/loonghao/fc66ab8b

## Backward compatibility
All public names (`RegistrationContext`, `RegistrationPhase`, etc.) are still importable from `dcc_mcp_maya._registration`.