### PR TITLE
fix: align maya-primitives inputSchema with script parameter names

### DIFF
--- a/src/dcc_mcp_maya/skills/maya-primitives/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-primitives/tools.yaml
@@ -96,9 +96,9 @@ tools:
   input_schema:
     type: object
     required:
-    - names
+    - object_names
     properties:
-      names:
+      object_names:
         oneOf:
         - type: string
           description: Single object name.
@@ -122,10 +122,6 @@ tools:
     properties:
       object_name:
         type: string
-      world_space:
-        type: boolean
-        default: false
-        description: Read worldSpace transform values instead of object-space.
 - name: rename_object
   description: Rename an object in the scene.
   execution: sync
@@ -136,10 +132,10 @@ tools:
   input_schema:
     type: object
     required:
-    - old_name
+    - object_name
     - new_name
     properties:
-      old_name:
+      object_name:
         type: string
       new_name:
         type: string


### PR DESCRIPTION
## Summary

Fix three `inputSchema` ↔ script-parameter mismatches in `maya-primitives/tools.yaml` that caused MCP tool calls to fail with `unexpected keyword argument` errors:

| Tool | Schema used | Script expects | Fix |
|------|-------------|----------------|-----|
| `get_transform` | `world_space` (undeclared) | not supported | Removed `world_space` |
| `delete_objects` | `names` | `object_names` | Renamed `names` → `object_names` |
| `rename_object` | `old_name` | `object_name` | Renamed `old_name` → `object_name` |

## Test plan

- [x] `test_maya_primitives_error_envelopes.py` — 5 passed
- [x] `test_maya_primitives_created_context.py` — 1 passed
- [x] `test_lint_skills.py` — 40 passed (no schema contract regressions)
- [x] `test_skill_load_integration.py` — 22 passed
- [x] All skill test suites — 321 passed, 3 skipped (Maya not available)

Closes #380