### PR TITLE
fix: sanitize Maya sidecar instance ids

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
     env:
       DCC_MCP_ALLOW_AMBIENT_PYTHON: "1"
       DCC_MCP_DISABLE_FILE_LOGGING: "1"
-      DCC_MCP_GATEWAY_PORT: "0"
+      DCC_MCP_GATEWAY_PORT: "18765"
       DCC_MCP_MAYA_SIDECAR: "0"
       DCC_MCP_BASE_URL: "http://127.0.0.1:18765"
     steps:
@@ -223,7 +223,7 @@ jobs:
           import time
           from dcc_mcp_maya import start_server
 
-          handle = start_server(port=18765, gateway_port=0, enable_gateway_failover=False)
+          handle = start_server(port=18766, gateway_port=18765, enable_gateway_failover=False)
           print(handle.mcp_url(), flush=True)
           try:
               while True:
@@ -235,6 +235,8 @@ jobs:
 
       - name: Probe service with dcc-mcp-cli
         run: |
+          set -o pipefail
+
           cleanup() {
             if [ -f "$RUNNER_TEMP/maya-cli-smoke.pid" ]; then
               kill "$(cat "$RUNNER_TEMP/maya-cli-smoke.pid")" 2>/dev/null || true
@@ -250,8 +252,41 @@ jobs:
           done
 
           dcc-mcp-cli health
-          dcc-mcp-cli search --query get_session --limit 3 | tee "$RUNNER_TEMP/dcc-mcp-cli-search.json"
-          dcc-mcp-cli describe maya.maya-scene.maya_scene__get_session_info
+
+          TOOL_SLUG=""
+          for _ in $(seq 1 30); do
+            if ! dcc-mcp-cli search --query scene --limit 10 | tee "$RUNNER_TEMP/dcc-mcp-cli-search.json"; then
+              sleep 1
+              continue
+            fi
+            TOOL_SLUG="$(python - <<'PY'
+          import json
+          import os
+
+          preferred = "maya_scene__get_session_info"
+          path = os.path.join(os.environ["RUNNER_TEMP"], "dcc-mcp-cli-search.json")
+          try:
+              payload = json.load(open(path, encoding="utf-8"))
+          except Exception:
+              raise SystemExit(0)
+          fallback = ""
+          for hit in payload.get("hits", []) or payload.get("tools", []):
+              backend_tool = hit.get("backend_tool") or hit.get("tool") or hit.get("name") or ""
+              slug = hit.get("slug") or hit.get("tool_slug") or hit.get("name") or ""
+              if slug and not fallback:
+                  fallback = slug
+              if slug and (backend_tool == preferred or slug.endswith(preferred)):
+                  print(slug)
+                  break
+          else:
+              print(fallback)
+          PY
+          )"
+            if [ -n "$TOOL_SLUG" ]; then
+              break
+            fi
+            sleep 1
+          done
 
           python - <<'PY'
           import json
@@ -259,11 +294,18 @@ jobs:
 
           path = os.path.join(os.environ["RUNNER_TEMP"], "dcc-mcp-cli-search.json")
           payload = json.load(open(path, encoding="utf-8"))
-          slugs = {hit.get("slug") for hit in payload.get("hits", [])}
-          expected = "maya.maya-scene.maya_scene__get_session_info"
-          if expected not in slugs:
-              raise SystemExit(f"{expected} not found in dcc-mcp-cli search results: {sorted(slugs)}")
+          hits = payload.get("hits", []) or payload.get("tools", [])
+          slugs = []
+          for hit in hits:
+              slug = hit.get("slug") or hit.get("tool_slug") or hit.get("name") or ""
+              if slug:
+                  slugs.append(slug)
+          if not slugs:
+              raise SystemExit(f"dcc-mcp-cli search returned no describable slug: {payload!r}")
           PY
