### PR TITLE
fix: remove stale test requirements install

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,7 +18,6 @@ default:
     echo "🔧 Installing development dependencies..."
     python -m pip install --upgrade pip
     python -m pip install -e ".[dev]"
-    python -m pip install -r requirements-test.txt
     echo "✅ Development dependencies installed"
 
 # Install minimal dependencies (production only)
@@ -243,8 +242,6 @@ lint-all: lint lint-skills lint-docs
     python -m pip install -e .
     echo "  - Installing dev dependencies..."
     python -m pip install -e ".[dev]"
-    echo "  - Installing test requirements..."
-    python -m pip install -r requirements-test.txt
     echo "✅ Dependency issues fixed"
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- remove the stale `requirements-test.txt` install step from development setup
- rely on the existing `.[dev]` dependency set as the single source of truth

## Verification
- `just --dry-run install-dev`
- `just --dry-run fix-deps`
- `python -m ruff check src tests`