### PR TITLE
feat: adapt to dcc-mcp-core v0.18.14 (shared registration + 4 seam controllers)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # Release Train anchor: dcc-mcp-core v0.18.9 (PIP-908).
+    # Release Train anchor: dcc-mcp-core v0.18.14 (PIP-688/689).
+    # 4 seam controllers + shared registration phase pipeline.
     # Provides abi3 (cp38+) on 3.8+; separate cp37 wheels on Python 3.7 (Maya 2022).
-    "dcc-mcp-core>=0.18.9,<1.0.0",
+    "dcc-mcp-core>=0.18.14,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_maya/_registration.py
+++ b/src/dcc_mcp_maya/_registration.py
@@ -3,109 +3,23 @@
 Shared base classes (RegistrationContext, RegistrationPhase,
 PhaseOutcome, RegistrationReport) and the executor
 (run_registration_phases) are imported from
-:mod:`dcc_mcp_core._registration` and re-exported here so existing
-callers are unaffected.
+:mod:`dcc_mcp_core._registration` (PIP-689, core v0.18.14+).
 
-If the shared module is not yet available (e.g. older dcc-mcp-core
-release), local definitions are used as fallback.
+Adapters define their own phase subclasses here for host-specific
+registration steps.
 """
 
 from __future__ import annotations
 
-import time
-from dataclasses import dataclass, field
-from typing import Any, List, Optional, Sequence
+from typing import Sequence
 
-try:
-    from dcc_mcp_core._registration import (  # noqa: F401 - re-export
-        PhaseOutcome,
-        RegistrationContext,
-        RegistrationPhase,
-        RegistrationReport,
-        run_registration_phases,
-    )
-except ModuleNotFoundError:
-    # Fallback: local definitions for backward compatibility with older
-    # dcc-mcp-core releases that do not yet expose _registration.
-    @dataclass
-    class RegistrationContext:  # type: ignore
-        """Input shared by every registration phase."""
-
-        server: Any
-        extra_skill_paths: Optional[List[str]] = None
-        include_bundled: bool = True
-        minimal: Optional[bool] = None
-        strict_scan: Optional[bool] = None
-
-    @dataclass
-    class PhaseOutcome:  # type: ignore
-        """Result for one registration phase."""
-
-        name: str
-        success: bool
-        elapsed_secs: float
-        error: Optional[str] = None
-
-    @dataclass
-    class RegistrationReport:  # type: ignore
-        """Summary emitted after builtin-action registration completes."""
-
-        outcomes: List[PhaseOutcome] = field(default_factory=list)
-
-        @property
-        def success(self) -> bool:
-            return all(outcome.success for outcome in self.outcomes)
-
-        @property
-        def elapsed_secs(self) -> float:
-            return sum(outcome.elapsed_secs for outcome in self.outcomes)
-
-    class RegistrationPhase:  # type: ignore
-        """Base class for one side-effect in Maya builtin registration."""
-
-        name = "registration"
-        fatal_exceptions = ()
-
-        def run(self, context: RegistrationContext) -> None:
-            raise NotImplementedError
-
-    def run_registration_phases(  # type: ignore
-        phases: Sequence[RegistrationPhase],
-        context: RegistrationContext,
-    ) -> RegistrationReport:
-        report = RegistrationReport()
-        for phase in phases:
-            started = time.monotonic()
-            try:
-                phase.run(context)
-            except phase.fatal_exceptions as exc:
-                report.outcomes.append(
-                    PhaseOutcome(
-                        name=phase.name,
-                        success=False,
-                        elapsed_secs=time.monotonic() - started,
-                        error=str(exc),
-                    )
-                )
-                raise
-            except Exception as exc:
-                report.outcomes.append(
-                    PhaseOutcome(
-                        name=phase.name,
-                        success=False,
-                        elapsed_secs=time.monotonic() - started,
-                        error=str(exc),
-                    )
-                )
-            else:
-                report.outcomes.append(
-                    PhaseOutcome(
-                        name=phase.name,
-                        success=True,
-                        elapsed_secs=time.monotonic() - started,
-                    )
-                )
-        return report
+from dcc_mcp_core._registration import (
+    PhaseOutcome,
+    RegistrationContext,
+    RegistrationPhase,
+    RegistrationReport,
+    run_registration_phases,
+)
 
 
 class CoreBuiltinActionsPhase(RegistrationPhase):

--- a/src/dcc_mcp_maya/_registration.py
+++ b/src/dcc_mcp_maya/_registration.py
@@ -14,11 +14,9 @@ from __future__ import annotations
 from typing import Sequence
 
 from dcc_mcp_core._registration import (
-    PhaseOutcome,
     RegistrationContext,
     RegistrationPhase,
-    RegistrationReport,
-    run_registration_phases,
+    run_registration_phases,  # noqa: F401 - re-exported for callers
 )
 
 

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -82,7 +82,7 @@ class TestCollectSkillSearchPathsCoverage:
         srv = _make_bare_server(builtin_dir=fake_builtin)
         with patch("dcc_mcp_core.get_app_skill_paths_from_env", return_value=[]), patch(
             "dcc_mcp_core._core.get_skill_paths_from_env", return_value=[], create=True
-        ), patch("dcc_mcp_core.server_base.get_skills_dir", return_value=None):
+        ), patch("dcc_mcp_core._server.skill_discovery.get_skills_dir", return_value=None):
             paths = srv.collect_skill_search_paths(include_bundled=False)
         assert str(fake_builtin) not in paths
 
@@ -90,7 +90,7 @@ class TestCollectSkillSearchPathsCoverage:
         """get_skills_dir() result is appended when not already in paths."""
         sentinel = "/sentinel/default/skills"
         srv = _make_bare_server()
-        with patch("dcc_mcp_core.server_base.get_skills_dir", return_value=sentinel), patch(
+        with patch("dcc_mcp_core._server.skill_discovery.get_skills_dir", return_value=sentinel), patch(
             "dcc_mcp_core.get_app_skill_paths_from_env", return_value=[]
         ), patch("dcc_mcp_core.get_skill_paths_from_env", return_value=[]):
             paths = srv.collect_skill_search_paths(include_bundled=False)
@@ -104,7 +104,7 @@ class TestCollectSkillSearchPathsCoverage:
         srv = _make_bare_server()
         with patch("dcc_mcp_core.get_app_skill_paths_from_env", return_value=[]), patch(
             "dcc_mcp_core._core.get_skill_paths_from_env", return_value=[], create=True
-        ), patch("dcc_mcp_core.server_base.get_skills_dir", return_value=builtin):
+        ), patch("dcc_mcp_core._server.skill_discovery.get_skills_dir", return_value=builtin):
             paths = srv.collect_skill_search_paths(include_bundled=False)
         assert paths.count(builtin) == 1
 
@@ -113,7 +113,7 @@ class TestCollectSkillSearchPathsCoverage:
         srv = _make_bare_server()
         with patch("dcc_mcp_core.get_app_skill_paths_from_env", return_value=[]), patch(
             "dcc_mcp_core._core.get_skill_paths_from_env", return_value=[], create=True
-        ), patch("dcc_mcp_core.server_base.get_skills_dir", return_value=None):
+        ), patch("dcc_mcp_core._server.skill_discovery.get_skills_dir", return_value=None):
             paths = srv.collect_skill_search_paths(include_bundled=False)
         assert None not in paths
 


### PR DESCRIPTION
## Summary

Adapt dcc-mcp-maya to dcc-mcp-core v0.18.14 changes:

- **PIP-689 (shared registration)**: Remove local fallback definitions in `_registration.py` and import unconditionally from `dcc_mcp_core._registration`. The shared pipeline was extracted from Maya adapter in core v0.18.14.
- **PIP-688 (4 seam controllers)**: No adapter-side API changes needed — `DccServerBase` already delegates to the 4 controllers. Fixed 4 test mocks that referenced the old `get_skills_dir` location (moved from `server_base` to `_server.skill_discovery`).
- **Dependency**: Bump minimum `dcc-mcp-core` from `>=0.18.9` to `>=0.18.14`.

## Files changed

| File | Change |
|------|--------|
| `pyproject.toml` | Bump core dep to `>=0.18.14` |
| `src/dcc_mcp_maya/_registration.py` | Remove fallback; unconditional import from core |
| `tests/test_server_coverage.py` | Fix `get_skills_dir` mock paths |

## Test plan

- [x] All 74 unit tests pass locally
- [ ] CI all-green
- [ ] Review gate: loonghao

Refs: PIP-1259