### PR TITLE
fix: align core registration and gateway runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Maya plugin starts a Rust `dcc-mcp-server` sidecar by default, so HTTP and g
 [![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-maya?label=Python)](https://pypi.org/project/dcc-mcp-maya/)
 [![Maya](https://img.shields.io/badge/Maya-2020%2B-37A5CC)](https://www.autodesk.com/products/maya/overview)
 [![MCP](https://img.shields.io/badge/MCP-Streamable%20HTTP-6f42c1)](https://modelcontextprotocol.io/)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.43-blue)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.18.17-blue)](https://github.com/loonghao/dcc-mcp-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ## Why Use It
@@ -47,11 +47,11 @@ The agent should follow
 which delegates the setup workflow to
 [`skills/dcc-mcp-maya-setup`](https://github.com/loonghao/dcc-mcp-maya/tree/main/skills/dcc-mcp-maya-setup).
 
-Install into Maya's Python. Include the `sidecar` extra unless your studio
-already ships the `dcc-mcp-server` binary:
+Install into Maya's Python. The normal install includes the standard
+`dcc-mcp-server` runtime used by the default gateway path:
 
 ```bash
-mayapy -m pip install "dcc-mcp-maya[sidecar]"
+mayapy -m pip install dcc-mcp-maya
 ```
 
 Load the Maya plugin from `maya/plugin/dcc_mcp_maya_plugin.py` with
@@ -156,32 +156,23 @@ See [`src/dcc_mcp_maya/skills/SKILLS_INDEX.md`](src/dcc_mcp_maya/skills/SKILLS_I
 ### PyPI
 
 ```bash
-mayapy -m pip install "dcc-mcp-maya[sidecar]"
-```
-
-If your environment already provides `dcc-mcp-server`, the base package is
-enough:
-
-```bash
 mayapy -m pip install dcc-mcp-maya
 ```
 
 ### Maya Module ZIPs
 
 Release module archives bundle the Maya plugin, `dcc-mcp-maya`, and the
-in-process Python bridge dependencies such as `dcc-mcp-core`. They do not bundle
-the external `dcc-mcp-server` sidecar binary used by default plugin gateway
-mode. On clean machines, install or provide the sidecar runtime before loading
-the plugin:
+in-process Python bridge dependencies such as `dcc-mcp-core`, plus the
+`dcc-mcp-server` sidecar binary used by the default plugin gateway mode.
+Clean-machine verification:
 
 ```bash
-mayapy -m pip install "dcc-mcp-server>=0.17.43"
 mayapy -c "from dcc_mcp_maya.sidecar import resolve_sidecar_binary; print(resolve_sidecar_binary())"
 ```
 
-Alternatively, set `DCC_MCP_SERVER_BIN` to the sidecar executable, put
-`dcc-mcp-server` on `PATH`, or set `DCC_MCP_MAYA_SIDECAR=0` before loading the
-plugin to use the legacy in-process gateway path.
+Set `DCC_MCP_SERVER_BIN` only when you want to override the bundled sidecar
+executable. Set `DCC_MCP_MAYA_SIDECAR=0` before loading the plugin to use the
+legacy in-process gateway path.
 
 ### Maya Plugin
 
@@ -372,8 +363,8 @@ Windows symlinks require Developer Mode or an elevated shell. If symlinks are un
 
 - Autodesk Maya 2020+
 - Python 3.7+
-- `dcc-mcp-core>=0.17.43,<1.0.0`
-- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.17.43`
+- `dcc-mcp-core>=0.18.17,<1.0.0`
+- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.18.17`
 
 ## License
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -12,17 +12,14 @@ Get Maya talking to an MCP host in under 5 minutes.
 Install into Maya's Python interpreter:
 
 ```bash
-mayapy -m pip install "dcc-mcp-maya[sidecar]"
+mayapy -m pip install dcc-mcp-maya
 ```
 
 For a specific Maya version (Windows example):
 
 ```bash
-"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install "dcc-mcp-maya[sidecar]"
+"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install dcc-mcp-maya
 ```
-
-Use `dcc-mcp-maya` without `[sidecar]` only when your environment already
-provides the `dcc-mcp-server` binary.
 
 ## Step 2 — Load the Maya Plugin
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -4,7 +4,8 @@
 
 - **Maya**: 2020+ (tested with Maya 2022 through 2026 module packages)
 - **Python**: 3.7 – 3.12 (embedded in Maya)
-- **dcc-mcp-core**: ≥ 0.17.31 (auto-installed as dependency)
+- **dcc-mcp-core**: ≥ 0.18.17 (auto-installed as dependency)
+- **dcc-mcp-server**: ≥ 0.18.17 (auto-installed as dependency for the default sidecar gateway)
 
 ## Method 1 — pip into mayapy
 
@@ -12,13 +13,13 @@ The simplest approach. Use Maya's own Python interpreter:
 
 ```bash
 # Generic
-mayapy -m pip install "dcc-mcp-maya[sidecar]"
+mayapy -m pip install dcc-mcp-maya
 
 # Windows — Maya 2024
-"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install "dcc-mcp-maya[sidecar]"
+"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install dcc-mcp-maya
 
 # macOS — Maya 2024
-/Applications/Autodesk/maya2024/Maya.app/Contents/bin/mayapy -m pip install "dcc-mcp-maya[sidecar]"
+/Applications/Autodesk/maya2024/Maya.app/Contents/bin/mayapy -m pip install dcc-mcp-maya
 ```
 
 Verify installation:
@@ -27,15 +28,10 @@ Verify installation:
 mayapy -c "import dcc_mcp_maya; print(dcc_mcp_maya.__version__)"
 ```
 
-Use `dcc-mcp-maya` without `[sidecar]` only when your environment already
-provides the `dcc-mcp-server` binary.
-
 Release module ZIPs follow the same rule: they include the Maya plugin,
-`dcc-mcp-maya`, and the in-process bridge dependencies such as `dcc-mcp-core`,
-but they do not bundle the external `dcc-mcp-server` sidecar binary. For clean
-module deployments, install `dcc-mcp-server>=0.17.31` into the matching
-`mayapy`, set `DCC_MCP_SERVER_BIN`, or put `dcc-mcp-server` on `PATH`. Verify
-with `mayapy -c "from dcc_mcp_maya.sidecar import resolve_sidecar_binary; print(resolve_sidecar_binary())"`.
+`dcc-mcp-maya`, the in-process bridge dependencies such as `dcc-mcp-core`, and
+the `dcc-mcp-server` sidecar binary used by the default gateway path. Verify
+clean module deployments with `mayapy -c "from dcc_mcp_maya.sidecar import resolve_sidecar_binary; print(resolve_sidecar_binary())"`.
 
 ## Method 2 — Maya Plugin
 
@@ -142,13 +138,13 @@ Each Maya version has its own Python interpreter. Install separately per version
 
 ```bash
 # Maya 2022 (Python 3.7)
-"C:\Program Files\Autodesk\Maya2022\bin\mayapy.exe" -m pip install "dcc-mcp-maya[sidecar]"
+"C:\Program Files\Autodesk\Maya2022\bin\mayapy.exe" -m pip install dcc-mcp-maya
 
 # Maya 2024
-"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install "dcc-mcp-maya[sidecar]"
+"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install dcc-mcp-maya
 
 # Maya 2025
-"C:\Program Files\Autodesk\Maya2025\bin\mayapy.exe" -m pip install "dcc-mcp-maya[sidecar]"
+"C:\Program Files\Autodesk\Maya2025\bin\mayapy.exe" -m pip install dcc-mcp-maya
 ```
 
 If running multiple Maya instances simultaneously, plugin gateway mode is

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -12,17 +12,14 @@
 将包安装到 Maya 的 Python 解释器中：
 
 ```bash
-mayapy -m pip install "dcc-mcp-maya[sidecar]"
+mayapy -m pip install dcc-mcp-maya
 ```
 
 Windows 指定 Maya 版本的示例：
 
 ```bash
-"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install "dcc-mcp-maya[sidecar]"
+"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install dcc-mcp-maya
 ```
-
-只有当你的环境已经提供 `dcc-mcp-server` binary 时，才使用不带
-`[sidecar]` 的基础包。
 
 ## 第二步 — 加载 Maya 插件
 

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -4,7 +4,8 @@
 
 - **Maya**：2020+（模块包覆盖 Maya 2022 至 2026）
 - **Python**：3.7 – 3.12（Maya 内嵌）
-- **dcc-mcp-core**：≥ 0.17.31（作为依赖自动安装）
+- **dcc-mcp-core**：≥ 0.18.17（作为依赖自动安装）
+- **dcc-mcp-server**：≥ 0.18.17（默认 sidecar gateway 运行时，作为依赖自动安装）
 
 ## 方式一 — pip 安装到 mayapy
 
@@ -12,13 +13,13 @@
 
 ```bash
 # 通用
-mayapy -m pip install "dcc-mcp-maya[sidecar]"
+mayapy -m pip install dcc-mcp-maya
 
 # Windows — Maya 2024
-"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install "dcc-mcp-maya[sidecar]"
+"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install dcc-mcp-maya
 
 # macOS — Maya 2024
-/Applications/Autodesk/maya2024/Maya.app/Contents/bin/mayapy -m pip install "dcc-mcp-maya[sidecar]"
+/Applications/Autodesk/maya2024/Maya.app/Contents/bin/mayapy -m pip install dcc-mcp-maya
 ```
 
 验证安装：
@@ -26,9 +27,6 @@ mayapy -m pip install "dcc-mcp-maya[sidecar]"
 ```bash
 mayapy -c "import dcc_mcp_maya; print(dcc_mcp_maya.__version__)"
 ```
-
-只有当你的环境已经提供 `dcc-mcp-server` binary 时，才使用不带
-`[sidecar]` 的基础包。
 
 ## 方式二 — Maya 插件
 
@@ -130,13 +128,13 @@ gateway URL：`http://127.0.0.1:9765/mcp`。
 
 ```bash
 # Maya 2022（Python 3.7）
-"C:\Program Files\Autodesk\Maya2022\bin\mayapy.exe" -m pip install "dcc-mcp-maya[sidecar]"
+"C:\Program Files\Autodesk\Maya2022\bin\mayapy.exe" -m pip install dcc-mcp-maya
 
 # Maya 2024
-"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install "dcc-mcp-maya[sidecar]"
+"C:\Program Files\Autodesk\Maya2024\bin\mayapy.exe" -m pip install dcc-mcp-maya
 
 # Maya 2025
-"C:\Program Files\Autodesk\Maya2025\bin\mayapy.exe" -m pip install "dcc-mcp-maya[sidecar]"
+"C:\Program Files\Autodesk\Maya2025\bin\mayapy.exe" -m pip install dcc-mcp-maya
 ```
 
 同时运行多个 Maya 实例时，插件 gateway 模式更简单：所有实例都会注册到

--- a/packaging/README-pipeline.txt
+++ b/packaging/README-pipeline.txt
@@ -5,10 +5,8 @@ This package is designed for network-share deployment in pipeline
 environments. No install scripts are included.
 
 The module content includes the Maya plugin, dcc-mcp-maya Python
-package, and the in-process bridge dependencies such as dcc-mcp-core.
-It does not bundle the external dcc-mcp-server sidecar binary. Default
-plugin gateway mode needs that binary to be available from the same
-environment that launches Maya.
+package, the in-process bridge dependencies such as dcc-mcp-core, and
+the dcc-mcp-server sidecar binary used by the default gateway path.
 
 Deployment Options
 ------------------
@@ -40,14 +38,11 @@ userSetup.py.
 
 Sidecar runtime
 ---------------
-Default plugin mode starts a dcc-mcp-server sidecar and exposes the
-gateway at http://127.0.0.1:9765/mcp. Provide dcc-mcp-server >= 0.17.23
-for every Maya environment that consumes this network module.
+Default plugin mode starts the bundled dcc-mcp-server sidecar and exposes
+the gateway at http://127.0.0.1:9765/mcp.
 
 Common deployment options:
 
-- Install into each target mayapy:
-    mayapy -m pip install "dcc-mcp-server>=0.17.23"
 - Set DCC_MCP_SERVER_BIN to a centrally managed dcc-mcp-server path.
 - Put dcc-mcp-server on PATH in the launcher that starts Maya.
 - Set DCC_MCP_MAYA_SIDECAR=0 before loading the plugin to use the

--- a/packaging/README.txt
+++ b/packaging/README.txt
@@ -2,17 +2,14 @@ DCC-MCP-Maya — Maya Module Distribution
 ========================================
 
 Offline Maya .mod module package. Contains the MCP Streamable HTTP
-server plugin and the Python dependencies needed by the in-process
-Maya bridge (including dcc-mcp-core).
-
-This ZIP does not bundle the external dcc-mcp-server sidecar binary.
-Default plugin gateway mode needs that binary to be available from the
-same environment that launches Maya.
+server plugin, the Python dependencies needed by the in-process Maya
+bridge (including dcc-mcp-core), and the dcc-mcp-server sidecar binary
+used by the default gateway path.
 
 Requirements
 ------------
 - Autodesk Maya 2022, 2023, 2024, 2025, or 2026 (matching platform ZIP; Maya 2022 requires python37/, available in Windows/Linux packages)
-- dcc-mcp-server >= 0.17.31 for default sidecar gateway mode, unless your studio provides the binary on PATH or via DCC_MCP_SERVER_BIN
+- Bundled dcc-mcp-server >= 0.18.17 for default sidecar gateway mode
 
 Installation
 ------------
@@ -27,11 +24,8 @@ files stay where you extracted them — only the .mod pointer is copied.
 
 Sidecar runtime
 ---------------
-Default plugin mode starts a dcc-mcp-server sidecar and exposes the
-gateway at http://127.0.0.1:9765/mcp. Install or provide the sidecar
-runtime before loading the plugin on a clean machine:
-
-  mayapy -m pip install "dcc-mcp-server>=0.17.31"
+Default plugin mode starts the bundled dcc-mcp-server sidecar and exposes
+the gateway at http://127.0.0.1:9765/mcp.
 
 Clean-machine verification:
 

--- a/packaging/assemble_mod.py
+++ b/packaging/assemble_mod.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -35,7 +36,17 @@ PLATFORMS_WITH_CP37_WHEELS = {"win64", "linux"}
 
 
 def resolve_core_version(project_root: Path) -> str:
-    """Resolve the best available dcc-mcp-core version from PyPI.
+    """Resolve the best available dcc-mcp-core version from PyPI."""
+    return _resolve_dependency_version(project_root, "dcc-mcp-core")
+
+
+def resolve_server_version(project_root: Path) -> str:
+    """Resolve the best available dcc-mcp-server version from PyPI."""
+    return _resolve_dependency_version(project_root, "dcc-mcp-server")
+
+
+def _resolve_dependency_version(project_root: Path, package_name: str) -> str:
+    """Resolve the best available dependency version from PyPI.
 
     Reads the minimum version from pyproject.toml, then queries PyPI
     for the latest compatible version.  Falls back to the minimum
@@ -45,11 +56,12 @@ def resolve_core_version(project_root: Path) -> str:
 
     toml_path = project_root / "pyproject.toml"
     content = toml_path.read_text(encoding="utf-8")
-    m = re.search(r"dcc-mcp-core>=(\d+\.\d+\.\d+)", content)
+    escaped = re.escape(package_name)
+    m = re.search(rf"{escaped}>=(\d+\.\d+\.\d+)", content)
     if not m:
-        m = re.search(r"dcc-mcp-core>=([\d.]+)", content)
+        m = re.search(rf"{escaped}>=([\d.]+)", content)
     if not m:
-        raise RuntimeError("Cannot find dcc-mcp-core version in pyproject.toml")
+        raise RuntimeError(f"Cannot find {package_name} version in pyproject.toml")
     min_version = m.group(1)
 
     # Try to get the latest version from PyPI so we download a version
@@ -57,15 +69,15 @@ def resolve_core_version(project_root: Path) -> str:
     try:
         import urllib.request
 
-        url = "https://pypi.org/pypi/dcc-mcp-core/json"
+        url = f"https://pypi.org/pypi/{package_name}/json"
         with urllib.request.urlopen(url, timeout=15) as resp:
             data = json.loads(resp.read())
         latest = data.get("info", {}).get("version", "")
         if latest and _version_gte(latest, min_version):
-            print(f"  PyPI latest dcc-mcp-core: {latest} (>= {min_version})")
+            print(f"  PyPI latest {package_name}: {latest} (>= {min_version})")
             return latest
     except Exception as exc:
-        print(f"  Warning: could not query PyPI for latest version ({exc}), using minimum {min_version}")
+        print(f"  Warning: could not query PyPI for latest {package_name} ({exc}), using minimum {min_version}")
 
     return min_version
 
@@ -123,6 +135,39 @@ def download_core_wheels(version: str, platform: str, dest: Path) -> List[Path]:
     return wheels
 
 
+def download_server_wheel(version: str, platform: str, dest: Path) -> Path:
+    """Download the dcc-mcp-server sidecar wheel for the target platform."""
+    import urllib.request
+
+    pypi_url = f"https://pypi.org/pypi/dcc-mcp-server/{version}/json"
+    print(f"  Querying PyPI: {pypi_url}")
+    with urllib.request.urlopen(pypi_url, timeout=30) as resp:
+        pypi_data = json.loads(resp.read())
+
+    releases = pypi_data.get("releases", {})
+    version_files = releases.get(version, [])
+    if not version_files:
+        version_files = pypi_data.get("urls", [])
+
+    file_map = {f["filename"]: f["url"] for f in version_files if f.get("packagetype") == "bdist_wheel"}
+    patterns = _server_wheel_patterns(platform)
+    for pattern in patterns:
+        matching = [fn for fn in file_map if pattern in fn]
+        if not matching:
+            continue
+        filename = matching[0]
+        dest_file = dest / filename
+        if dest_file.exists():
+            print(f"  Already cached: {filename}")
+            return dest_file
+        print(f"  Downloading {filename} (sidecar server)...")
+        urllib.request.urlretrieve(file_map[filename], str(dest_file))
+        return dest_file
+    raise RuntimeError(
+        f"No dcc-mcp-server wheel matching {patterns!r} found on PyPI for platform={platform}, version={version}"
+    )
+
+
 def _core_wheel_patterns(platform: str) -> List[Tuple[str, str]]:
     if platform == "win64":
         return [("cp37-cp37m-win_amd64", "cp37, win_amd64"), ("cp38-abi3-win_amd64", "cp38-abi3, win_amd64")]
@@ -133,6 +178,16 @@ def _core_wheel_patterns(platform: str) -> List[Tuple[str, str]]:
         ]
     if platform == "macos":
         return [("cp38-abi3-macosx", "cp38-abi3, macosx universal2")]
+    return []
+
+
+def _server_wheel_patterns(platform: str) -> List[str]:
+    if platform == "win64":
+        return ["win_amd64"]
+    if platform == "linux":
+        return ["manylinux", "linux_x86_64"]
+    if platform == "macos":
+        return ["macosx"]
     return []
 
 
@@ -171,6 +226,39 @@ def extract_wheel(
             dest_file.parent.mkdir(parents=True, exist_ok=True)
             with zf.open(info) as src, open(dest_file, "wb") as dst:
                 dst.write(src.read())
+            mode = info.external_attr >> 16
+            if mode:
+                os.chmod(dest_file, mode)
+
+
+def extract_server_wheel(wheel_path: Path, dest: Path) -> None:
+    """Extract dcc-mcp-server package files and its binary into *dest*.
+
+    ``pip install`` maps ``*.data/scripts/dcc-mcp-server`` into the target
+    environment's scripts directory.  Module ZIP assembly extracts wheels
+    directly, so we perform that mapping explicitly.
+    """
+    import zipfile
+
+    with zipfile.ZipFile(str(wheel_path)) as zf:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            parts = Path(info.filename).parts
+            if any(p.endswith(".dist-info") for p in parts):
+                continue
+            if len(parts) >= 3 and parts[0].endswith(".data") and parts[1] == "scripts":
+                dest_file = dest / "scripts" / Path(*parts[2:])
+            elif parts[0] == "dcc_mcp_server":
+                dest_file = dest / info.filename
+            else:
+                continue
+            dest_file.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info) as src, open(dest_file, "wb") as dst:
+                dst.write(src.read())
+            mode = info.external_attr >> 16
+            if mode:
+                os.chmod(dest_file, mode)
 
 
 def generate_mod_file(version: str, platform: str, path: str = ".") -> str:
@@ -226,9 +314,13 @@ def assemble(project_root: Path, version: str, platform: str, output: Path) -> P
     # 1. Download and extract dcc_mcp_core
     core_version = resolve_core_version(project_root)
     print(f"  Resolved dcc-mcp-core version: >={core_version}")
+    server_version = resolve_server_version(project_root)
+    print(f"  Resolved dcc-mcp-server version: >={server_version}")
 
     with tempfile.TemporaryDirectory() as wheel_cache:
-        wheels = download_core_wheels(core_version, platform, Path(wheel_cache))
+        cache_dir = Path(wheel_cache)
+        wheels = download_core_wheels(core_version, platform, cache_dir)
+        server_wheel = download_server_wheel(server_version, platform, cache_dir)
         abi3_wheels = [wheel for wheel in wheels if "abi3" in wheel.name]
         cp37_wheels = [wheel for wheel in wheels if "cp37-cp37m" in wheel.name]
 
@@ -241,7 +333,14 @@ def assemble(project_root: Path, version: str, platform: str, output: Path) -> P
             for wheel in cp37_wheels:
                 print(f"  Extracting {wheel.name} extensions to python37/...")
                 extract_wheel(wheel, python37_dir, extensions_only=True)
+
+        for package_root in (python_dir, python37_dir):
+            if not package_root.is_dir():
+                continue
+            print(f"  Extracting {server_wheel.name} to {package_root.name}/...")
+            extract_server_wheel(server_wheel, package_root)
     print("  Extracted dcc_mcp_core")
+    print("  Extracted dcc_mcp_server")
 
     # 2. Copy Maya plugin
     plugin_src = project_root / "maya" / "plugin" / "dcc_mcp_maya_plugin.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,11 @@ classifiers = [
 ]
 
 dependencies = [
-    # Release Train anchor: dcc-mcp-core v0.18.14 (PIP-688/689).
-    # 4 seam controllers + shared registration phase pipeline.
+    # Release Train anchor: dcc-mcp-core/server v0.18.17 (PIP-688/689).
+    # 4 lifecycle controllers + shared registration phase pipeline + gateway runtime.
     # Provides abi3 (cp38+) on 3.8+; separate cp37 wheels on Python 3.7 (Maya 2022).
-    "dcc-mcp-core>=0.18.14,<1.0.0",
+    "dcc-mcp-core>=0.18.17,<1.0.0",
+    "dcc-mcp-server>=0.18.17,<1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -41,15 +42,12 @@ dev = [
     "pytest-timeout>=2.1.0",
     "pytest-xdist>=3.0",
     "requests>=2.28.0",
-    "dcc-mcp-server>=0.18.0,<1.0.0",
+    "dcc-mcp-server>=0.18.17,<1.0.0",
     "ruff>=0.8.0",
     "hatchling",
     "build",
     "tomli; python_version < '3.11'",
     "pyyaml>=5.0",
-]
-sidecar = [
-    "dcc-mcp-server>=0.18.0,<1.0.0",
 ]
 
 [project.urls]

--- a/src/dcc_mcp_maya/_gateway_runtime.py
+++ b/src/dcc_mcp_maya/_gateway_runtime.py
@@ -1,0 +1,42 @@
+"""Gateway runtime wiring for Maya's embedded server path."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Callable, MutableMapping, Optional
+
+from dcc_mcp_maya.sidecar._resolver import ENV_SIDECAR_BINARY, SidecarBinaryError, resolve_sidecar_binary
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_gateway_server_binary_env(
+    *,
+    env: Optional[MutableMapping[str, str]] = None,
+    resolver: Callable[[], Path] = resolve_sidecar_binary,
+) -> bool:
+    """Expose Maya's packaged ``dcc-mcp-server`` binary to core.
+
+    ``dcc-mcp-core`` starts the standalone gateway daemon from
+    ``DCC_MCP_SERVER_BIN`` or ``PATH``.  Maya module ZIPs bundle the
+    ``dcc_mcp_server`` package under ``python/`` and its executable under
+    ``python/scripts/``; that location is importable but not necessarily on
+    ``PATH``.  Bridge the two contracts before calling core startup.
+
+    Returns ``True`` when this function set the env var.
+    """
+    target_env = os.environ if env is None else env
+    if target_env.get(ENV_SIDECAR_BINARY):
+        return False
+
+    try:
+        binary = resolver()
+    except SidecarBinaryError as exc:
+        logger.debug("gateway runtime binary not configured: %s", exc)
+        return False
+
+    target_env[ENV_SIDECAR_BINARY] = str(binary)
+    logger.debug("gateway runtime binary configured via %s=%s", ENV_SIDECAR_BINARY, binary)
+    return True

--- a/src/dcc_mcp_maya/_registration.py
+++ b/src/dcc_mcp_maya/_registration.py
@@ -1,9 +1,9 @@
 """Registration phases for MayaMcpServer builtin actions.
 
-Shared base classes (RegistrationContext, RegistrationPhase,
-PhaseOutcome, RegistrationReport) and the executor
-(run_registration_phases) are imported from
-:mod:`dcc_mcp_core._registration` (PIP-689, core v0.18.14+).
+Shared base classes (RegistrationContext, RegistrationPhase, and
+run_registration_phases) are imported from :mod:`dcc_mcp_core._registration`
+(PIP-689, core v0.18.14+). Older core builds did not ship that helper module,
+so this adapter keeps a narrow local fallback with the same contract.
 
 Adapters define their own phase subclasses here for host-specific
 registration steps.
@@ -11,13 +11,99 @@ registration steps.
 
 from __future__ import annotations
 
-from typing import Sequence
+import time
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Sequence
 
-from dcc_mcp_core._registration import (
-    RegistrationContext,
-    RegistrationPhase,
-    run_registration_phases,  # noqa: F401 - re-exported for callers
-)
+try:
+    from dcc_mcp_core._registration import (  # noqa: F401 - re-exported for callers
+        RegistrationContext,
+        RegistrationPhase,
+        run_registration_phases,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name != "dcc_mcp_core._registration":
+        raise
+
+    @dataclass
+    class RegistrationContext:  # type: ignore[no-redef]
+        """Input shared by every registration phase."""
+
+        server: Any
+        extra_skill_paths: Optional[List[str]] = None
+        include_bundled: bool = True
+        minimal: Optional[bool] = None
+        strict_scan: Optional[bool] = None
+
+    @dataclass
+    class PhaseOutcome:
+        """Result for one registration phase."""
+
+        name: str
+        success: bool
+        elapsed_secs: float
+        error: Optional[str] = None
+
+    @dataclass
+    class RegistrationReport:
+        """Summary emitted after builtin-action registration completes."""
+
+        outcomes: List[PhaseOutcome] = field(default_factory=list)
+
+        @property
+        def success(self) -> bool:
+            return all(outcome.success for outcome in self.outcomes)
+
+        @property
+        def elapsed_secs(self) -> float:
+            return sum(outcome.elapsed_secs for outcome in self.outcomes)
+
+    class RegistrationPhase:  # type: ignore[no-redef]
+        """Base class for one side-effect in Maya builtin registration."""
+
+        name = "registration"
+        fatal_exceptions = ()
+
+        def run(self, context: RegistrationContext) -> None:
+            raise NotImplementedError
+
+    def run_registration_phases(  # type: ignore[no-redef]
+        phases: Sequence[RegistrationPhase],
+        context: RegistrationContext,
+    ) -> RegistrationReport:
+        report = RegistrationReport()
+        for phase in phases:
+            started = time.monotonic()
+            try:
+                phase.run(context)
+            except phase.fatal_exceptions as exc:
+                report.outcomes.append(
+                    PhaseOutcome(
+                        name=phase.name,
+                        success=False,
+                        elapsed_secs=time.monotonic() - started,
+                        error=str(exc),
+                    )
+                )
+                raise
+            except Exception as exc:  # noqa: BLE001
+                report.outcomes.append(
+                    PhaseOutcome(
+                        name=phase.name,
+                        success=False,
+                        elapsed_secs=time.monotonic() - started,
+                        error=str(exc),
+                    )
+                )
+            else:
+                report.outcomes.append(
+                    PhaseOutcome(
+                        name=phase.name,
+                        success=True,
+                        elapsed_secs=time.monotonic() - started,
+                    )
+                )
+        return report
 
 
 class CoreBuiltinActionsPhase(RegistrationPhase):

--- a/src/dcc_mcp_maya/server.py
+++ b/src/dcc_mcp_maya/server.py
@@ -39,6 +39,7 @@ from dcc_mcp_core.server_base import DccServerBase
 from dcc_mcp_maya import (
     _env,
     _executor,
+    _gateway_runtime,
     _project_tools,
     _readiness,
     _registration,
@@ -764,7 +765,13 @@ class MayaMcpServer(DccServerBase):
         registered before the local election won.  The gateway's own
         heartbeat (5 s) publishes our metadata anyway.
         """
+        if self._is_gateway_daemon_enabled():
+            _gateway_runtime.ensure_gateway_server_binary_env()
         return super().start()
+
+    def _is_gateway_daemon_enabled(self) -> bool:
+        gateway_port = int(getattr(self._config, "gateway_port", 0) or 0)
+        return bool(gateway_port > 0 and getattr(self, "_enable_gateway_failover", False))
 
     def _upgrade_to_gateway(self) -> bool:
         """Promote to gateway on the Maya UI thread when possible.

--- a/tests/test_assemble_mod.py
+++ b/tests/test_assemble_mod.py
@@ -33,7 +33,10 @@ def _make_fake_wheel(dest: Path, name: str, files: dict[str, bytes]) -> Path:
 def _make_fake_pyproject(dest: Path, core_version: str = "0.15.7") -> Path:
     toml_path = dest / "pyproject.toml"
     toml_path.write_text(
-        f'[project]\ndependencies = [\n    "dcc-mcp-core>={core_version},<1.0.0",\n]\n',
+        "[project]\ndependencies = [\n"
+        f'    "dcc-mcp-core>={core_version},<1.0.0",\n'
+        f'    "dcc-mcp-server>={core_version},<1.0.0",\n'
+        "]\n",
         encoding="utf-8",
     )
     return toml_path
@@ -81,6 +84,22 @@ class TestResolveCoreVersion:
         (tmp_path / "pyproject.toml").write_text("[project]\ndependencies = []\n", encoding="utf-8")
         with pytest.raises(RuntimeError, match="Cannot find dcc-mcp-core version"):
             assemble_mod.resolve_core_version(tmp_path)
+
+
+class TestResolveServerVersion:
+    def test_extracts_minimum_version(self, tmp_path):
+        _make_fake_pyproject(tmp_path, "0.18.17")
+        with patch("urllib.request.urlopen", side_effect=Exception("offline")):
+            version = assemble_mod.resolve_server_version(tmp_path)
+        assert version == "0.18.17"
+
+    def test_raises_when_no_version_found(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\ndependencies = [\n    "dcc-mcp-core>=0.18.17,<1.0.0",\n]\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(RuntimeError, match="Cannot find dcc-mcp-server version"):
+            assemble_mod.resolve_server_version(tmp_path)
 
 
 class TestDownloadCoreWheels:
@@ -158,6 +177,42 @@ class TestDownloadCoreWheels:
                 assemble_mod.download_core_wheels("0.15.0", "win64", tmp_path)
 
 
+class TestDownloadServerWheel:
+    def test_win64_downloads_server_wheel(self, tmp_path):
+        version = "0.18.17"
+        filename = f"dcc_mcp_server-{version}-py3-none-win_amd64.whl"
+        pypi_data = {
+            "info": {"version": version},
+            "urls": [{"filename": filename, "url": f"https://example.com/{filename}", "packagetype": "bdist_wheel"}],
+            "releases": {
+                version: [
+                    {"filename": filename, "url": f"https://example.com/{filename}", "packagetype": "bdist_wheel"}
+                ]
+            },
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(pypi_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        def fake_urlretrieve(_url, dest):
+            _make_fake_wheel(
+                Path(dest).parent,
+                Path(dest).name,
+                {
+                    "dcc_mcp_server/__init__.py": b"# server",
+                    f"dcc_mcp_server-{version}.data/scripts/dcc-mcp-server.exe": b"server",
+                },
+            )
+
+        with patch("urllib.request.urlopen", return_value=mock_resp), patch(
+            "urllib.request.urlretrieve", side_effect=fake_urlretrieve
+        ):
+            wheel = assemble_mod.download_server_wheel(version, "win64", tmp_path)
+
+        assert wheel.name == filename
+
+
 class TestExtractWheel:
     def test_extracts_python_files(self, tmp_path):
         files = {
@@ -185,6 +240,19 @@ class TestExtractWheel:
         assemble_mod.extract_wheel(wheel, dest, extensions_only=True)
         assert (dest / "dcc_mcp_core" / "__init__.py").read_bytes() == b"existing"
         assert (dest / "dcc_mcp_core" / "_core.pyd").read_bytes() == b"\x00binary"
+
+    def test_extract_server_wheel_maps_scripts_data_dir(self, tmp_path):
+        files = {
+            "dcc_mcp_server/__init__.py": b"# server",
+            "dcc_mcp_server-0.18.17.data/scripts/dcc-mcp-server.exe": b"server-bin",
+            "dcc_mcp_server-0.18.17.dist-info/METADATA": b"Metadata-Version: 2.1",
+        }
+        wheel = _make_fake_wheel(tmp_path, "dcc_mcp_server-0.18.17-py3-none-win_amd64.whl", files)
+        dest = tmp_path / "out"
+        assemble_mod.extract_server_wheel(wheel, dest)
+
+        assert (dest / "dcc_mcp_server" / "__init__.py").read_bytes() == b"# server"
+        assert (dest / "scripts" / "dcc-mcp-server.exe").read_bytes() == b"server-bin"
 
 
 class TestGenerateModFile:
@@ -220,10 +288,11 @@ class TestGenerateModuleInfo:
 
 
 class TestPackagingReadmes:
-    def test_module_readmes_document_external_sidecar_runtime(self):
+    def test_module_readmes_document_bundled_sidecar_runtime(self):
         for name in ("README.txt", "README-pipeline.txt"):
             text = (PROJECT_ROOT / "packaging" / name).read_text(encoding="utf-8")
-            assert "does not bundle the external dcc-mcp-server sidecar binary" in text
+            assert "dcc-mcp-server sidecar binary" in text
+            assert "bundled" in text.lower()
             assert "DCC_MCP_SERVER_BIN" in text
             assert "DCC_MCP_MAYA_SIDECAR=0" in text
             assert "resolve_sidecar_binary" in text
@@ -274,6 +343,17 @@ def _mock_download_and_resolve(_project: Path, _tmp_path: Path):
     return fake_download
 
 
+def _mock_server_download(version, _platform, dest):
+    return _make_fake_wheel(
+        dest,
+        f"dcc_mcp_server-{version}-py3-none-win_amd64.whl",
+        {
+            "dcc_mcp_server/__init__.py": b"def binary_path(): pass\n",
+            f"dcc_mcp_server-{version}.data/scripts/dcc-mcp-server.exe": b"server-bin",
+        },
+    )
+
+
 class TestAssemble:
     def test_win64_creates_python_and_python37(self, tmp_path):
         project = _setup_project(tmp_path)
@@ -283,14 +363,20 @@ class TestAssemble:
 
         with patch.object(assemble_mod, "resolve_core_version", return_value="0.15.0"), patch.object(
             assemble_mod, "download_core_wheels", side_effect=fake_download
+        ), patch.object(assemble_mod, "resolve_server_version", return_value="0.15.0"), patch.object(
+            assemble_mod, "download_server_wheel", side_effect=_mock_server_download
         ):
             result = assemble_mod.assemble(project, "0.2.2", "win64", output)
 
         assert (result / "python" / "dcc_mcp_core" / "__init__.py").exists()
         assert (result / "python" / "dcc_mcp_core" / "_core.pyd").exists()
+        assert (result / "python" / "dcc_mcp_server" / "__init__.py").exists()
+        assert (result / "python" / "scripts" / "dcc-mcp-server.exe").exists()
         assert (result / "python" / "dcc_mcp_maya" / "__init__.py").exists()
         assert (result / "python37" / "dcc_mcp_core" / "__init__.py").exists()
         assert (result / "python37" / "dcc_mcp_core" / "_core.pyd").read_bytes() == b"\x00cp37_core"
+        assert (result / "python37" / "dcc_mcp_server" / "__init__.py").exists()
+        assert (result / "python37" / "scripts" / "dcc-mcp-server.exe").exists()
         assert (result / "python37" / "dcc_mcp_maya" / "__init__.py").exists()
 
         mod_content = (result / "dcc_mcp_maya.mod").read_text(encoding="utf-8")
@@ -307,6 +393,8 @@ class TestAssemble:
 
         with patch.object(assemble_mod, "resolve_core_version", return_value="0.15.0"), patch.object(
             assemble_mod, "download_core_wheels", side_effect=fake_download
+        ), patch.object(assemble_mod, "resolve_server_version", return_value="0.15.0"), patch.object(
+            assemble_mod, "download_server_wheel", side_effect=_mock_server_download
         ):
             result = assemble_mod.assemble(project, "0.2.2", "win64", output)
 
@@ -323,6 +411,8 @@ class TestAssemblePortable:
 
         with patch.object(assemble_mod, "resolve_core_version", return_value="0.15.0"), patch.object(
             assemble_mod, "download_core_wheels", side_effect=fake_download
+        ), patch.object(assemble_mod, "resolve_server_version", return_value="0.15.0"), patch.object(
+            assemble_mod, "download_server_wheel", side_effect=_mock_server_download
         ):
             result = assemble_mod.assemble_portable(project, "0.2.2", "win64", output)
 
@@ -340,6 +430,8 @@ class TestAssemblePortable:
 
         with patch.object(assemble_mod, "resolve_core_version", return_value="0.15.0"), patch.object(
             assemble_mod, "download_core_wheels", side_effect=fake_download
+        ), patch.object(assemble_mod, "resolve_server_version", return_value="0.15.0"), patch.object(
+            assemble_mod, "download_server_wheel", side_effect=_mock_server_download
         ):
             result = assemble_mod.assemble_portable(project, "0.2.2", "linux", output)
 
@@ -357,6 +449,8 @@ class TestAssemblePipeline:
 
         with patch.object(assemble_mod, "resolve_core_version", return_value="0.15.0"), patch.object(
             assemble_mod, "download_core_wheels", side_effect=fake_download
+        ), patch.object(assemble_mod, "resolve_server_version", return_value="0.15.0"), patch.object(
+            assemble_mod, "download_server_wheel", side_effect=_mock_server_download
         ):
             result = assemble_mod.assemble_pipeline(project, "0.2.2", "win64", output)
 
@@ -377,6 +471,8 @@ class TestMain:
 
         with patch.object(assemble_mod, "resolve_core_version", return_value="0.15.0"), patch.object(
             assemble_mod, "download_core_wheels", side_effect=fake_download
+        ), patch.object(assemble_mod, "resolve_server_version", return_value="0.15.0"), patch.object(
+            assemble_mod, "download_server_wheel", side_effect=_mock_server_download
         ):
             old_argv = sys.argv
             try:

--- a/tests/test_gateway_runtime.py
+++ b/tests/test_gateway_runtime.py
@@ -1,0 +1,49 @@
+"""Gateway runtime env wiring tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dcc_mcp_maya._gateway_runtime import ensure_gateway_server_binary_env
+from dcc_mcp_maya.sidecar._resolver import ENV_SIDECAR_BINARY, SidecarBinaryError
+
+
+def test_ensure_gateway_server_binary_env_sets_resolved_binary() -> None:
+    env: dict[str, str] = {}
+    binary = Path("/opt/dcc-mcp/bin/dcc-mcp-server")
+
+    changed = ensure_gateway_server_binary_env(
+        env=env,
+        resolver=lambda: binary,
+    )
+
+    assert changed is True
+    assert env[ENV_SIDECAR_BINARY] == str(binary)
+
+
+def test_ensure_gateway_server_binary_env_respects_explicit_override() -> None:
+    env = {ENV_SIDECAR_BINARY: "/custom/dcc-mcp-server"}
+    called = False
+
+    def resolver() -> Path:
+        nonlocal called
+        called = True
+        return Path("/other/dcc-mcp-server")
+
+    changed = ensure_gateway_server_binary_env(env=env, resolver=resolver)
+
+    assert changed is False
+    assert called is False
+    assert env[ENV_SIDECAR_BINARY] == "/custom/dcc-mcp-server"
+
+
+def test_ensure_gateway_server_binary_env_is_best_effort_when_missing() -> None:
+    env: dict[str, str] = {}
+
+    def resolver() -> Path:
+        raise SidecarBinaryError("missing")
+
+    changed = ensure_gateway_server_binary_env(env=env, resolver=resolver)
+
+    assert changed is False
+    assert ENV_SIDECAR_BINARY not in env

--- a/tests/test_registration_phases.py
+++ b/tests/test_registration_phases.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import builtins
+import importlib.util
+import sys
 from unittest.mock import MagicMock
 
 import pytest
@@ -81,3 +84,38 @@ def test_phase_methods_delegate_to_server() -> None:
     server._register_capability_manifest_tool.assert_called_once_with()
     server._attach_project_tools.assert_called_once_with()
     server._attach_resources.assert_called_once_with()
+
+
+def test_registration_module_falls_back_when_core_helper_is_missing(monkeypatch) -> None:
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):  # noqa: A002
+        if name == "dcc_mcp_core._registration":
+            raise ModuleNotFoundError("No module named 'dcc_mcp_core._registration'", name=name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    module_path = _registration.__file__
+    spec = importlib.util.spec_from_file_location("_maya_registration_fallback_test", module_path)
+    fallback = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = fallback
+    spec.loader.exec_module(fallback)
+
+    calls = []
+    server = MagicMock()
+    context = fallback.RegistrationContext(server=server)
+    report = fallback.run_registration_phases(
+        [
+            _RecordingPhase("one", calls),
+            _RecordingPhase("two", calls, fail=True),
+            _RecordingPhase("three", calls),
+        ],
+        context,
+    )
+
+    assert [outcome.name for outcome in report.outcomes] == ["one", "two", "three"]
+    assert [outcome.success for outcome in report.outcomes] == [True, False, True]
+    assert report.success is False
+    assert report.outcomes[1].error == "boom"


### PR DESCRIPTION
## Summary
- align Maya runtime dependencies to `dcc-mcp-core` / `dcc-mcp-server` 0.18.17
- keep registration phase startup compatible when the core registration helper is unavailable
- make the gateway server runtime part of the default install and module package path

## Validation
- `PYTHONPATH=src;tests python -m pytest tests/test_registration_phases.py tests/test_plugin_env_vars.py::TestSidecarUsesCoreRegistryDefaults tests/test_sidecar_supervisor.py tests/test_assemble_mod.py -q`
- `python -m build --wheel --no-isolation`
- checked built wheel metadata for default `dcc-mcp-server>=0.18.17` dependency