### PR TITLE
fix: align Maya sidecar diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Maya plugin starts a Rust `dcc-mcp-server` sidecar by default, so HTTP and g
 [![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-maya?label=Python)](https://pypi.org/project/dcc-mcp-maya/)
 [![Maya](https://img.shields.io/badge/Maya-2020%2B-37A5CC)](https://www.autodesk.com/products/maya/overview)
 [![MCP](https://img.shields.io/badge/MCP-Streamable%20HTTP-6f42c1)](https://modelcontextprotocol.io/)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.18.19-blue)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.18.20-blue)](https://github.com/loonghao/dcc-mcp-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ## Why Use It
@@ -363,8 +363,8 @@ Windows symlinks require Developer Mode or an elevated shell. If symlinks are un
 
 - Autodesk Maya 2020+
 - Python 3.7+
-- `dcc-mcp-core>=0.18.19,<1.0.0`
-- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.18.19`
+- `dcc-mcp-core>=0.18.20,<1.0.0`
+- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.18.20`
 
 ## License
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -4,8 +4,8 @@
 
 - **Maya**: 2020+ (tested with Maya 2022 through 2026 module packages)
 - **Python**: 3.7 – 3.12 (embedded in Maya)
-- **dcc-mcp-core**: ≥ 0.18.19 (auto-installed as dependency)
-- **dcc-mcp-server**: ≥ 0.18.19 (auto-installed as dependency for the default sidecar gateway)
+- **dcc-mcp-core**: ≥ 0.18.20 (auto-installed as dependency)
+- **dcc-mcp-server**: ≥ 0.18.20 (auto-installed as dependency for the default sidecar gateway)
 
 ## Method 1 — pip into mayapy
 

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -4,8 +4,8 @@
 
 - **Maya**：2020+（模块包覆盖 Maya 2022 至 2026）
 - **Python**：3.7 – 3.12（Maya 内嵌）
-- **dcc-mcp-core**：≥ 0.18.19（作为依赖自动安装）
-- **dcc-mcp-server**：≥ 0.18.19（默认 sidecar gateway 运行时，作为依赖自动安装）
+- **dcc-mcp-core**：≥ 0.18.20（作为依赖自动安装）
+- **dcc-mcp-server**：≥ 0.18.20（默认 sidecar gateway 运行时，作为依赖自动安装）
 
 ## 方式一 — pip 安装到 mayapy
 

--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -29,7 +29,7 @@ Gateway mode (default ON)
 By default the plugin starts a per-Maya ``dcc-mcp-server sidecar``. The sidecar
 ensures a standalone machine-wide gateway is running on port ``9765`` and then
 registers this Maya instance as a backend. Every Maya sidecar gets an explicit
-``--display-name`` and ``--instance-id``; the gateway gets a machine-level
+``--display-name`` and, when available, ``--instance-id``; the gateway gets a machine-level
 ``--gateway-name`` (default ``dcc-mcp-gateway@<hostname>``) so admin and CLI
 debug views can distinguish the gateway from Maya sessions.
 
@@ -881,6 +881,12 @@ def _print_sidecar_info(handle) -> None:  # noqa: ANN001
         *gateway_lines,
         border,
     ]
+    stdout_path = getattr(handle, "stdout_path", None)
+    stderr_path = getattr(handle, "stderr_path", None)
+    if stdout_path:
+        lines.insert(-1, f"  stdout log   : {stdout_path}")
+    if stderr_path:
+        lines.insert(-1, f"  stderr log   : {stderr_path}")
     print("\n".join(lines))  # noqa: T201 — intentional console output
 
     if _is_interactive():
@@ -928,6 +934,19 @@ def _probe_gateway_health_deferred(
             try:
                 with urlopen(url, timeout=timeout) as resp:
                     if resp.status == 200:
+                        exit_message = _format_sidecar_exit_message(handle)
+                        if exit_message:
+                            print(  # noqa: T201
+                                f"[dcc-mcp-maya] Gateway health OK at {url}, but {exit_message}"
+                            )
+                            return
+                        time.sleep(0.25)
+                        exit_message = _format_sidecar_exit_message(handle)
+                        if exit_message:
+                            print(  # noqa: T201
+                                f"[dcc-mcp-maya] Gateway health OK at {url}, but {exit_message}"
+                            )
+                            return
                         print(f"[dcc-mcp-maya] Gateway health OK: {url}")  # noqa: T201
                         return
                     last_error = f"HTTP {resp.status}"
@@ -941,10 +960,9 @@ def _probe_gateway_health_deferred(
             if callable(poll):
                 returncode = poll()
                 if returncode is not None:
-                    pid = getattr(proc, "pid", "?")
                     print(  # noqa: T201
                         f"[dcc-mcp-maya] Gateway NOT reachable at {url}; "
-                        f"sidecar PID {pid} exited early (exit={returncode}). "
+                        f"{_format_sidecar_exit_message(handle, returncode=returncode)} "
                         f"Last probe error: {last_error}. Check dcc-mcp-server "
                         f"logs or run: dcc-mcp-server gateway --port {gateway_port}"
                     )
@@ -963,6 +981,44 @@ def _probe_gateway_health_deferred(
 
     t = threading.Thread(target=_probe, name="dcc-mcp-gateway-probe", daemon=True)
     t.start()
+
+
+def _format_sidecar_exit_message(handle=None, returncode=None) -> str:  # noqa: ANN001
+    proc = getattr(handle, "proc", None)
+    if proc is None:
+        return ""
+    if returncode is None:
+        poll = getattr(proc, "poll", None)
+        if not callable(poll):
+            return ""
+        returncode = poll()
+    if returncode is None:
+        return ""
+    pid = getattr(proc, "pid", "?")
+    parts = [f"sidecar PID {pid} exited early (exit={returncode})."]
+    stderr_path = getattr(handle, "stderr_path", None)
+    stdout_path = getattr(handle, "stdout_path", None)
+    if stderr_path:
+        parts.append(f"stderr log: {stderr_path}.")
+        tail = _read_log_tail(stderr_path)
+        if tail:
+            parts.append(f"stderr tail: {tail}")
+    if stdout_path:
+        parts.append(f"stdout log: {stdout_path}.")
+    return " ".join(parts)
+
+
+def _read_log_tail(path, *, limit: int = 800) -> str:  # noqa: ANN001
+    try:
+        with open(path, "rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - limit), os.SEEK_SET)
+            data = handle.read()
+    except OSError:
+        return ""
+    text = data.decode("utf-8", "replace").strip()
+    return " ".join(text.split())
 
 
 def _resolve_gateway_port_for_display() -> int:
@@ -1139,15 +1195,15 @@ def _stop_blocking() -> None:
 # ── shutdown safety nets (issue #186) ─────────────────────────────────────────
 
 
-def _resolve_instance_id() -> str:
-    """Return the Maya MCP instance id for the active server, or ``"unknown"``.
+def _resolve_instance_id() -> Optional[str]:
+    """Return the Maya MCP instance id for the active server, if available.
 
     Used to tag the crash-resilient process sentinel (issue #186) so
     sweepers can cross-reference a FileRegistry row against its
     sentinel.  Robust to every degraded state — missing server,
-    Python-3.7 fallback path, server not yet registered — because the
-    tag is cosmetic; the sentinel's filesystem presence is what
-    actually matters.
+    Python-3.7 fallback path, server not yet registered.  Sidecar launch
+    treats the value as a strict CLI contract, so degraded states return
+    ``None`` instead of a cosmetic sentinel like ``"unknown"``.
     """
     try:
         import dcc_mcp_maya  # noqa: PLC0415
@@ -1159,7 +1215,7 @@ def _resolve_instance_id() -> str:
                 return str(instance_id)
     except Exception as exc:  # noqa: BLE001
         logger.debug("instance id lookup failed: %s", exc)
-    return "unknown"
+    return None
 
 
 def _resolve_sidecar_display_name() -> str:
@@ -1206,7 +1262,7 @@ def _install_shutdown_safety() -> None:
         coordinator = ShutdownCoordinator()
         coordinator.install(
             stop_callback=_stop_blocking,
-            instance_id=_resolve_instance_id(),
+            instance_id=_resolve_instance_id() or "unknown",
             registry_dir=os.environ.get("DCC_MCP_REGISTRY_DIR") or None,
         )
         _shutdown_coordinator = coordinator

--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -849,7 +849,7 @@ def _maybe_spawn_sidecar() -> None:
         return
 
     _print_sidecar_info(_sidecar_handle)
-    _probe_gateway_health_deferred()
+    _probe_gateway_health_deferred(_sidecar_handle)
 
 
 def _print_sidecar_info(handle) -> None:  # noqa: ANN001
@@ -895,15 +895,26 @@ def _print_sidecar_info(handle) -> None:  # noqa: ANN001
             pass
 
 
-def _probe_gateway_health_deferred(delay: float = 3.0, timeout: float = 2.0) -> None:
+def _probe_gateway_health_deferred(
+    handle=None,  # noqa: ANN001 - sidecar handle shape is intentionally duck-typed.
+    delay: float = 1.0,
+    timeout: float = 1.0,
+    attempts: int = 12,
+    interval: float = 1.0,
+) -> None:
     """Deferred gateway health probe (non-blocking, runs on a daemon thread).
 
     Spawned after the sidecar so users get timely feedback about whether the
-    sidecar-managed gateway actually became reachable.
+    sidecar-managed gateway actually became reachable.  The gateway daemon may
+    need a couple of seconds to reclaim stale registry state and bind the local
+    and LAN listeners, so this probe is deliberately bounded-retry rather than a
+    single startup snapshot.
     """
     gateway_port = _resolve_gateway_port_for_display()
     if gateway_port <= 0:
         return
+    attempts = max(1, int(attempts))
+    interval = max(0.0, float(interval))
 
     def _probe() -> None:
         import time
@@ -912,26 +923,43 @@ def _probe_gateway_health_deferred(delay: float = 3.0, timeout: float = 2.0) -> 
 
         time.sleep(delay)
         url = f"http://127.0.0.1:{gateway_port}/health"
-        try:
-            with urlopen(url, timeout=timeout) as resp:
-                if resp.status == 200:
-                    print(f"[dcc-mcp-maya] Gateway health OK: {url}")  # noqa: T201
-                else:
-                    print(f"[dcc-mcp-maya] Gateway health check: HTTP {resp.status} at {url}")  # noqa: T201
-        except HTTPError as exc:
-            print(  # noqa: T201
-                f"[dcc-mcp-maya] Gateway NOT reachable (HTTP {exc.code}) — "
-                f"the sidecar may still be starting the gateway, or the "
-                f"dcc-mcp-server binary may be missing the gateway-daemon feature. "
-                f"Check sidecar logs or run: dcc-mcp-server gateway --port {gateway_port}"
-            )
-        except (URLError, OSError):
-            print(  # noqa: T201
-                f"[dcc-mcp-maya] Gateway NOT reachable at {url} — "
-                f"the sidecar may still be starting the gateway. "
-                f"If this persists, verify the dcc-mcp-server binary was built "
-                f"with the gateway-daemon feature."
-            )
+        last_error = None
+        for attempt in range(1, attempts + 1):
+            try:
+                with urlopen(url, timeout=timeout) as resp:
+                    if resp.status == 200:
+                        print(f"[dcc-mcp-maya] Gateway health OK: {url}")  # noqa: T201
+                        return
+                    last_error = f"HTTP {resp.status}"
+            except HTTPError as exc:
+                last_error = f"HTTP {exc.code}"
+            except (URLError, OSError) as exc:
+                last_error = str(exc) or exc.__class__.__name__
+
+            proc = getattr(handle, "proc", None)
+            poll = getattr(proc, "poll", None)
+            if callable(poll):
+                returncode = poll()
+                if returncode is not None:
+                    pid = getattr(proc, "pid", "?")
+                    print(  # noqa: T201
+                        f"[dcc-mcp-maya] Gateway NOT reachable at {url}; "
+                        f"sidecar PID {pid} exited early (exit={returncode}). "
+                        f"Last probe error: {last_error}. Check dcc-mcp-server "
+                        f"logs or run: dcc-mcp-server gateway --port {gateway_port}"
+                    )
+                    return
+
+            if attempt < attempts:
+                time.sleep(interval)
+
+        print(  # noqa: T201
+            f"[dcc-mcp-maya] Gateway NOT reachable at {url} after {attempts} "
+            f"attempt(s). Last probe error: {last_error}. The sidecar may still "
+            f"be starting the gateway, stale registry state may need cleanup, "
+            f"or the dcc-mcp-server binary may be missing the gateway-daemon "
+            f"feature."
+        )
 
     t = threading.Thread(target=_probe, name="dcc-mcp-gateway-probe", daemon=True)
     t.start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,11 @@ classifiers = [
 ]
 
 dependencies = [
-    # Release Train anchor: dcc-mcp-core/server v0.18.19 (PIP-688/689).
+    # Release Train anchor: dcc-mcp-core/server v0.18.20 (sidecar diagnostics).
     # 4 lifecycle controllers + shared registration phase pipeline + gateway runtime.
     # Provides abi3 (cp38+) on 3.8+; separate cp37 wheels on Python 3.7 (Maya 2022).
-    "dcc-mcp-core>=0.18.19,<1.0.0",
-    "dcc-mcp-server>=0.18.19,<1.0.0",
+    "dcc-mcp-core>=0.18.20,<1.0.0",
+    "dcc-mcp-server>=0.18.20,<1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -42,7 +42,7 @@ dev = [
     "pytest-timeout>=2.1.0",
     "pytest-xdist>=3.0",
     "requests>=2.28.0",
-    "dcc-mcp-server>=0.18.19,<1.0.0",
+    "dcc-mcp-server>=0.18.20,<1.0.0",
     "ruff>=0.8.0",
     "hatchling",
     "build",

--- a/src/dcc_mcp_maya/sidecar/_supervisor.py
+++ b/src/dcc_mcp_maya/sidecar/_supervisor.py
@@ -41,10 +41,6 @@ Design choices worth pinning:
   inheriting Maya's process tree. When Maya exits the OS reaps the
   sidecar naturally as a backstop in case PPID-watch was somehow
   bypassed.
-* **No raw ``log to stderr`` plumbing** — the binary writes structured
-  logs to ``DCC_MCP_LOG_DIR`` already (see
-  ``dcc-mcp-logging::file_logging``). The Python plug-in shouldn't
-  duplicate that.
 """
 
 from __future__ import annotations
@@ -125,6 +121,8 @@ class SidecarHandle:
     command: list = field(default_factory=list)
     launch_contract: dict = field(default_factory=dict)
     extra_env: dict = field(default_factory=dict)
+    stdout_path: Optional[Path] = None
+    stderr_path: Optional[Path] = None
 
     @property
     def is_alive(self) -> bool:
@@ -340,19 +338,22 @@ def start_sidecar(
         maya_pid,
         qt_binding,
     )
+    stdio = _prepare_sidecar_stdio(launch_contract, spawn_env, maya_pid)
     try:
         proc = subprocess.Popen(  # noqa: S603 — argv is built from trusted vars
             cmd,
             env=spawn_env,
             stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=stdio["stdout"],
+            stderr=stdio["stderr"],
             close_fds=True,
             creationflags=_detached_process_flags(),
         )
     except OSError as exc:
         _stop_qt_server(stop_qt_server_fn)
         raise SidecarSpawnError("failed to spawn dcc-mcp-server sidecar at {0}: {1}".format(binary, exc)) from exc
+    finally:
+        _close_sidecar_stdio(stdio)
 
     return SidecarHandle(
         proc=proc,
@@ -364,6 +365,8 @@ def start_sidecar(
         command=cmd,
         launch_contract=dict(launch_contract),
         extra_env=dict(extra_env or {}),
+        stdout_path=stdio.get("stdout_path"),
+        stderr_path=stdio.get("stderr_path"),
     )
 
 
@@ -480,6 +483,51 @@ def _detached_process_flags() -> int:
         CREATE_NO_WINDOW = 0x0800_0000  # noqa: N806
         return CREATE_NO_WINDOW
     return 0
+
+
+def _prepare_sidecar_stdio(launch_contract: dict, env: dict, maya_pid: int) -> dict:
+    """Open stdout/stderr log files for the sidecar child process.
+
+    The sidecar can exit before structured file logging starts, especially for
+    CLI argument-contract failures. Keeping raw stdio makes those failures
+    visible without blocking Maya startup.
+    """
+
+    try:
+        log_root = env.get("DCC_MCP_LOG_DIR")
+        if log_root:
+            log_dir = Path(log_root)
+        else:
+            log_dir = Path(str(launch_contract.get("registry_dir") or ".")) / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        prefix = "dcc-mcp-sidecar-{0}-{1}".format(maya_pid, stamp)
+        stdout_path = log_dir / "{0}.stdout.log".format(prefix)
+        stderr_path = log_dir / "{0}.stderr.log".format(prefix)
+        return {
+            "stdout": stdout_path.open("ab"),
+            "stderr": stderr_path.open("ab"),
+            "stdout_path": stdout_path,
+            "stderr_path": stderr_path,
+        }
+    except OSError as exc:
+        logger.warning("dcc-mcp-maya: failed to open sidecar stdio logs; falling back to DEVNULL: %s", exc)
+        return {
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.DEVNULL,
+            "stdout_path": None,
+            "stderr_path": None,
+        }
+
+
+def _close_sidecar_stdio(stdio: dict) -> None:
+    for key in ("stdout", "stderr"):
+        handle = stdio.get(key)
+        if hasattr(handle, "close"):
+            try:
+                handle.close()
+            except OSError as exc:
+                logger.debug("sidecar stdio close raised: %s", exc)
 
 
 def _await_proc_alive(proc: subprocess.Popen, timeout: float = 0.5) -> bool:

--- a/tests/test_plugin_env_vars.py
+++ b/tests/test_plugin_env_vars.py
@@ -378,6 +378,17 @@ class TestSidecarUsesCoreRegistryDefaults:
         assert kwargs["instance_id"] == "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
         plugin_module._probe_gateway_health_deferred.assert_called_once_with(plugin_module._sidecar_handle)
 
+    def test_sidecar_omits_unresolved_instance_id(self, plugin_module, monkeypatch):
+        """A cosmetic sentinel value must not become a strict sidecar CLI UUID."""
+        monkeypatch.setattr(plugin_module, "_resolve_instance_id", lambda: None)
+
+        sidecar_pkg = self._arm_plugin(plugin_module, monkeypatch)
+        plugin_module._maybe_spawn_sidecar()
+
+        sidecar_pkg.start_sidecar.assert_called_once()
+        _, kwargs = sidecar_pkg.start_sidecar.call_args
+        assert kwargs["instance_id"] is None
+
     def test_sidecar_banner_omits_internal_rfc_marker(self, plugin_module, monkeypatch, capsys):
         monkeypatch.setattr(plugin_module, "_is_interactive", lambda: False)
         monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "9765")

--- a/tests/test_plugin_env_vars.py
+++ b/tests/test_plugin_env_vars.py
@@ -18,8 +18,10 @@ import os
 import sys
 import threading
 import types
+import urllib.request
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.error import URLError
 
 # Import third-party modules
 import pytest
@@ -306,6 +308,7 @@ class TestSidecarUsesCoreRegistryDefaults:
 
         # Stub the banner so we don't print to stdout during tests.
         plugin_module._print_sidecar_info = MagicMock()
+        plugin_module._probe_gateway_health_deferred = MagicMock()
         return sidecar_pkg
 
     def test_sidecar_does_not_reimplement_registry_env_resolution(self, plugin_module, monkeypatch, tmp_path):
@@ -373,6 +376,7 @@ class TestSidecarUsesCoreRegistryDefaults:
         assert kwargs["display_name"] == "Maya 2025 pid 1234"
         assert kwargs["gateway_name"] == "dcc-mcp-gateway@workstation-01"
         assert kwargs["instance_id"] == "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        plugin_module._probe_gateway_health_deferred.assert_called_once_with(plugin_module._sidecar_handle)
 
     def test_sidecar_banner_omits_internal_rfc_marker(self, plugin_module, monkeypatch, capsys):
         monkeypatch.setattr(plugin_module, "_is_interactive", lambda: False)
@@ -408,6 +412,81 @@ class TestSidecarUsesCoreRegistryDefaults:
         monkeypatch.setenv("DCC_MCP_GATEWAY_REMOTE_HOST", "192.168.2.10")
         monkeypatch.setenv("DCC_MCP_GATEWAY_REMOTE_PORT", "0")
         assert resolve_gateway_remote_options() == ("192.168.2.10", 0)
+
+
+class TestGatewayHealthProbe:
+    """Gateway probe should be useful without blocking Maya startup."""
+
+    class _ImmediateThread:
+        def __init__(self, target, **_kwargs):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    class _Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def _run_probe_inline(self, plugin_module, monkeypatch):
+        monkeypatch.setattr(plugin_module.threading, "Thread", self._ImmediateThread)
+        monkeypatch.setattr("time.sleep", lambda _secs: None)
+        monkeypatch.setattr(plugin_module, "_resolve_gateway_port_for_display", lambda: 9765)
+
+    def test_probe_retries_before_reporting_success(self, plugin_module, monkeypatch, capsys):
+        self._run_probe_inline(plugin_module, monkeypatch)
+        calls = []
+
+        def fake_urlopen(url, timeout):  # noqa: ARG001
+            calls.append((url, timeout))
+            if len(calls) == 1:
+                raise URLError("connection refused")
+            return self._Response()
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        handle = MagicMock()
+        handle.proc.poll.return_value = None
+
+        plugin_module._probe_gateway_health_deferred(
+            handle,
+            delay=0,
+            timeout=0.1,
+            attempts=2,
+            interval=0,
+        )
+
+        output = capsys.readouterr().out
+        assert "Gateway health OK" in output
+        assert "Gateway NOT reachable" not in output
+        assert len(calls) == 2
+
+    def test_probe_reports_early_sidecar_exit(self, plugin_module, monkeypatch, capsys):
+        self._run_probe_inline(plugin_module, monkeypatch)
+
+        def fake_urlopen(url, timeout):  # noqa: ARG001
+            raise URLError("timed out")
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        handle = MagicMock()
+        handle.proc.pid = 12345
+        handle.proc.poll.return_value = 7
+
+        plugin_module._probe_gateway_health_deferred(
+            handle,
+            delay=0,
+            timeout=0.1,
+            attempts=3,
+            interval=0,
+        )
+
+        output = capsys.readouterr().out
+        assert "sidecar PID 12345 exited early (exit=7)" in output
+        assert "Last probe error:" in output
 
 
 class TestRestartStopsSidecar:

--- a/tests/test_sidecar_supervisor.py
+++ b/tests/test_sidecar_supervisor.py
@@ -69,6 +69,39 @@ def test_start_sidecar_forwards_identity_flags(monkeypatch):
     assert handle.launch_contract["recommended_next_action"]
 
 
+def test_start_sidecar_captures_stdio_to_registry_logs(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["kwargs"] = dict(kwargs)
+        return _FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    registry_dir = tmp_path / "registry"
+
+    handle = start_sidecar(
+        maya_pid=1234,
+        binary_override=Path("dcc-mcp-server"),
+        qt_port_override=45555,
+        registry_dir=registry_dir,
+        start_qt_server_fn=lambda port: {
+            "host": "127.0.0.1",
+            "port": port,
+            "qt_binding": "fake-test-stub",
+        },
+    )
+
+    stdout_path = Path(captured["kwargs"]["stdout"].name)
+    stderr_path = Path(captured["kwargs"]["stderr"].name)
+    assert stdout_path.parent == registry_dir / "logs"
+    assert stderr_path.parent == registry_dir / "logs"
+    assert stdout_path.name.startswith("dcc-mcp-sidecar-1234-")
+    assert stderr_path.name.startswith("dcc-mcp-sidecar-1234-")
+    assert handle.stdout_path == stdout_path
+    assert handle.stderr_path == stderr_path
+
+
 def test_start_sidecar_honors_extra_env_gateway_port_zero(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary
- Raise dcc-mcp-core and dcc-mcp-server floors to 0.18.20 for the latest sidecar diagnostics contract.
- Make the Maya plugin gateway health probe retry briefly and report early sidecar exits with PID and exit code.
- Add regression coverage for retry success and sidecar early-exit diagnostics.

## Related
- Pairs with dcc-mcp-core#1631.

## Validation
- PYTHONPATH=src vx python -m pytest tests/test_plugin_env_vars.py -q
- PYTHONPATH=src vx python -m ruff check maya/plugin/dcc_mcp_maya_plugin.py tests/test_plugin_env_vars.py
- PYTHONPATH=src vx python -m ruff format --check maya/plugin/dcc_mcp_maya_plugin.py tests/test_plugin_env_vars.py
- git diff --check -- pyproject.toml README.md docs/guide/installation.md docs/zh/guide/installation.md maya/plugin/dcc_mcp_maya_plugin.py tests/test_plugin_env_vars.py