### PR TITLE
fix: add source_file and main() router for maya-scripting introspect tools

### DIFF
--- a/src/dcc_mcp_maya/skills/maya-scripting/scripts/introspect.py
+++ b/src/dcc_mcp_maya/skills/maya-scripting/scripts/introspect.py
@@ -486,6 +486,29 @@ def main_eval(**kwargs) -> dict:
     return eval_expr(**kwargs)
 
 
+# -- main() routing -- the executor's run_skill_script calls main(**params),
+# so we inspect kwargs to dispatch to the correct underlying function.
+# Each function has a unique distinguishing parameter.
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Route to the correct introspect entry point based on parameters.
+
+    The ``@skill_entry`` wrapper catches ``ImportError`` (Maya not running),
+    ``Exception``, and ``BaseException`` so the caller always receives a
+    structured envelope instead of an unhandled traceback.
+    """
+    if "expression" in kwargs:
+        return eval_expr(**kwargs)
+    if "name" in kwargs:
+        return signature(**kwargs)
+    if "query" in kwargs:
+        return search(**kwargs)
+    # Fallback: list_module is the default when only module/page/per_page is present.
+    return list_module(**kwargs)
+
+
 if __name__ == "__main__":
     from dcc_mcp_core.skill import run_main
 

--- a/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
@@ -266,6 +266,7 @@ tools:
   description: Introspect list module for agent-facing Maya scripting introspection.
   execution: sync
   affinity: any
+  source_file: scripts/introspect.py
   annotations:
     read_only_hint: true
     idempotent_hint: true
@@ -275,6 +276,7 @@ tools:
     introspection.
   execution: sync
   affinity: any
+  source_file: scripts/introspect.py
   annotations:
     read_only_hint: true
     idempotent_hint: true
@@ -284,6 +286,7 @@ tools:
     scripting introspection.
   execution: sync
   affinity: any
+  source_file: scripts/introspect.py
   annotations:
     read_only_hint: true
     idempotent_hint: true
@@ -293,6 +296,7 @@ tools:
     introspection.
   execution: sync
   affinity: main
+  source_file: scripts/introspect.py
   annotations:
     read_only_hint: true
   group: introspect


### PR DESCRIPTION
## Summary

The `maya-scripting` skill declares 4 introspection tools (`introspect_list_module`, `introspect_signature`, `introspect_search`, `introspect_eval`) in `tools.yaml` with no `source_file` field. The Rust `resolve_tool_script` returns `None` when no `source_file` is set, no script stem matches the tool name, and more than one script exists in the skill — causing `ToolDispatcher` to skip handler registration. The tools appear in `tools/list` but return `NO_HANDLER` when called.

## Changes

1. **`tools.yaml`** — Add `source_file: scripts/introspect.py` to each of the 4 introspection tools so `resolve_tool_script` returns the correct absolute script path.
2. **`introspect.py`** — Add a `main(**kwargs)` routing function that dispatches to the correct underlying function based on which parameters are present. The executor's `run_skill_script` calls `main(**params)`, and each tool has a unique distinguishing parameter (`expression` → `eval_expr`, `name` → `signature`, `query` → `search`, fallback → `list_module`).

## Testing

- All four tools now have registered handlers via the `source_file` path.
- `@skill_entry` wraps `main()` with error handling (`ImportError`, `Exception`, `BaseException`).
- Existing entry points (`main_list_module`, `main_signature`, `main_search`, `main_eval`) are preserved for backward compatibility.

Fixes #381