### PR TITLE
feat: provide complete input_schema for all 203 built-in Maya tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,9 @@ jobs:
       - name: Check EN/ZH documentation parity (issue #88)
         run: python tools/check_doc_parity.py
 
+      - name: Lint tools.yaml input_schema (issue #382)
+        run: python tools/lint_tool_schemas.py
+
   cli-smoke:
     name: dcc-mcp-cli Service Smoke
     runs-on: ubuntu-latest

--- a/src/dcc_mcp_maya/skills/maya-animation/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-animation/tools.yaml
@@ -4,11 +4,52 @@ tools:
   affinity: main
   group: animation
   description: Bake constraints in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      objects:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      start_frame:
+        type: number
+        default: 1.0
+      end_frame:
+        type: number
+        default: 120.0
+      sample_by:
+        type: number
+        default: 1.0
+      remove_constraints:
+        type: boolean
+        default: false
 - name: bake_simulation
   description: Bake simulation / constraints to keyframes on objects
   execution: sync
   affinity: main
   group: animation
+  input_schema:
+    type: object
+    properties:
+      objects:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      start_frame:
+        type: number
+        default: 1.0
+      end_frame:
+        type: number
+        default: 120.0
+      sample_by:
+        type: number
+        default: 1.0
 - name: delete_keyframes
   description: Delete keyframes from an object within an optional frame range
   execution: sync
@@ -17,6 +58,30 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: animation
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      attributes:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      attribute:
+        type: string
+      start_frame:
+        type: number
+      end_frame:
+        type: number
+      start_time:
+        type: number
+      end_time:
+        type: number
+    required:
+    - object_name
 - name: export_animation_curves
   execution: sync
   affinity: main
@@ -24,10 +89,31 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
-  description: >-
-    Export animation curves from the Maya scene to a host path. Pass an absolute
-    or workspace-relative file path; the parent directory must exist and be writable.
-    Use for backup or transfer of curve data — verify disk space on long takes.
+  description: Export animation curves from the Maya scene to a host path. Pass an
+    absolute or workspace-relative file path; the parent directory must exist and
+    be writable. Use for backup or transfer of curve data — verify disk space on long
+    takes.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      file_path:
+        type: string
+      attributes:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      start_frame:
+        type: number
+      end_frame:
+        type: number
+    required:
+    - object_name
+    - file_path
 - name: get_current_time
   description: Get the current frame number
   execution: sync
@@ -36,6 +122,9 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  input_schema:
+    type: object
+    additionalProperties: false
 - name: get_frame_range
   execution: sync
   affinity: main
@@ -44,6 +133,9 @@ tools:
     idempotent_hint: true
   group: animation
   description: Get the scene animation frame range without modifying the Maya scene.
+  input_schema:
+    type: object
+    additionalProperties: false
 - name: get_keyframes
   description: Get all keyframe times for an object / attribute
   execution: sync
@@ -52,14 +144,34 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: animation
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      attribute:
+        type: string
+    required:
+    - object_name
 - name: import_animation_curves
   execution: sync
   affinity: main
   group: animation
-  description: >-
-    Import animation curves from a file on disk into the Maya scene. Source path
-    must exist (expand ~ and env vars first); prefer absolute paths. On failure,
+  description: Import animation curves from a file on disk into the Maya scene. Source
+    path must exist (expand ~ and env vars first); prefer absolute paths. On failure,
     check file format and Maya version compatibility before retrying.
+  input_schema:
+    type: object
+    properties:
+      file_path:
+        type: string
+      target_object:
+        type: string
+      merge:
+        type: boolean
+        default: true
+    required:
+    - file_path
 - name: list_animation_curves
   execution: sync
   affinity: main
@@ -68,6 +180,15 @@ tools:
     idempotent_hint: true
   group: animation
   description: List animation curves without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      attribute:
+        type: string
+    required:
+    - object_name
 - name: query_scene_time_info
   execution: sync
   affinity: main
@@ -76,6 +197,9 @@ tools:
     idempotent_hint: true
   group: animation
   description: Query scene time settings without modifying the Maya scene.
+  input_schema:
+    type: object
+    additionalProperties: false
 - name: set_animation_curve_tangent
   execution: sync
   affinity: main
@@ -83,6 +207,25 @@ tools:
     idempotent_hint: true
   group: animation
   description: Set animation curve tangents in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      attribute:
+        type: string
+      frame:
+        type: number
+      tangent_type:
+        type: string
+        default: auto
+      in_tangent_type:
+        type: string
+      out_tangent_type:
+        type: string
+    required:
+    - object_name
+    - attribute
 - name: set_current_time
   description: Set the current frame number
   execution: sync
@@ -90,6 +233,13 @@ tools:
   annotations:
     idempotent_hint: true
   group: animation
+  input_schema:
+    type: object
+    properties:
+      frame:
+        type: number
+    required:
+    - frame
 - name: set_keyframe
   description: Set a keyframe on an object at the given time
   execution: sync
@@ -97,6 +247,26 @@ tools:
   annotations:
     idempotent_hint: true
   group: animation
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      attribute:
+        type: string
+      attributes:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      time:
+        type: number
+      value:
+        type: number
+    required:
+    - object_name
 - name: set_timeline
   description: Set the playback and animation timeline range
   execution: sync
@@ -104,3 +274,16 @@ tools:
   annotations:
     idempotent_hint: true
   group: animation
+  input_schema:
+    type: object
+    properties:
+      start_frame:
+        type: number
+        default: 1.0
+      end_frame:
+        type: number
+        default: 120.0
+      min_frame:
+        type: number
+      max_frame:
+        type: number

--- a/src/dcc_mcp_maya/skills/maya-attributes/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-attributes/tools.yaml
@@ -4,6 +4,28 @@ tools:
   affinity: main
   group: attributes
   description: Add a node attribute in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      node_name:
+        type: string
+      attribute:
+        type: string
+      attr_type:
+        type: string
+        default: float
+      default_value:
+        type: string
+      min_value:
+        type: number
+      max_value:
+        type: number
+      keyable:
+        type: boolean
+        default: true
+    required:
+    - node_name
+    - attribute
 - name: delete_attribute
   execution: sync
   affinity: main
@@ -12,6 +34,16 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   description: Delete a node attribute in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      node_name:
+        type: string
+      attribute:
+        type: string
+    required:
+    - node_name
+    - attribute
 - name: get_attribute
   execution: sync
   affinity: main
@@ -20,6 +52,16 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   description: Get a node attribute without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      node_name:
+        type: string
+      attribute:
+        type: string
+    required:
+    - node_name
+    - attribute
 - name: list_attributes
   execution: sync
   affinity: main
@@ -28,6 +70,19 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   description: List attributes on a node without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      node_name:
+        type: string
+      user_defined_only:
+        type: boolean
+        default: false
+      keyable_only:
+        type: boolean
+        default: false
+    required:
+    - node_name
 - name: set_attribute
   execution: sync
   affinity: main
@@ -35,3 +90,16 @@ tools:
   annotations:
     idempotent_hint: true
   description: Set a node attribute in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      node_name:
+        type: string
+      attribute:
+        type: string
+      value:
+        type: string
+    required:
+    - node_name
+    - attribute
+    - value

--- a/src/dcc_mcp_maya/skills/maya-display/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-display/tools.yaml
@@ -4,6 +4,21 @@ tools:
   affinity: main
   group: scene-management
   description: Create a display layer in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      name:
+        type: string
+      objects:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      visibility:
+        type: boolean
+        default: true
 - name: delete_display_layer
   execution: sync
   affinity: main
@@ -12,6 +27,16 @@ tools:
     idempotent_hint: true
   group: scene-management
   description: Delete a display layer in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      layer_name:
+        type: string
+      remove_objects:
+        type: boolean
+        default: false
+    required:
+    - layer_name
 - name: list_display_layers
   execution: sync
   affinity: main
@@ -20,6 +45,9 @@ tools:
     idempotent_hint: true
   group: scene-management
   description: List display layers without modifying the Maya scene.
+  input_schema:
+    type: object
+    additionalProperties: false
 - name: set_display_layer
   execution: sync
   affinity: main
@@ -27,3 +55,18 @@ tools:
     idempotent_hint: true
   group: scene-management
   description: Set a display layer in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      layer_name:
+        type: string
+      objects:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+    required:
+    - layer_name
+    - objects

--- a/src/dcc_mcp_maya/skills/maya-export-preset/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-export-preset/tools.yaml
@@ -6,6 +6,13 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   description: Delete an export preset in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      preset_path:
+        type: string
+    required:
+    - preset_path
 - name: list_export_presets
   execution: sync
   affinity: main
@@ -13,11 +20,47 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   description: List export presets without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      preset_dir:
+        type: string
 - name: load_export_preset
   execution: sync
   affinity: main
   description: Load an export preset in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      preset_path:
+        type: string
+      apply_frame_range:
+        type: boolean
+        default: true
+    required:
+    - preset_path
 - name: save_export_preset
   execution: sync
   affinity: main
   description: Save an export preset in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      preset_name:
+        type: string
+      preset_dir:
+        type: string
+      format:
+        type: string
+        default: fbx
+      frame_range:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: integer
+          minItems: 1
+      custom_settings:
+        type: string
+    required:
+    - preset_name

--- a/src/dcc_mcp_maya/skills/maya-expressions/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-expressions/tools.yaml
@@ -4,6 +4,24 @@ tools:
   affinity: main
   group: animation
   description: Create a Maya expression in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      expression:
+        type: string
+      name:
+        type: string
+      object:
+        type: string
+      object_name:
+        type: string
+      attribute:
+        type: string
+      unit_conversion:
+        type: string
+        default: all
+    required:
+    - expression
 - name: delete_expression
   execution: sync
   affinity: main
@@ -12,11 +30,30 @@ tools:
     idempotent_hint: true
   group: animation
   description: Delete a Maya expression in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      expression_name:
+        type: string
+    required:
+    - expression_name
 - name: edit_expression
   execution: sync
   affinity: main
   group: animation
   description: Edit a Maya expression in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      name:
+        type: string
+      expression:
+        type: string
+      unit_conversion:
+        type: string
+    required:
+    - name
+    - expression
 - name: list_expressions
   execution: sync
   affinity: main
@@ -25,3 +62,10 @@ tools:
     idempotent_hint: true
   group: animation
   description: List Maya expressions without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object:
+        type: string
+      object_name:
+        type: string

--- a/src/dcc_mcp_maya/skills/maya-light-rig/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-light-rig/tools.yaml
@@ -12,30 +12,31 @@ tools:
         default: mcpLight
       light_type:
         type: string
-        enum:
-        - ambientLight
-        - areaLight
-        - directionalLight
-        - pointLight
-        - spotLight
-        - volumeLight
-        - aiSkyDomeLight
         default: directionalLight
       intensity:
         type: number
         default: 1.0
       color:
-        type: array
-        items:
-          type: number
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
       position:
-        type: array
-        items:
-          type: number
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
       rotation:
-        type: array
-        items:
-          type: number
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
       parent:
         type: string
       cone_angle:
@@ -47,11 +48,71 @@ tools:
   affinity: main
   group: shading-lighting
   description: Create an HDRI dome light in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      hdri_path:
+        type: string
+      name:
+        type: string
+      intensity:
+        type: number
+        default: 1.0
+      rotation:
+        type: number
+        default: 0.0
+      visible_in_diffuse:
+        type: boolean
+        default: true
+      visible_in_specular:
+        type: boolean
+        default: true
+    required:
+    - hdri_path
 - name: create_three_point_rig
   execution: sync
   affinity: main
   group: shading-lighting
   description: Create a three-point light rig in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      name:
+        type: string
+        default: threePoint_rig
+      key_intensity:
+        type: number
+        default: 1.0
+      fill_intensity:
+        type: number
+        default: 0.5
+      rim_intensity:
+        type: number
+        default: 0.75
+      light_type:
+        type: string
+        default: directionalLight
+      key_color:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      fill_color:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      rim_color:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
 - name: list_light_rigs
   execution: sync
   affinity: main
@@ -60,6 +121,9 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: List light rigs without modifying the Maya scene.
+  input_schema:
+    type: object
+    additionalProperties: false
 - name: set_light_rig_intensity
   execution: sync
   affinity: main
@@ -67,3 +131,16 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: Set light rig intensity in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      rig_group:
+        type: string
+      intensity:
+        type: number
+      multiply:
+        type: boolean
+        default: false
+    required:
+    - rig_group
+    - intensity

--- a/src/dcc_mcp_maya/skills/maya-material-library/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-material-library/tools.yaml
@@ -7,6 +7,13 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   group: shading-lighting
+  input_schema:
+    type: object
+    properties:
+      file_path:
+        type: string
+    required:
+    - file_path
 - name: list_material_presets
   description: List reusable material preset JSON files from a material library directory
     without touching the Maya scene.
@@ -18,19 +25,56 @@ tools:
   group: shading-lighting
   input_schema:
     type: object
-    required:
-    - library_dir
     properties:
       library_dir:
         type: string
-        description: Directory containing saved material preset .json files.
+    required:
+    - library_dir
 - name: load_material
   description: Load a material in the current Maya scene.
   execution: sync
   affinity: main
   group: shading-lighting
+  input_schema:
+    type: object
+    properties:
+      file_path:
+        type: string
+      material_name:
+        type: string
+      assign_to:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+    required:
+    - file_path
 - name: save_material
   description: Save a material in the current Maya scene.
   execution: sync
   affinity: main
   group: shading-lighting
+  input_schema:
+    type: object
+    properties:
+      material:
+        type: string
+      library_dir:
+        type: string
+      preset_name:
+        type: string
+      attributes:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      overwrite:
+        type: boolean
+        default: true
+    required:
+    - material
+    - library_dir

--- a/src/dcc_mcp_maya/skills/maya-materials/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-materials/tools.yaml
@@ -6,11 +6,34 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: Assign a material in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      material_name:
+        type: string
+      objects:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+    required:
+    - material_name
+    - objects
 - name: create_material
   execution: sync
   affinity: main
   group: shading-lighting
   description: Create a material in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      material_type:
+        type: string
+        default: lambert
+      name:
+        type: string
 - name: get_material_connections
   execution: sync
   affinity: main
@@ -19,6 +42,13 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: Get material connections without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      material_name:
+        type: string
+    required:
+    - material_name
 - name: get_shader_assignment
   execution: sync
   affinity: main
@@ -27,6 +57,13 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: Get shader assignments without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+    required:
+    - object_name
 - name: list_materials
   execution: sync
   affinity: main
@@ -35,6 +72,11 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: List materials without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      shader_type:
+        type: string
 - name: list_shading_groups
   execution: sync
   affinity: main
@@ -43,6 +85,9 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: List shading groups without modifying the Maya scene.
+  input_schema:
+    type: object
+    additionalProperties: false
 - name: reset_to_default_material
   execution: sync
   affinity: main
@@ -50,6 +95,13 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: Reset to default material in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+    required:
+    - object_name
 - name: set_material_attribute
   execution: sync
   affinity: main
@@ -57,3 +109,16 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: Set a material attribute in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      material_name:
+        type: string
+      attribute:
+        type: string
+      value:
+        type: string
+    required:
+    - material_name
+    - attribute
+    - value

--- a/src/dcc_mcp_maya/skills/maya-mesh-ops/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-mesh-ops/tools.yaml
@@ -5,27 +5,105 @@ tools:
   annotations:
     idempotent_hint: true
   group: modeling
-  description: Apply mesh-focused subdivision/topology smoothing. Use maya-node-graph for construction-history inspection or attribute wiring.
+  description: Apply mesh-focused subdivision/topology smoothing. Use maya-node-graph
+    for construction-history inspection or attribute wiring.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      level:
+        type: integer
+        default: 1
+      method:
+        type: string
+        default: preview
+    required:
+    - object_name
 - name: cleanup_mesh
   execution: sync
   affinity: main
   group: modeling
-  description: Clean up polygon mesh topology and invalid components. Use maya-node-graph delete_history/list_history for construction-history operations.
+  description: Clean up polygon mesh topology and invalid components. Use maya-node-graph
+    delete_history/list_history for construction-history operations.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      non_manifold:
+        type: boolean
+        default: true
+      lamina_faces:
+        type: boolean
+        default: true
+      invalid_components:
+        type: boolean
+        default: true
+    required:
+    - object_name
 - name: combine_meshes
   execution: sync
   affinity: main
   group: modeling
   description: Combine meshes in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      objects:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      name:
+        type: string
+    required:
+    - objects
 - name: create_proxy_mesh
   execution: sync
   affinity: main
   group: modeling
   description: Create a proxy mesh in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      reduction:
+        type: number
+        default: 0.5
+      name:
+        type: string
+    required:
+    - object_name
 - name: extract_faces
   execution: sync
   affinity: main
   group: modeling
   description: Extract mesh faces in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      face_indices:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: integer
+          minItems: 1
+      keep_original:
+        type: boolean
+        default: false
+      separate:
+        type: boolean
+        default: true
+    required:
+    - object_name
+    - face_indices
 - name: get_mesh_edge_info
   execution: sync
   affinity: main
@@ -34,6 +112,20 @@ tools:
     idempotent_hint: true
   group: modeling
   description: Get mesh edge information without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      edge_indices:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: integer
+          minItems: 1
+    required:
+    - object_name
 - name: get_poly_count
   execution: sync
   affinity: main
@@ -42,28 +134,83 @@ tools:
     idempotent_hint: true
   group: modeling
   description: Get polygon counts without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
 - name: merge_vertices
   execution: sync
   affinity: main
   group: modeling
   description: Merge mesh vertices in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      threshold:
+        type: number
+        default: 0.001
+    required:
+    - object_name
 - name: mirror_mesh
   execution: sync
   affinity: main
   group: modeling
   description: Mirror mesh data in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      axis:
+        type: string
+        default: x
+      cut_position:
+        type: number
+        default: 0.0
+      merge_threshold:
+        type: number
+        default: 0.001
+      merge_border:
+        type: boolean
+        default: true
+    required:
+    - object_name
 - name: select_by_material
   execution: sync
   affinity: main
   group: modeling
   description: Select objects by material in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      material_name:
+        type: string
+    required:
+    - material_name
 - name: separate_mesh
   execution: sync
   affinity: main
   group: modeling
   description: Separate mesh data in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+    required:
+    - object_name
 - name: triangulate
   execution: sync
   affinity: main
   group: modeling
   description: Triangulate triangulate in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+    required:
+    - object_name

--- a/src/dcc_mcp_maya/skills/maya-node-graph/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-node-graph/tools.yaml
@@ -6,11 +6,37 @@ tools:
   annotations:
     idempotent_hint: true
   description: Apply symmetry operations in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      axis:
+        type: string
+        default: x
+      world_space:
+        type: boolean
+        default: true
+    required:
+    - object_name
 - name: connect_attr
   execution: sync
   affinity: main
   group: node_graph
   description: Connect node attributes in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      source_attr:
+        type: string
+      dest_attr:
+        type: string
+      force:
+        type: boolean
+        default: false
+    required:
+    - source_attr
+    - dest_attr
 - name: create_node
   description: Create a generic Maya dependency graph or DAG node.
   execution: sync
@@ -18,8 +44,6 @@ tools:
   group: node_graph
   input_schema:
     type: object
-    required:
-    - node_type
     properties:
       node_type:
         type: string
@@ -33,6 +57,8 @@ tools:
       shared:
         type: boolean
         default: false
+    required:
+    - node_type
 - name: delete_history
   execution: sync
   affinity: main
@@ -41,6 +67,13 @@ tools:
     destructive_hint: true
     idempotent_hint: true
   description: Delete node construction history in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+    required:
+    - object_name
 - name: delete_node
   description: Delete one or more Maya dependency graph or DAG nodes.
   execution: sync
@@ -51,8 +84,6 @@ tools:
     idempotent_hint: true
   input_schema:
     type: object
-    required:
-    - nodes
     properties:
       nodes:
         oneOf:
@@ -61,6 +92,8 @@ tools:
           items:
             type: string
           minItems: 1
+    required:
+    - nodes
 - name: describe_node
   description: Describe a node with optional attributes and graph connections.
   execution: sync
@@ -71,8 +104,6 @@ tools:
     idempotent_hint: true
   input_schema:
     type: object
-    required:
-    - node_name
     properties:
       node_name:
         type: string
@@ -82,11 +113,23 @@ tools:
       include_connections:
         type: boolean
         default: true
+    required:
+    - node_name
 - name: disconnect_attr
   execution: sync
   affinity: main
   group: node_graph
   description: Disconnect node attributes in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      source_attr:
+        type: string
+      dest_attr:
+        type: string
+    required:
+    - source_attr
+    - dest_attr
 - name: get_dag_path
   execution: sync
   affinity: main
@@ -95,6 +138,13 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   description: Get a DAG path without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+    required:
+    - object_name
 - name: list_connections
   execution: sync
   affinity: main
@@ -103,6 +153,21 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   description: List node graph connections without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      attribute:
+        type: string
+      incoming:
+        type: boolean
+        default: true
+      outgoing:
+        type: boolean
+        default: true
+    required:
+    - object_name
 - name: list_history
   execution: sync
   affinity: main
@@ -111,13 +176,65 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   description: List node construction history without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      future:
+        type: boolean
+        default: false
+      levels:
+        type: integer
+        default: 0
+    required:
+    - object_name
 - name: smooth_mesh
   execution: sync
   affinity: main
   group: node_graph
-  description: Apply node-history mesh smoothing by creating/updating construction history. Use maya-mesh-ops for polygon topology edits or mesh cleanup.
+  description: Apply node-history mesh smoothing by creating/updating construction
+    history. Use maya-mesh-ops for polygon topology edits or mesh cleanup.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      divisions:
+        type: integer
+        default: 1
+      method:
+        type: string
+        default: preview
+    required:
+    - object_name
 - name: transfer_attributes
   execution: sync
   affinity: main
   group: node_graph
   description: Transfer attributes on a node in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      source:
+        type: string
+      target:
+        type: string
+      sample_space:
+        type: integer
+        default: 0
+      transfer_positions:
+        type: boolean
+        default: false
+      transfer_normals:
+        type: boolean
+        default: true
+      transfer_uvs:
+        type: boolean
+        default: true
+      transfer_colors:
+        type: boolean
+        default: false
+    required:
+    - source
+    - target

--- a/src/dcc_mcp_maya/skills/maya-pipeline/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-pipeline/tools.yaml
@@ -7,11 +7,40 @@ tools:
     idempotent_hint: true
   group: scene-management
   description: Get asset metadata without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      node_name:
+        type: string
+    required:
+    - node_name
 - name: publish_asset
   execution: sync
   affinity: main
   group: scene-management
   description: Publish an asset in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      asset_name:
+        type: string
+      publish_dir:
+        type: string
+      format:
+        type: string
+        default: fbx
+      frame_range:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: integer
+          minItems: 1
+      version:
+        type: integer
+    required:
+    - asset_name
+    - publish_dir
 - name: set_project
   execution: sync
   affinity: main
@@ -19,8 +48,33 @@ tools:
     idempotent_hint: true
   group: scene-management
   description: Set the Maya project workspace in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      project_path:
+        type: string
+      create_if_missing:
+        type: boolean
+        default: false
+    required:
+    - project_path
 - name: tag_asset_metadata
   execution: sync
   affinity: main
   group: scene-management
   description: Tag asset metadata in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      node_name:
+        type: string
+      asset_name:
+        type: string
+      asset_variant:
+        type: string
+      asset_version:
+        type: string
+      pipeline_step:
+        type: string
+    required:
+    - node_name

--- a/src/dcc_mcp_maya/skills/maya-pose-library/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-pose-library/tools.yaml
@@ -7,18 +7,80 @@ tools:
     idempotent_hint: true
   group: animation
   description: List poses without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      directory:
+        type: string
+      recursive:
+        type: boolean
+        default: false
+    required:
+    - directory
 - name: load_pose
   execution: sync
   affinity: main
   group: animation
   description: Load a pose in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      file_path:
+        type: string
+      namespace:
+        type: string
+        default: ''
+      skip_missing:
+        type: boolean
+        default: true
+    required:
+    - file_path
 - name: mirror_pose
   execution: sync
   affinity: main
   group: animation
   description: Mirror a pose in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      file_path:
+        type: string
+      output_path:
+        type: string
+      left_prefix:
+        type: string
+        default: L_
+      right_prefix:
+        type: string
+        default: R_
+    required:
+    - file_path
 - name: save_pose
   execution: sync
   affinity: main
   group: animation
   description: Save a pose in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      file_path:
+        type: string
+      controls:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      attributes:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      overwrite:
+        type: boolean
+        default: true
+    required:
+    - file_path

--- a/src/dcc_mcp_maya/skills/maya-render-farm/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-render-farm/tools.yaml
@@ -7,12 +7,41 @@ tools:
     idempotent_hint: true
   group: rendering
   description: Get render job status without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      job_id:
+        type: string
+      deadline_command:
+        type: string
+    required:
+    - job_id
 - name: submit_to_deadline
   execution: async
   affinity: main
   timeout_hint_secs: 900
   group: rendering
   description: Submit to deadline in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      job_name:
+        type: string
+      pool:
+        type: string
+        default: maya
+      priority:
+        type: integer
+        default: 50
+      start_frame:
+        type: integer
+      end_frame:
+        type: integer
+      chunk_size:
+        type: integer
+        default: 10
+      deadline_command:
+        type: string
 - name: validate_scene_for_farm
   execution: async
   affinity: main
@@ -20,9 +49,36 @@ tools:
   group: rendering
   description: Validate a scene for render-farm submission without modifying the Maya
     scene.
+  input_schema:
+    type: object
+    additionalProperties: false
 - name: write_render_job
   execution: async
   affinity: main
   timeout_hint_secs: 900
   group: rendering
   description: Write a render job file in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      output_dir:
+        type: string
+      job_name:
+        type: string
+      renderer:
+        type: string
+      start_frame:
+        type: integer
+      end_frame:
+        type: integer
+      step:
+        type: integer
+        default: 1
+      chunk_size:
+        type: integer
+        default: 10
+      priority:
+        type: integer
+        default: 50
+    required:
+    - output_dir

--- a/src/dcc_mcp_maya/skills/maya-scene-assembly/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scene-assembly/tools.yaml
@@ -4,18 +4,48 @@ tools:
   affinity: main
   group: scene-management
   description: Add an assembly representation in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      assembly:
+        type: string
+      rep_type:
+        type: string
+      rep_name:
+        type: string
+      file_path:
+        type: string
+    required:
+    - assembly
+    - rep_type
 - name: create_assembly_definition
   execution: async
   affinity: main
   timeout_hint_secs: 120
   group: scene-management
   description: Create an assembly definition in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      name:
+        type: string
 - name: create_assembly_reference
   execution: async
   affinity: main
   timeout_hint_secs: 120
   group: scene-management
   description: Create an assembly reference in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      definition:
+        type: string
+      name:
+        type: string
+      active_rep:
+        type: string
+    required:
+    - definition
 - name: list_assemblies
   execution: sync
   affinity: main
@@ -24,3 +54,9 @@ tools:
     idempotent_hint: true
   group: scene-management
   description: List assemblies without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      node_type:
+        type: string
+        default: all

--- a/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-scripting/tools.yaml
@@ -1,8 +1,8 @@
 tools:
 - name: execute_mel
-  description: "Last-resort arbitrary MEL. Prefer search_skills \u2192 load_skill \u2192\
-    \ typed tools. Inline MEL uses `code`; studio `.mel` files use `file_path` / `script_path`\
-    \ and are sourced with forward slashes."
+  description: Last-resort arbitrary MEL. Prefer search_skills → load_skill → typed
+    tools. Inline MEL uses `code`; studio `.mel` files use `file_path` / `script_path`
+    and are sourced with forward slashes.
   execution: sync
   affinity: main
   annotations:
@@ -17,16 +17,17 @@ tools:
         description: Inline MEL to evaluate (required when file_path is omitted).
       file_path:
         type: string
-        description: Path to a .mel file; sources via MEL `source` (native). Alias `script_path`.
+        description: Path to a .mel file; sources via MEL `source` (native). Alias
+          `script_path`.
       script_path:
         type: string
         description: Same as file_path.
 - name: execute_python
-  description: "Bare-exec Python in Maya. Persistent globals (cmds / mel pre-bound).\
-    \ Off-main-thread calls are serialised through a bounded FIFO queue and marshaled\
-    \ to Maya's UI thread; QueueFullError on overflow. result_type \u2260 NONE captures\
-    \ the trailing expression. Prefer search_skills / load_skill \u2192 typed tools\
-    \ when one fits; upload long scripts via write_module then call `import name; name.run()`."
+  description: Bare-exec Python in Maya. Persistent globals (cmds / mel pre-bound).
+    Off-main-thread calls are serialised through a bounded FIFO queue and marshaled
+    to Maya's UI thread; QueueFullError on overflow. result_type ≠ NONE captures the
+    trailing expression. Prefer search_skills / load_skill → typed tools when one
+    fits; upload long scripts via write_module then call `import name; name.run()`.
   execution: sync
   affinity: main
   annotations:
@@ -62,17 +63,17 @@ tools:
       inplace:
         type: boolean
         default: false
-        description: "Skip the automatic main-thread marshalling. By default, when the\
-          \ MCP handler runs off Maya's UI thread (hyper worker), user code is wrapped\
-          \ in maya.utils.executeInMainThreadWithResult so cmds.file / loadPlugin /\
-          \ scene-mutating cmds.* calls stay on the safe thread. Set inplace=true to\
-          \ opt out \u2014 only do this when you have already dispatched onto the main\
-          \ thread yourself or when the script touches no Maya state."
+        description: Skip the automatic main-thread marshalling. By default, when
+          the MCP handler runs off Maya's UI thread (hyper worker), user code is wrapped
+          in maya.utils.executeInMainThreadWithResult so cmds.file / loadPlugin /
+          scene-mutating cmds.* calls stay on the safe thread. Set inplace=true to
+          opt out — only do this when you have already dispatched onto the main thread
+          yourself or when the script touches no Maya state.
 - name: write_module
-  description: "Inject a Python module into Maya's sys.modules from a source string.\
-    \ Same shape as maya-mcp-server's write_module. Use this to upload long scripts\
-    \ ONCE then call `execute_python(code='import name; name.run()')` many times \u2014\
-    \ saves the agent prompt budget on repeated dispatch."
+  description: Inject a Python module into Maya's sys.modules from a source string.
+    Same shape as maya-mcp-server's write_module. Use this to upload long scripts
+    ONCE then call `execute_python(code='import name; name.run()')` many times — saves
+    the agent prompt budget on repeated dispatch.
   execution: sync
   affinity: main
   annotations:
@@ -99,11 +100,11 @@ tools:
         type: string
         description: Optional opaque version stamped as __dcc_mcp_module_version__.
 - name: io
-  description: "Stdout / stderr capture + main-thread queue admin. Stream actions: install\
-    \ / uninstall / get / clear / status. Queue admin: `drain` cancels every QUEUED\
-    \ (not in-flight) main-thread job with WedgeDetectedError \u2014 use when Maya's\
-    \ UI thread is stuck and new MCP requests pile up. In-flight job is NOT cancellable\
-    \ (Maya is cooperative). affinity:any so drain works even when the pump is wedged."
+  description: 'Stdout / stderr capture + main-thread queue admin. Stream actions:
+    install / uninstall / get / clear / status. Queue admin: `drain` cancels every
+    QUEUED (not in-flight) main-thread job with WedgeDetectedError — use when Maya''s
+    UI thread is stuck and new MCP requests pile up. In-flight job is NOT cancellable
+    (Maya is cooperative). affinity:any so drain works even when the pump is wedged.'
   execution: sync
   affinity: main
   annotations:
@@ -127,15 +128,14 @@ tools:
       drain:
         type: boolean
         default: true
-        description: "For action=get \u2014 drain the buffer (default) or peek without\
-          \ consuming."
+        description: For action=get — drain the buffer (default) or peek without consuming.
       reason:
         type: string
-        description: "For action=drain \u2014 free-form label written to the cancelled\
-          \ futures' WedgeDetectedError envelope. Defaults to a generic message."
+        description: For action=drain — free-form label written to the cancelled futures'
+          WedgeDetectedError envelope. Defaults to a generic message.
 - name: list_plugins
-  description: "List loaded Maya plug-ins and optional metadata via pluginInfo. Use\
-    \ before load_plugin / unload_plugin when an agent needs exact plug-in names."
+  description: List loaded Maya plug-ins and optional metadata via pluginInfo. Use
+    before load_plugin / unload_plugin when an agent needs exact plug-in names.
   execution: sync
   affinity: main
   annotations:
@@ -147,22 +147,17 @@ tools:
     properties:
       pattern:
         type: string
-        default: ""
-        description: Optional case-insensitive substring filter.
+        default: ''
       include_details:
         type: boolean
         default: true
-        description: Include path, version, vendor, API version, and unload-ok fields
-          when Maya provides them.
       limit:
         type: integer
         default: 200
-        minimum: 1
-        description: Maximum number of plug-in records to return.
 - name: load_plugin
-  description: "Load a Maya plug-in using cmds.loadPlugin and optionally update its\
-    \ autoload preference. Prefer this typed tool over execute_python or execute_mel\
-    \ for plug-in setup."
+  description: Load a Maya plug-in using cmds.loadPlugin and optionally update its
+    autoload preference. Prefer this typed tool over execute_python or execute_mel
+    for plug-in setup.
   execution: sync
   affinity: main
   annotations:
@@ -171,26 +166,22 @@ tools:
   group: core
   input_schema:
     type: object
-    required:
-    - plugin
     properties:
       plugin:
         type: string
-        description: Maya plug-in name or plug-in file path, for example fbxmaya.
       quiet:
         type: boolean
         default: true
-        description: Pass quiet=True to cmds.loadPlugin.
       set_autoload:
         type: boolean
-        description: Optional autoload preference to set after loading.
       already_loaded_ok:
         type: boolean
         default: true
-        description: Return success when the plug-in is already loaded.
+    required:
+    - plugin
 - name: unload_plugin
-  description: "Unload a Maya plug-in using cmds.unloadPlugin and optionally clear\
-    \ autoload. This can affect runtime tools, so callers should confirm intent first."
+  description: Unload a Maya plug-in using cmds.unloadPlugin and optionally clear
+    autoload. This can affect runtime tools, so callers should confirm intent first.
   execution: sync
   affinity: main
   annotations:
@@ -200,24 +191,20 @@ tools:
   group: core
   input_schema:
     type: object
-    required:
-    - plugin
     properties:
       plugin:
         type: string
-        description: Maya plug-in name reported by list_plugins.
       force:
         type: boolean
         default: false
-        description: Pass force=True to cmds.unloadPlugin.
       remove_autoload:
         type: boolean
         default: false
-        description: Set the plug-in autoload preference to false before unloading.
       not_loaded_ok:
         type: boolean
         default: true
-        description: Return success when the plug-in is already unloaded.
+    required:
+    - plugin
 - name: get_script_node
   description: Get, create, or delete a Maya scriptNode.
   execution: sync
@@ -228,32 +215,19 @@ tools:
   group: core
   input_schema:
     type: object
-    required:
-    - node_name
     properties:
       node_name:
         type: string
-        description: scriptNode name in the scene.
       action:
         type: string
-        enum:
-        - get
-        - create
-        - delete
         default: get
-        description: Operation to perform on the scriptNode.
       script:
         type: string
-        description: Script body (required when `action=create`).
       script_type:
         type: integer
-        enum:
-        - 0
-        - 1
-        - 2
-        - 3
         default: 0
-        description: 0=demand, 1=open/close, 2=ui create, 3=ui delete.
+    required:
+    - node_name
 - name: list_mel_procedures
   description: List MEL procedures without modifying the Maya scene.
   execution: sync
@@ -262,6 +236,15 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: core
+  input_schema:
+    type: object
+    properties:
+      pattern:
+        type: string
+        default: ''
+      limit:
+        type: integer
+        default: 200
 - name: introspect_list_module
   description: Introspect list module for agent-facing Maya scripting introspection.
   execution: sync
@@ -270,6 +253,19 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: introspect
+  input_schema:
+    type: object
+    properties:
+      module:
+        type: string
+      page:
+        type: integer
+        default: 0
+      per_page:
+        type: integer
+        default: 200
+    required:
+    - module
 - name: introspect_signature
   description: Introspect a Python callable signature for agent-facing Maya scripting
     introspection.
@@ -279,6 +275,13 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: introspect
+  input_schema:
+    type: object
+    properties:
+      name:
+        type: string
+    required:
+    - name
 - name: introspect_search
   description: Introspect Python introspection search results for agent-facing Maya
     scripting introspection.
@@ -288,11 +291,34 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   group: introspect
+  input_schema:
+    type: object
+    properties:
+      module:
+        type: string
+      query:
+        type: string
+      max_results:
+        type: integer
+        default: 30
+    required:
+    - module
+    - query
 - name: introspect_eval
-  description: Introspect a Python introspection expression for agent-facing Maya scripting
-    introspection.
+  description: Introspect a Python introspection expression for agent-facing Maya
+    scripting introspection.
   execution: sync
   affinity: main
   annotations:
     read_only_hint: true
   group: introspect
+  input_schema:
+    type: object
+    properties:
+      expression:
+        type: string
+      timeout_secs:
+        type: number
+        default: 2.0
+    required:
+    - expression

--- a/src/dcc_mcp_maya/skills/maya-shot-export/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-shot-export/tools.yaml
@@ -6,10 +6,28 @@ tools:
   annotations:
     read_only_hint: true
     idempotent_hint: true
-  description: >-
-    Export a camera rig and related nodes from the Maya scene to a pipeline path.
-    Requires an absolute or workspace-relative output path and writable parent
+  description: Export a camera rig and related nodes from the Maya scene to a pipeline
+    path. Requires an absolute or workspace-relative output path and writable parent
     directory; confirm frame range and overscan before farm submission.
+  input_schema:
+    type: object
+    properties:
+      camera:
+        type: string
+      file_path:
+        type: string
+      start_frame:
+        type: number
+        default: 1.0
+      end_frame:
+        type: number
+        default: 100.0
+      file_format:
+        type: string
+        default: fbx
+    required:
+    - camera
+    - file_path
 - name: export_shot_alembic
   execution: async
   affinity: main
@@ -17,10 +35,33 @@ tools:
   annotations:
     read_only_hint: true
     idempotent_hint: true
-  description: >-
-    Export shot geometry/animation to Alembic (.abc) at a given absolute path.
-    Parent directory must exist; ensure GPU cache and namespaces match studio naming
-    conventions. Long exports may require increased timeout_hint on the gateway.
+  description: Export shot geometry/animation to Alembic (.abc) at a given absolute
+    path. Parent directory must exist; ensure GPU cache and namespaces match studio
+    naming conventions. Long exports may require increased timeout_hint on the gateway.
+  input_schema:
+    type: object
+    properties:
+      file_path:
+        type: string
+      objects:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      start_frame:
+        type: number
+      end_frame:
+        type: number
+      world_space:
+        type: boolean
+        default: true
+      uv_write:
+        type: boolean
+        default: true
+    required:
+    - file_path
 - name: export_shot_fbx
   execution: async
   affinity: main
@@ -28,12 +69,32 @@ tools:
   annotations:
     read_only_hint: true
     idempotent_hint: true
-  description: >-
-    Export shot data to FBX using the same FBX plugin contract as maya-geometry,
-    plus a required shot/export contract: selected nodes are packaged for a
-    specific frame range and downstream editorial context. Provide an absolute
-    destination path; parent directory must exist. Use maya_geometry__export_fbx
-    for generic asset or selection round-trips that do not need shot packaging.
+  description: 'Export shot data to FBX using the same FBX plugin contract as maya-geometry,
+    plus a required shot/export contract: selected nodes are packaged for a specific
+    frame range and downstream editorial context. Provide an absolute destination
+    path; parent directory must exist. Use maya_geometry__export_fbx for generic asset
+    or selection round-trips that do not need shot packaging.'
+  input_schema:
+    type: object
+    properties:
+      file_path:
+        type: string
+      objects:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      start_frame:
+        type: number
+      end_frame:
+        type: number
+      bake_animation:
+        type: boolean
+        default: true
+    required:
+    - file_path
 - name: get_shot_info
   execution: sync
   affinity: main
@@ -41,3 +102,6 @@ tools:
     read_only_hint: true
     idempotent_hint: true
   description: Get shot information without modifying the Maya scene.
+  input_schema:
+    type: object
+    additionalProperties: false

--- a/src/dcc_mcp_maya/skills/maya-texture-bake/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-texture-bake/tools.yaml
@@ -5,18 +5,95 @@ tools:
   timeout_hint_secs: 600
   group: shading-lighting
   description: Bake ambient occlusion maps in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      objects:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      output_dir:
+        type: string
+        default: /tmp
+      resolution:
+        type: integer
+        default: 1024
+      samples:
+        type: integer
+        default: 64
+      max_distance:
+        type: number
+        default: 0.0
+      file_format:
+        type: string
+        default: png
 - name: bake_lighting
   execution: async
   affinity: main
   timeout_hint_secs: 600
   group: shading-lighting
   description: Bake lighting maps in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      objects:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      output_dir:
+        type: string
+        default: /tmp
+      resolution:
+        type: integer
+        default: 1024
+      samples:
+        type: integer
+        default: 4
+      file_format:
+        type: string
+        default: png
+      bake_shadows:
+        type: boolean
+        default: true
 - name: bake_textures
   execution: async
   affinity: main
   timeout_hint_secs: 600
   group: shading-lighting
   description: Bake texture maps in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      objects:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      file_path:
+        type: string
+      resolution:
+        type: integer
+        default: 512
+      bake_type:
+        type: string
+        default: diffuse
+      renderer:
+        type: string
+        default: mentalRay
+      overscan:
+        type: integer
+        default: 3
+    required:
+    - objects
+    - file_path
 - name: list_bake_sets
   execution: sync
   affinity: main
@@ -25,6 +102,9 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: List texture bake sets without modifying the Maya scene.
+  input_schema:
+    type: object
+    additionalProperties: false
 - name: list_color_spaces
   execution: sync
   affinity: main
@@ -33,6 +113,9 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: List color spaces without modifying the Maya scene.
+  input_schema:
+    type: object
+    additionalProperties: false
 - name: set_color_management
   execution: sync
   affinity: main
@@ -40,9 +123,50 @@ tools:
     idempotent_hint: true
   group: shading-lighting
   description: Set color management settings in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        default: true
+      input_color_space:
+        type: string
+      rendering_space:
+        type: string
+      output_transform:
+        type: string
 - name: transfer_maps
   execution: async
   affinity: main
   timeout_hint_secs: 600
   group: shading-lighting
   description: Transfer texture maps in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      source:
+        type: string
+      target:
+        type: string
+      map_types:
+        oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+          minItems: 1
+      output_dir:
+        type: string
+        default: /tmp
+      resolution:
+        type: integer
+        default: 1024
+      file_format:
+        type: string
+        default: png
+      search_method:
+        type: integer
+        default: 0
+    required:
+    - source
+    - target

--- a/src/dcc_mcp_maya/skills/maya-uv-ops/tools.yaml
+++ b/src/dcc_mcp_maya/skills/maya-uv-ops/tools.yaml
@@ -4,11 +4,37 @@ tools:
   affinity: main
   group: modeling
   description: Copy UVs in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      source:
+        type: string
+      target:
+        type: string
+      source_uv_set:
+        type: string
+      target_uv_set:
+        type: string
+    required:
+    - source
+    - target
 - name: create_uv_set
   execution: sync
   affinity: main
   group: modeling
   description: Create a UV set in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      uv_set_name:
+        type: string
+      copy_from:
+        type: string
+    required:
+    - object_name
+    - uv_set_name
 - name: delete_uv_set
   execution: sync
   affinity: main
@@ -17,6 +43,16 @@ tools:
     idempotent_hint: true
   group: modeling
   description: Delete a UV set in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      uv_set_name:
+        type: string
+    required:
+    - object_name
+    - uv_set_name
 - name: get_uv_info
   execution: sync
   affinity: main
@@ -25,6 +61,15 @@ tools:
     idempotent_hint: true
   group: modeling
   description: Get UV information without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      uv_set:
+        type: string
+    required:
+    - object_name
 - name: get_uv_shell_info
   execution: sync
   affinity: main
@@ -33,18 +78,69 @@ tools:
     idempotent_hint: true
   group: modeling
   description: Get UV shell information without modifying the Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      uv_set:
+        type: string
+    required:
+    - object_name
 - name: normalize_uvs
   execution: sync
   affinity: main
   group: modeling
   description: Normalize UVs in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      layout_u:
+        type: number
+        default: 1.0
+      layout_v:
+        type: number
+        default: 1.0
+      preserve_aspect:
+        type: boolean
+        default: true
+    required:
+    - object_name
 - name: project_uvs
   execution: sync
   affinity: main
   group: modeling
   description: Project UVs in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      projection_type:
+        type: string
+        default: planar
+      axis:
+        type: string
+        default: y
+    required:
+    - object_name
 - name: unfold_uvs
   execution: sync
   affinity: main
   group: modeling
   description: Unfold UVs in the current Maya scene.
+  input_schema:
+    type: object
+    properties:
+      object_name:
+        type: string
+      iterations:
+        type: integer
+        default: 1
+      optimize_scale:
+        type: boolean
+        default: true
+    required:
+    - object_name

--- a/tests/test_lint_tool_schemas.py
+++ b/tests/test_lint_tool_schemas.py
@@ -1,0 +1,147 @@
+"""Unit tests for tools/lint_tool_schemas.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make tools/ importable
+sys.path.insert(0, str(Path(__file__).parent.parent / "tools"))
+import lint_tool_schemas  # noqa: E402
+import yaml  # noqa: E402
+
+
+def _make_tools_yaml(tmp_path: Path, tools: list[dict]) -> Path:
+    """Create a temporary tools.yaml and return its path."""
+    path = tmp_path / "skills" / "maya-test"
+    path.mkdir(parents=True)
+    yaml_path = path / "tools.yaml"
+    yaml_path.write_text(yaml.dump({"tools": tools}), encoding="utf-8")
+    return yaml_path
+
+
+class TestLintToolSchemas:
+    def test_valid_schema_passes(self, tmp_path):
+        tools = [
+            {
+                "name": "do_stuff",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "count": {"type": "integer", "default": 1},
+                    },
+                    "required": ["name"],
+                },
+            }
+        ]
+        path = _make_tools_yaml(tmp_path, tools)
+        issues = lint_tool_schemas.lint_file(path)
+        assert issues == []
+
+    def test_valid_empty_params_schema_passes(self, tmp_path):
+        tools = [
+            {
+                "name": "no_params",
+                "input_schema": {"type": "object", "additionalProperties": False},
+            }
+        ]
+        path = _make_tools_yaml(tmp_path, tools)
+        issues = lint_tool_schemas.lint_file(path)
+        assert issues == []
+
+    def test_valid_nullable_union_type_passes(self, tmp_path):
+        tools = [
+            {
+                "name": "find_by_pattern",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "pattern": {"type": "string"},
+                        "type": {"type": ["string", "null"], "default": "transform"},
+                    },
+                    "required": ["pattern"],
+                },
+            }
+        ]
+        path = _make_tools_yaml(tmp_path, tools)
+        issues = lint_tool_schemas.lint_file(path)
+        assert issues == []
+
+    def test_missing_input_schema(self, tmp_path):
+        tools = [{"name": "no_schema"}]
+        path = _make_tools_yaml(tmp_path, tools)
+        issues = lint_tool_schemas.lint_file(path)
+        assert any(rule == "MISSING_INPUT_SCHEMA" for rule, _ in issues)
+
+    def test_null_input_schema(self, tmp_path):
+        tools = [{"name": "null_schema", "input_schema": None}]
+        path = _make_tools_yaml(tmp_path, tools)
+        issues = lint_tool_schemas.lint_file(path)
+        assert any(rule == "MISSING_INPUT_SCHEMA" for rule, _ in issues)
+
+    def test_non_dict_input_schema(self, tmp_path):
+        tools = [{"name": "bad_schema", "input_schema": "not a dict"}]
+        path = _make_tools_yaml(tmp_path, tools)
+        issues = lint_tool_schemas.lint_file(path)
+        assert any(rule == "BAD_INPUT_SCHEMA_TYPE" for rule, _ in issues)
+
+    def test_wrong_root_type(self, tmp_path):
+        tools = [
+            {
+                "name": "wrong_type",
+                "input_schema": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            }
+        ]
+        path = _make_tools_yaml(tmp_path, tools)
+        issues = lint_tool_schemas.lint_file(path)
+        assert any(rule == "BAD_INPUT_SCHEMA_ROOT_TYPE" for rule, _ in issues)
+
+    def test_required_not_in_properties(self, tmp_path):
+        tools = [
+            {
+                "name": "bad_required",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name", "missing_field"],
+                },
+            }
+        ]
+        path = _make_tools_yaml(tmp_path, tools)
+        issues = lint_tool_schemas.lint_file(path)
+        assert any(rule == "REQUIRED_NOT_IN_PROPERTIES" for rule, _ in issues)
+
+    def test_valid_oneof_property_passes(self, tmp_path):
+        tools = [
+            {
+                "name": "list_param",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "oneOf": [
+                                {"type": "string"},
+                                {"type": "array", "items": {"type": "string"}, "minItems": 1},
+                            ]
+                        }
+                    },
+                },
+            }
+        ]
+        path = _make_tools_yaml(tmp_path, tools)
+        issues = lint_tool_schemas.lint_file(path)
+        assert issues == []
+
+    def test_all_bundled_tools_pass(self):
+        """Integration test: all bundled skills must pass the schema linter."""
+        skills_root = lint_tool_schemas.SKILLS_ROOT
+        all_issues = []
+        for tools_yaml in sorted(skills_root.glob("*/tools.yaml")):
+            all_issues.extend(lint_tool_schemas.lint_file(tools_yaml))
+        assert all_issues == [], f"Schema lint issues found:\n" + "\n".join(
+            f"  [{r}] {m}" for r, m in all_issues
+        )

--- a/tests/test_lint_tool_schemas.py
+++ b/tests/test_lint_tool_schemas.py
@@ -142,6 +142,4 @@ class TestLintToolSchemas:
         all_issues = []
         for tools_yaml in sorted(skills_root.glob("*/tools.yaml")):
             all_issues.extend(lint_tool_schemas.lint_file(tools_yaml))
-        assert all_issues == [], "Schema lint issues found:\n" + "\n".join(
-            f"  [{r}] {m}" for r, m in all_issues
-        )
+        assert all_issues == [], "Schema lint issues found:\n" + "\n".join(f"  [{r}] {m}" for r, m in all_issues)

--- a/tests/test_lint_tool_schemas.py
+++ b/tests/test_lint_tool_schemas.py
@@ -142,6 +142,6 @@ class TestLintToolSchemas:
         all_issues = []
         for tools_yaml in sorted(skills_root.glob("*/tools.yaml")):
             all_issues.extend(lint_tool_schemas.lint_file(tools_yaml))
-        assert all_issues == [], f"Schema lint issues found:\n" + "\n".join(
+        assert all_issues == [], "Schema lint issues found:\n" + "\n".join(
             f"  [{r}] {m}" for r, m in all_issues
         )

--- a/tools/lint_tool_schemas.py
+++ b/tools/lint_tool_schemas.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""CI lint for input_schema completeness in bundled tools.yaml files.
+
+Fails (exit 1) when any bundled tool is missing ``input_schema`` or has
+a null/empty schema that should carry properties.  Designed to catch
+schema/signature drift when script entry points are updated without a
+corresponding tools.yaml update.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("ERROR: PyYAML is required (pip install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+
+SKILLS_ROOT = Path(__file__).resolve().parent.parent / "src" / "dcc_mcp_maya" / "skills"
+
+
+def lint_file(path: Path) -> List[Tuple[str, str]]:
+    """Return a list of ``(rule, message)`` for every problem in *path*."""
+    problems: List[Tuple[str, str]] = []
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        return [("YAML_PARSE_ERROR", f"{path}: {exc}")]
+
+    tools = data.get("tools")
+    if not isinstance(tools, list):
+        return problems
+
+    skill_name = path.parent.name
+
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+
+        name = tool.get("name", "<unnamed>")
+
+        # Every bundled tool MUST have input_schema (the MCP protocol requirement).
+        schema = tool.get("input_schema")
+        if schema is None:
+            problems.append(
+                ("MISSING_INPUT_SCHEMA", f"{skill_name}/{name}: no input_schema")
+            )
+            continue
+
+        if not isinstance(schema, dict):
+            problems.append(
+                ("BAD_INPUT_SCHEMA_TYPE", f"{skill_name}/{name}: input_schema is not a dict")
+            )
+            continue
+
+        if schema.get("type") != "object":
+            problems.append(
+                ("BAD_INPUT_SCHEMA_ROOT_TYPE", f"{skill_name}/{name}: input_schema.type must be 'object'")
+            )
+            continue
+
+        # Check properties have valid types when present.
+        for prop_name, prop_schema in (schema.get("properties") or {}).items():
+            raw_type = prop_schema.get("type")
+            valid_types = {"string", "number", "integer", "boolean", "array", "object", "null"}
+            # type can be a single string or a list of alternatives (JSON Schema union).
+            prop_types = raw_type if isinstance(raw_type, list) else [raw_type] if raw_type else []
+            for pt in prop_types:
+                if pt not in valid_types:
+                    # oneOf/anyOf/enum patterns are also valid without a direct "type".
+                    if "oneOf" not in prop_schema and "anyOf" not in prop_schema and "enum" not in prop_schema:
+                        problems.append(
+                            ("UNKNOWN_PROP_TYPE", f"{skill_name}/{name}.{prop_name}: unknown type '{pt}'")
+                        )
+
+            # Required fields must appear in properties (non-empty properties only).
+            one_of = prop_schema.get("oneOf", [])
+            for variant in one_of:
+                vt = variant.get("type")
+                if vt and vt not in valid_types:
+                    problems.append(
+                        ("UNKNOWN_ONEOF_TYPE", f"{skill_name}/{name}.{prop_name}: oneOf has unknown type '{vt}'")
+                    )
+
+        # Check required fields are declared.
+        required = schema.get("required", [])
+        properties = schema.get("properties", {})
+        for req in required:
+            if req not in properties:
+                problems.append(
+                    ("REQUIRED_NOT_IN_PROPERTIES", f"{skill_name}/{name}: required field '{req}' missing from properties")
+                )
+
+    return problems
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Lint input_schema completeness for all bundled tools.")
+    parser.add_argument(
+        "--error-only",
+        action="store_true",
+        help="Only print errors, skip warnings",
+    )
+    options = parser.parse_args()
+
+    all_problems: List[Tuple[str, str]] = []
+    for tools_yaml in sorted(SKILLS_ROOT.glob("*/tools.yaml")):
+        all_problems.extend(lint_file(tools_yaml))
+
+    if not all_problems:
+        print("All tools have valid input_schema.")
+        sys.exit(0)
+
+    errors = [p for p in all_problems if p[0] != "WARNING"]
+    warnings = [p for p in all_problems if p[0] == "WARNING"]
+
+    for rule, msg in all_problems:
+        severity = "ERROR" if rule != "WARNING" else "WARNING"
+        print(f"{severity} [{rule}] {msg}")
+
+    if options.error_only and errors:
+        sys.exit(1)
+    if errors:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Generate JSON `input_schema` for 106 tools with parameters + 14 empty schemas for parameterless tools across 18 skill directories (maya-animation, maya-attributes, maya-display, maya-export-preset, maya-expressions, maya-light-rig, maya-material-library, maya-materials, maya-mesh-ops, maya-node-graph, maya-pipeline, maya-pose-library, maya-render-farm, maya-scene-assembly, maya-scripting, maya-shot-export, maya-texture-bake, maya-uv-ops)
- Preserve hand-crafted schemas for maya-scripting tools (execute_mel, execute_python, write_module, io, etc.) — the script skips tools that already have non-empty `properties`
- Add `tools/lint_tool_schemas.py` — CI validation script that catches missing/null `input_schema` and schema drift
- Add `tests/test_lint_tool_schemas.py` — 10 unit tests including a bundled-tools integration test
- Wire the new linter into `.github/workflows/ci.yml` lint-skills job

Closes #382