### PR TITLE
fix: publish sidecar discovery endpoint

### DIFF
--- a/maya/plugin/dcc_mcp_maya_plugin.py
+++ b/maya/plugin/dcc_mcp_maya_plugin.py
@@ -832,6 +832,7 @@ def _maybe_spawn_sidecar() -> None:
         _sidecar_handle = start_sidecar(
             adapter_version=VERSION,
             display_name=_resolve_sidecar_display_name(),
+            discovery_mcp_url=_handle.mcp_url() if _handle is not None else None,
             gateway_name=_resolve_gateway_name(),
             instance_id=_resolve_instance_id(),
         )

--- a/src/dcc_mcp_maya/sidecar/_supervisor.py
+++ b/src/dcc_mcp_maya/sidecar/_supervisor.py
@@ -219,6 +219,7 @@ def start_sidecar(
     instance_id: Optional[str] = None,
     display_name: Optional[str] = None,
     adapter_version: Optional[str] = None,
+    discovery_mcp_url: Optional[str] = None,
     gateway_name: Optional[str] = None,
     extra_args: Optional[list] = None,
     extra_env: Optional[dict] = None,
@@ -251,6 +252,10 @@ def start_sidecar(
             the row (``--adapter-version``). The plug-in passes its own
             ``VERSION`` here so gateway and admin diagnostics can report
             adapter generations.
+        discovery_mcp_url: read-only in-process MCP/REST endpoint used by
+            the gateway for ``tools/list``, schema describe, resources,
+            prompts, and admin skill inventory. Tool calls still route
+            through the sidecar dispatcher endpoint.
         gateway_name: machine-level gateway label forwarded to
             ``--gateway-name``. Keep this stable per workstation; do
             not derive it from a scene because the standalone gateway
@@ -309,22 +314,35 @@ def start_sidecar(
     if instance_id not in (None, "") and normalized_instance_id is None:
         logger.debug("Ignoring invalid sidecar instance_id %r; expected UUID", instance_id)
 
-    launch_contract = build_sidecar_command(
-        dcc_type=dcc_name,
-        host_rpc=host_rpc_uri,
-        watch_pid=maya_pid,
-        registry_dir=registry_dir,
-        server_bin=str(binary),
-        instance_id=normalized_instance_id,
-        display_name=display_name,
-        adapter_version=adapter_version,
-        gateway_port=_resolve_gateway_port(spawn_env),
-        gateway_name=gateway_name,
-        gateway_remote_host=gateway_remote_host,
-        gateway_remote_port=gateway_remote_port,
-        extra_args=extra_args,
-        env=spawn_env,
-    )
+    launch_kwargs = {
+        "dcc_type": dcc_name,
+        "host_rpc": host_rpc_uri,
+        "watch_pid": maya_pid,
+        "registry_dir": registry_dir,
+        "server_bin": str(binary),
+        "instance_id": normalized_instance_id,
+        "display_name": display_name,
+        "adapter_version": adapter_version,
+        "gateway_port": _resolve_gateway_port(spawn_env),
+        "gateway_name": gateway_name,
+        "gateway_remote_host": gateway_remote_host,
+        "gateway_remote_port": gateway_remote_port,
+        "extra_args": extra_args,
+        "env": spawn_env,
+    }
+    if discovery_mcp_url:
+        launch_kwargs["discovery_mcp_url"] = discovery_mcp_url
+    try:
+        launch_contract = build_sidecar_command(**launch_kwargs)
+    except TypeError as exc:
+        if "discovery_mcp_url" not in str(exc):
+            raise
+        launch_kwargs.pop("discovery_mcp_url", None)
+        logger.debug(
+            "dcc-mcp-maya: core sidecar helper does not accept discovery_mcp_url; "
+            "continuing without sidecar discovery endpoint metadata"
+        )
+        launch_contract = build_sidecar_command(**launch_kwargs)
     if not launch_contract.get("success"):
         _stop_qt_server(stop_qt_server_fn)
         reason = launch_contract.get("reason") or "invalid_sidecar_launch"

--- a/tests/test_plugin_env_vars.py
+++ b/tests/test_plugin_env_vars.py
@@ -366,6 +366,8 @@ class TestSidecarUsesCoreRegistryDefaults:
         monkeypatch.setattr(plugin_module, "_resolve_instance_id", lambda: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
         monkeypatch.setattr(plugin_module, "_resolve_sidecar_display_name", lambda: "Maya 2025 pid 1234")
         monkeypatch.setattr(plugin_module, "_resolve_gateway_name", lambda: "dcc-mcp-gateway@workstation-01")
+        plugin_module._handle = MagicMock()
+        plugin_module._handle.mcp_url.return_value = "http://127.0.0.1:8765/mcp"
 
         sidecar_pkg = self._arm_plugin(plugin_module, monkeypatch)
         plugin_module._maybe_spawn_sidecar()
@@ -374,6 +376,7 @@ class TestSidecarUsesCoreRegistryDefaults:
         _, kwargs = sidecar_pkg.start_sidecar.call_args
         assert kwargs["adapter_version"] == plugin_module.VERSION
         assert kwargs["display_name"] == "Maya 2025 pid 1234"
+        assert kwargs["discovery_mcp_url"] == "http://127.0.0.1:8765/mcp"
         assert kwargs["gateway_name"] == "dcc-mcp-gateway@workstation-01"
         assert kwargs["instance_id"] == "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
         plugin_module._probe_gateway_health_deferred.assert_called_once_with(plugin_module._sidecar_handle)

--- a/tests/test_sidecar_supervisor.py
+++ b/tests/test_sidecar_supervisor.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from uuid import UUID
+
+import pytest
 
 from dcc_mcp_maya.sidecar import _supervisor
 from dcc_mcp_maya.sidecar._supervisor import start_sidecar
@@ -19,6 +22,70 @@ class _FakeProc:
 def _flag_value(cmd, flag):
     index = cmd.index(flag)
     return cmd[index + 1]
+
+
+@pytest.fixture(autouse=True)
+def _fake_core_sidecar_command(monkeypatch):
+    def fake_build_sidecar_command(**kwargs):
+        registry_dir = Path(kwargs.get("registry_dir") or Path.cwd() / ".test-registry").resolve()
+        instance_id = kwargs.get("instance_id")
+        normalized_instance_id = None
+        if instance_id:
+            try:
+                normalized_instance_id = str(UUID(str(instance_id)))
+            except ValueError:
+                normalized_instance_id = None
+        gateway_port = str(kwargs.get("gateway_port") if kwargs.get("gateway_port") is not None else 9765)
+        command = [
+            str(kwargs["server_bin"]),
+            "sidecar",
+            "--dcc",
+            kwargs["dcc_type"],
+            "--host-rpc",
+            kwargs["host_rpc"],
+            "--watch-pid",
+            str(kwargs["watch_pid"]),
+            "--registry-dir",
+            str(registry_dir),
+            "--gateway-port",
+            gateway_port,
+        ]
+        for flag, key in (
+            ("--instance-id", "instance_id"),
+            ("--display-name", "display_name"),
+            ("--adapter-version", "adapter_version"),
+            ("--discovery-mcp-url", "discovery_mcp_url"),
+            ("--gateway-name", "gateway_name"),
+            ("--gateway-remote-host", "gateway_remote_host"),
+        ):
+            value = normalized_instance_id if key == "instance_id" else kwargs.get(key)
+            if value:
+                command.extend([flag, str(value)])
+        if kwargs.get("gateway_remote_port") is not None:
+            command.extend(["--gateway-remote-port", str(kwargs["gateway_remote_port"])])
+        command.extend(str(arg) for arg in kwargs.get("extra_args") or [])
+        return {
+            "success": True,
+            "role": "per-dcc-sidecar",
+            "registry_dir": str(registry_dir),
+            "command": command,
+            "environment": {
+                "set": {
+                    "DCC_MCP_REGISTRY_DIR": str(registry_dir),
+                    "DCC_MCP_GATEWAY_PORT": gateway_port,
+                }
+            },
+            "readiness_selector": {
+                "dcc_type": kwargs["dcc_type"],
+                "instance_id": normalized_instance_id,
+                "host_rpc": kwargs["host_rpc"],
+            },
+            "recommended_next_action": "wait for readiness",
+        }
+
+    import dcc_mcp_core.install_lifecycle as lifecycle
+
+    monkeypatch.setattr(lifecycle, "build_sidecar_command", fake_build_sidecar_command)
 
 
 def test_start_sidecar_forwards_identity_flags(monkeypatch):
@@ -39,6 +106,7 @@ def test_start_sidecar_forwards_identity_flags(monkeypatch):
         instance_id="aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
         display_name="Maya 2025 pid 1234",
         adapter_version="0.0.0-test",
+        discovery_mcp_url="http://127.0.0.1:8765/mcp",
         gateway_name="dcc-mcp-gateway@workstation-01",
         start_qt_server_fn=lambda port: {
             "host": "127.0.0.1",
@@ -56,6 +124,7 @@ def test_start_sidecar_forwards_identity_flags(monkeypatch):
     assert _flag_value(captured["cmd"], "--instance-id") == "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
     assert _flag_value(captured["cmd"], "--display-name") == "Maya 2025 pid 1234"
     assert _flag_value(captured["cmd"], "--adapter-version") == "0.0.0-test"
+    assert _flag_value(captured["cmd"], "--discovery-mcp-url") == "http://127.0.0.1:8765/mcp"
     assert _flag_value(captured["cmd"], "--gateway-name") == "dcc-mcp-gateway@workstation-01"
     assert _flag_value(captured["cmd"], "--gateway-port") == "9765"
     assert _flag_value(captured["cmd"], "--gateway-remote-host") == "0.0.0.0"
@@ -93,6 +162,71 @@ def test_start_sidecar_omits_invalid_instance_id(monkeypatch):
 
     assert "--instance-id" not in captured["cmd"]
     assert handle.launch_contract["readiness_selector"]["instance_id"] is None
+
+
+def test_start_sidecar_falls_back_when_core_helper_lacks_discovery_mcp_url(monkeypatch):
+    import dcc_mcp_core.install_lifecycle as lifecycle
+
+    captured = {"calls": []}
+
+    def fake_build_sidecar_command(**kwargs):
+        captured["calls"].append(dict(kwargs))
+        if "discovery_mcp_url" in kwargs:
+            raise TypeError("build_sidecar_command() got an unexpected keyword argument 'discovery_mcp_url'")
+        registry_dir = Path.cwd() / ".test-registry"
+        command = [
+            str(kwargs["server_bin"]),
+            "sidecar",
+            "--dcc",
+            kwargs["dcc_type"],
+            "--host-rpc",
+            kwargs["host_rpc"],
+            "--watch-pid",
+            str(kwargs["watch_pid"]),
+            "--registry-dir",
+            str(registry_dir),
+            "--gateway-port",
+            str(kwargs["gateway_port"]),
+        ]
+        return {
+            "success": True,
+            "role": "per-dcc-sidecar",
+            "registry_dir": str(registry_dir),
+            "command": command,
+            "environment": {"set": {"DCC_MCP_REGISTRY_DIR": str(registry_dir)}},
+            "readiness_selector": {
+                "dcc_type": kwargs["dcc_type"],
+                "instance_id": None,
+                "host_rpc": kwargs["host_rpc"],
+            },
+            "recommended_next_action": "wait for readiness",
+        }
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["kwargs"] = dict(kwargs)
+        return _FakeProc()
+
+    monkeypatch.setattr(lifecycle, "build_sidecar_command", fake_build_sidecar_command)
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    handle = start_sidecar(
+        maya_pid=1234,
+        binary_override=Path("dcc-mcp-server"),
+        qt_port_override=45555,
+        discovery_mcp_url="http://127.0.0.1:8765/mcp",
+        start_qt_server_fn=lambda port: {
+            "host": "127.0.0.1",
+            "port": port,
+            "qt_binding": "fake-test-stub",
+        },
+    )
+
+    assert len(captured["calls"]) == 2
+    assert "discovery_mcp_url" in captured["calls"][0]
+    assert "discovery_mcp_url" not in captured["calls"][1]
+    assert "--discovery-mcp-url" not in captured["cmd"]
+    assert handle.launch_contract["role"] == "per-dcc-sidecar"
 
 
 def test_start_sidecar_captures_stdio_to_registry_logs(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- pass the in-process Maya MCP URL to sidecar launch as the discovery endpoint
- forward discovery endpoint support through the sidecar supervisor
- cover plugin and supervisor handoff with tests

## Validation
- PYTHONPATH=src;maya/plugin vx python -m pytest tests/test_sidecar_supervisor.py tests/test_plugin_env_vars.py -q

Requires core discovery endpoint support from dcc-mcp-core.