+
+          echo "Resolved tool slug: $TOOL_SLUG"
+          dcc-mcp-cli describe "$TOOL_SLUG"
 
       - name: Dump service log on failure
         if: failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 `dcc-mcp-maya` embeds a standards-compliant MCP Streamable HTTP server directly inside Autodesk Maya. It exposes 198 Maya operations as MCP tools that any AI agent (Claude, Cursor, Gemini, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
 **Current version:** 0.8.8 <!-- x-release-please-version -->
-**Core dependency:** `dcc-mcp-core>=0.17.35,<1.0.0`
+**Core dependency:** `dcc-mcp-core>=0.18.21,<1.0.0`
 **Python:** 3.7+
 **Maya:** 2020+
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Maya plugin starts a Rust `dcc-mcp-server` sidecar by default, so HTTP and g
 [![Python](https://img.shields.io/pypi/pyversions/dcc-mcp-maya?label=Python)](https://pypi.org/project/dcc-mcp-maya/)
 [![Maya](https://img.shields.io/badge/Maya-2020%2B-37A5CC)](https://www.autodesk.com/products/maya/overview)
 [![MCP](https://img.shields.io/badge/MCP-Streamable%20HTTP-6f42c1)](https://modelcontextprotocol.io/)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.18.20-blue)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.18.21-blue)](https://github.com/loonghao/dcc-mcp-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ## Why Use It
@@ -363,8 +363,8 @@ Windows symlinks require Developer Mode or an elevated shell. If symlinks are un
 
 - Autodesk Maya 2020+
 - Python 3.7+
-- `dcc-mcp-core>=0.18.20,<1.0.0`
-- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.18.20`
+- `dcc-mcp-core>=0.18.21,<1.0.0`
+- Standard sidecar binary for plugin mode: `dcc-mcp-server>=0.18.21`
 
 ## License
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -4,8 +4,8 @@
 
 - **Maya**: 2020+ (tested with Maya 2022 through 2026 module packages)
 - **Python**: 3.7 – 3.12 (embedded in Maya)
-- **dcc-mcp-core**: ≥ 0.18.20 (auto-installed as dependency)
-- **dcc-mcp-server**: ≥ 0.18.20 (auto-installed as dependency for the default sidecar gateway)
+- **dcc-mcp-core**: ≥ 0.18.21 (auto-installed as dependency)
+- **dcc-mcp-server**: ≥ 0.18.21 (auto-installed as dependency for the default sidecar gateway)
 
 ## Method 1 — pip into mayapy
 

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -4,8 +4,8 @@
 
 - **Maya**：2020+（模块包覆盖 Maya 2022 至 2026）
 - **Python**：3.7 – 3.12（Maya 内嵌）
-- **dcc-mcp-core**：≥ 0.18.20（作为依赖自动安装）
-- **dcc-mcp-server**：≥ 0.18.20（默认 sidecar gateway 运行时，作为依赖自动安装）
+- **dcc-mcp-core**：≥ 0.18.21（作为依赖自动安装）
+- **dcc-mcp-server**：≥ 0.18.21（默认 sidecar gateway 运行时，作为依赖自动安装）
 
 ## 方式一 — pip 安装到 mayapy
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,7 +14,7 @@ Embeds a standards-compliant MCP Streamable HTTP server (2025-03-26 spec) direct
 - **Repository:** https://github.com/loonghao/dcc-mcp-maya
 - **Python:** >=3.7
 - **Maya:** 2020+
-- **Core dependency:** `dcc-mcp-core>=0.17.35,<1.0.0`
+- **Core dependency:** `dcc-mcp-core>=0.18.21,<1.0.0`
 - **Entry point:** `dcc_mcp.adapters` → `maya = "dcc_mcp_maya:MayaMcpServer"`
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 **Repo:** https://github.com/loonghao/dcc-mcp-maya
 **Python:** >=3.7
 **Maya:** 2020+
-**Core dep:** `dcc-mcp-core>=0.17.36,<1.0.0`
+**Core dep:** `dcc-mcp-core>=0.18.21,<1.0.0`
 
 ---
 

--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -1207,12 +1207,16 @@ def _resolve_instance_id() -> Optional[str]:
     """
     try:
         import dcc_mcp_maya  # noqa: PLC0415
+        from dcc_mcp_maya._identity import normalize_instance_id  # noqa: PLC0415
 
         server = getattr(dcc_mcp_maya.server, "_server_instance", None)
         if server is not None:
             instance_id = getattr(server, "instance_id", None)
+            normalized = normalize_instance_id(instance_id)
+            if normalized:
+                return normalized
             if instance_id:
-                return str(instance_id)
+                logger.debug("ignoring invalid server instance id for sidecar launch: %r", instance_id)
     except Exception as exc:  # noqa: BLE001
         logger.debug("instance id lookup failed: %s", exc)
     return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,11 @@ classifiers = [
 ]
 
 dependencies = [
-    # Release Train anchor: dcc-mcp-core/server v0.18.20 (sidecar diagnostics).
+    # Release Train anchor: dcc-mcp-core/server v0.18.21 (sidecar instance-id contract).
     # 4 lifecycle controllers + shared registration phase pipeline + gateway runtime.
     # Provides abi3 (cp38+) on 3.8+; separate cp37 wheels on Python 3.7 (Maya 2022).
-    "dcc-mcp-core>=0.18.20,<1.0.0",
-    "dcc-mcp-server>=0.18.20,<1.0.0",
+    "dcc-mcp-core>=0.18.21,<1.0.0",
+    "dcc-mcp-server>=0.18.21,<1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -42,7 +42,7 @@ dev = [
     "pytest-timeout>=2.1.0",
     "pytest-xdist>=3.0",
     "requests>=2.28.0",
-    "dcc-mcp-server>=0.18.20,<1.0.0",
+    "dcc-mcp-server>=0.18.21,<1.0.0",
     "ruff>=0.8.0",
     "hatchling",
     "build",

--- a/src/dcc_mcp_maya/_identity.py
+++ b/src/dcc_mcp_maya/_identity.py
@@ -1,0 +1,20 @@
+"""Identity normalization helpers shared by plugin and sidecar launch code."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from uuid import UUID
+
+
+def normalize_instance_id(value: Optional[Any]) -> Optional[str]:
+    """Return a canonical UUID string, or ``None`` when no valid id exists."""
+
+    if value in (None, ""):
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return str(UUID(text))
+    except (TypeError, ValueError):
+        return None

--- a/src/dcc_mcp_maya/sidecar/_supervisor.py
+++ b/src/dcc_mcp_maya/sidecar/_supervisor.py
@@ -54,6 +54,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+from dcc_mcp_maya._identity import normalize_instance_id
 from dcc_mcp_maya.sidecar._resolver import (
     SidecarBinaryError,
     resolve_sidecar_binary,
@@ -304,13 +305,17 @@ def start_sidecar(
         ) from exc
 
     gateway_remote_host, gateway_remote_port = resolve_gateway_remote_options(spawn_env)
+    normalized_instance_id = normalize_instance_id(instance_id)
+    if instance_id not in (None, "") and normalized_instance_id is None:
+        logger.debug("Ignoring invalid sidecar instance_id %r; expected UUID", instance_id)
+
     launch_contract = build_sidecar_command(
         dcc_type=dcc_name,
         host_rpc=host_rpc_uri,
         watch_pid=maya_pid,
         registry_dir=registry_dir,
         server_bin=str(binary),
-        instance_id=instance_id,
+        instance_id=normalized_instance_id,
         display_name=display_name,
         adapter_version=adapter_version,
         gateway_port=_resolve_gateway_port(spawn_env),

--- a/tests/test_plugin_env_vars.py
+++ b/tests/test_plugin_env_vars.py
@@ -389,6 +389,16 @@ class TestSidecarUsesCoreRegistryDefaults:
         _, kwargs = sidecar_pkg.start_sidecar.call_args
         assert kwargs["instance_id"] is None
 
+    def test_resolve_instance_id_ignores_invalid_server_value(self, plugin_module, monkeypatch):
+        """Core-sidecar UUID validation should not turn a cosmetic fallback into a launch failure."""
+        import dcc_mcp_maya.server as server_module
+
+        server = MagicMock()
+        server.instance_id = "unknown"
+        monkeypatch.setattr(server_module, "_server_instance", server)
+
+        assert plugin_module._resolve_instance_id() is None
+
     def test_sidecar_banner_omits_internal_rfc_marker(self, plugin_module, monkeypatch, capsys):
         monkeypatch.setattr(plugin_module, "_is_interactive", lambda: False)
         monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "9765")

--- a/tests/test_sidecar_supervisor.py
+++ b/tests/test_sidecar_supervisor.py
@@ -69,6 +69,32 @@ def test_start_sidecar_forwards_identity_flags(monkeypatch):
     assert handle.launch_contract["recommended_next_action"]
 
 
+def test_start_sidecar_omits_invalid_instance_id(monkeypatch):
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["kwargs"] = dict(kwargs)
+        return _FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    handle = start_sidecar(
+        maya_pid=1234,
+        binary_override=Path("dcc-mcp-server"),
+        qt_port_override=45555,
+        instance_id="unknown",
+        start_qt_server_fn=lambda port: {
+            "host": "127.0.0.1",
+            "port": port,
+            "qt_binding": "fake-test-stub",
+        },
+    )
+
+    assert "--instance-id" not in captured["cmd"]
+    assert handle.launch_contract["readiness_selector"]["instance_id"] is None
+
+
 def test_start_sidecar_captures_stdio_to_registry_logs(monkeypatch, tmp_path):
     captured = {}
 


### PR DESCRIPTION
## Summary
- normalize Maya sidecar instance ids before passing them to the core/server launch contract
- omit invalid fallback values like `unknown` so sidecar startup can continue without `--instance-id unknown`
- bump the core/server dependency floor and user-facing docs to `0.18.21`

## Tests
- `python -m ruff check src/ tests/`
- `python -m ruff format --check src/ tests/`
- `python tools/lint_skills.py --error-only`
- `python tools/lint_skill_affinity.py`
- `dcc-mcp-cli lint src/dcc_mcp_maya/skills`
- `python tools/check_doc_parity.py`
- `python -m pytest -q`

Closes #372
